### PR TITLE
Use UID in Dockerfile for increased compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /app
 COPY --from=builder /app/server /app/server
 COPY --from=builder /app/configs /app/configs
 
-USER nonroot:nonroot
+USER 65532:65532
 
 # Expose port
 EXPOSE 8080


### PR DESCRIPTION
In the Dockerfile, the "USER" statment specifies
which (non-root) user the container entrypoint
should be executed as.

Its value is currently set to "nonroot:nonroot",
which works for execution but is incompatible with
some tools that parse it from the container image
metadata to setup persistent volumes, enforce
security restrictions and similar (Kubernetes,
for example).

This change specifies the UID/GID for "nonroot"
instead of its username, which can be interpreted
directly by such tools instead of trying to parse
/etc/passwd from the container image filesystem.
