### PR TITLE
fix: don't exclude default tenant display name from login-finish return data

### DIFF
--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -851,10 +851,8 @@ func (s *WebAuthnService) FinishLogin(ctx context.Context, req *FinishLoginReque
 
 	// Get tenant display name for the response
 	var tenantDisplayName string
-	if tenantID != domain.DefaultTenantID {
-		if tenant, err := s.store.Tenants().GetByID(ctx, tenantID); err == nil {
-			tenantDisplayName = tenant.DisplayName
-		}
+	if tenant, err := s.store.Tenants().GetByID(ctx, tenantID); err == nil {
+		tenantDisplayName = tenant.DisplayName
 	}
 
 	s.logger.Info("User logged in via WebAuthn",


### PR DESCRIPTION
closes: #27 