### PR TITLE
Test YAML configuration with non-default values

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -238,9 +238,9 @@ func TestLoad_ValidYAMLFile(t *testing.T) {
 	content := `
 server:
   host: localhost
-  port: 8080
+  port: 8081
   rp_id: localhost
-  rp_origin: http://localhost:8080
+  rp_origin: http://localhost:8081
 storage:
   type: memory
 jwt:
@@ -255,8 +255,8 @@ jwt:
 		t.Fatalf("Load() error = %v", err)
 	}
 
-	if cfg.Server.Port != 8080 {
-		t.Errorf("Expected port 8080, got %d", cfg.Server.Port)
+	if cfg.Server.Port != 8081 {
+		t.Errorf("Expected port 8081, got %d", cfg.Server.Port)
 	}
 	if cfg.JWT.Secret != "test-secret" {
 		t.Errorf("Expected JWT secret 'test-secret', got %q", cfg.JWT.Secret)


### PR DESCRIPTION
The function "TestLoad_ValidYAMLFile" writes a YAML configuration file
to a temporary location, loads/parses it and validates that certain keys
contain expected values.

The generated configuration file does however use the same value for
keys like "port" as the default provided by struct tags, which makes it
impossible to know if file values are used or the defaults.

This change specifies a non-default value for the "port" key, which
circumvents the issue.

NOTE: Due to other bugs in the software at the time of writing, this
test will likely fail.
