### PR TITLE
Build/Publish container images for wallet-admin

### DIFF
--- a/.github/workflows/docker-publish-server.yml
+++ b/.github/workflows/docker-publish-server.yml
@@ -1,0 +1,110 @@
+name: Build and Publish Server Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build (branch, tag, or commit SHA)'
+        required: true
+        default: 'main'
+        type: string
+      image_tag:
+        description: 'Custom image tag (optional, defaults to ref name)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: sirosfoundation/go-wallet-backend
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.git_ref || github.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine image tags
+        id: tags
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            REF="${{ github.event.inputs.git_ref }}"
+            CUSTOM_TAG="${{ github.event.inputs.image_tag }}"
+            if [ -n "$CUSTOM_TAG" ]; then
+              echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${CUSTOM_TAG}" >> $GITHUB_OUTPUT
+            else
+              # Sanitize ref name for use as docker tag:
+              # - Strip common Git ref prefixes
+              # - Convert to lowercase
+              # - Replace invalid characters with '-'
+              # - Normalize separators and trim edges
+              # - Enforce Docker's 128-character tag limit
+              SAFE_REF=$(echo "$REF" \
+                | sed 's#^refs/heads/##; s#^refs/tags/##' \
+                | tr '[:upper:]' '[:lower:]' \
+                | sed 's/[^a-z0-9._-]/-/g' \
+                | sed 's/[-._]\{2,\}/-/g' \
+                | sed 's/^[-._]\+//; s/[-._]\+$//' \
+                | cut -c1-128 \
+              )
+              echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${SAFE_REF}" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        if: github.event_name != 'workflow_dispatch'
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.tags.outputs.tags || steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.event.inputs.git_ref || github.ref_name }}
+            COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish-wallet-admin.yml
+++ b/.github/workflows/docker-publish-wallet-admin.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Docker Image
+name: Build and Publish Wallet Admin Docker Image
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: sirosfoundation/go-wallet-backend
+  IMAGE_NAME: sirosfoundation/go-wallet-admin
 
 jobs:
   build-and-push:
@@ -98,7 +98,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.wallet-admin
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.tags.outputs.tags || steps.meta.outputs.tags }}

--- a/Dockerfile.wallet-admin
+++ b/Dockerfile.wallet-admin
@@ -1,0 +1,44 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /app
+
+# Install git for fetching dependencies
+RUN apk add --no-cache git ca-certificates
+
+# Build arguments for versioning and source control
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG GIT_REF=
+
+# If GIT_REF is provided, clone from that ref instead of using local context
+# Otherwise, use the local COPY approach for standard builds
+RUN if [ -n "$GIT_REF" ]; then \
+        echo "Building from git ref: $GIT_REF" && \
+        git clone https://github.com/sirosfoundation/go-wallet-backend.git /tmp/repo && \
+        cd /tmp/repo && \
+        git checkout "$GIT_REF" && \
+        cp -r /tmp/repo/* /app/ && \
+        rm -rf /tmp/repo; \
+    fi
+
+# Copy local source (these will be overwritten if GIT_REF was used)
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Build with version information
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w -X main.Version=${VERSION} -X main.Commit=${COMMIT}" \
+    -o wallet-admin cmd/wallet-admin/main.go
+
+# Runtime stage (based on Alpine to provide a shell and enable scripting)
+FROM docker.io/library/alpine:3.23
+
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /app/wallet-admin /usr/local/bin/
+
+# Match UID/GID from server container image
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/wallet-admin"]


### PR DESCRIPTION
This change adds a Dockerfile and a GitHub Actions workflow to build and
publish container images for the "wallet-admin" utility. Packaging the
tool in an image enables usage of it as a Kubernetes job/side-car.

The workflow is basically a copy of the main one used during server
builds, but in the future we should probably merge these together to
minimize build time/code duplication (possibly also for "registry", if
that survives as an independent component) - that kind of change does
however warrant its own PR.
