### PR TITLE
Bump Go image in Dockerfile to match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
When trying to build using the Dockerfile, the following error is returned:

```
RUN go mod download:
0.627 go: go.mod requires go >= 1.25.1 (running go 1.23.12; GOTOOLCHAIN=local)
```

This fix bumps the image version to 1.25, as required by "go.mod".
