### PR TITLE
refactor: remove unused tenant auto-retry login mechanism

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -164,20 +164,6 @@ func (h *Handlers) FinishWebAuthnLogin(c *gin.Context) {
 	if err != nil {
 		h.logger.Error("Failed to finish WebAuthn login", zap.Error(err))
 
-		// Check for redirect error - user belongs to a different tenant
-		// This enables tenant discovery from the passkey credential
-		if redirectErr, ok := service.IsTenantRedirectError(err); ok {
-			h.logger.Info("Tenant redirect required from global login",
-				zap.String("correct_tenant", string(redirectErr.CorrectTenantID)),
-				zap.String("user_id", redirectErr.UserID.String()))
-			c.JSON(409, gin.H{
-				"error":           "Tenant redirect required",
-				"redirect_tenant": string(redirectErr.CorrectTenantID),
-				"user_id":         redirectErr.UserID.String(),
-			})
-			return
-		}
-
 		switch {
 		case errors.Is(err, service.ErrChallengeNotFound):
 			c.JSON(404, gin.H{"error": "Challenge not found"})

--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -34,25 +34,6 @@ var (
 	ErrTenantNotFound     = errors.New("tenant not found")
 )
 
-// TenantRedirectError indicates the user should be redirected to a different tenant
-type TenantRedirectError struct {
-	CorrectTenantID domain.TenantID
-	UserID          domain.UserID
-}
-
-func (e *TenantRedirectError) Error() string {
-	return fmt.Sprintf("user belongs to tenant %s, redirect required", e.CorrectTenantID)
-}
-
-// IsTenantRedirectError checks if an error is a TenantRedirectError
-func IsTenantRedirectError(err error) (*TenantRedirectError, bool) {
-	var redirectErr *TenantRedirectError
-	if errors.As(err, &redirectErr) {
-		return redirectErr, true
-	}
-	return nil, false
-}
-
 // WebAuthnService handles WebAuthn authentication
 type WebAuthnService struct {
 	store    storage.Store


### PR DESCRIPTION
Solves #35 by removing the unused tenant-missmatch error on login. This PR also depends on [changes in the frontend](https://github.com/wwWallet/wallet-frontend/pull/993/changes/e24420181e2d80a78f767f6de43ab4590aaa7f39) to be complete.

Note: #34 partially covers this by removing the old unused tenant-specific handlers and methods.
