### PR TITLE
fix(proxy): force uppercase on proxy http method

### DIFF
--- a/internal/service/proxy.go
+++ b/internal/service/proxy.go
@@ -67,7 +67,7 @@ func (s *ProxyService) Execute(ctx context.Context, req *ProxyRequest) (*ProxyRe
 		return nil, nil, fmt.Errorf("URL is required")
 	}
 
-	method := strings.ToUpper(req.Method)
+	method := strings.ToUpper(strings.TrimSpace(req.Method))
 	if method == "" {
 		method = "GET"
 	}


### PR DESCRIPTION
Getting .well-known data from issuers fail because the wallet-frontend tries to use the HTTP METHOD "get" which is not allowed. It should be "GET". This PR forces the uppercase variant in the backend proxy.