### PR TITLE
test: improve OIDC/JWKS test helpers and add discovery path test

### DIFF
--- a/pkg/oidc/validator_test.go
+++ b/pkg/oidc/validator_test.go
@@ -67,7 +67,9 @@ func createTestJWKSServer(t *testing.T, jwkJSON string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/.well-known/openid-configuration":
-			// Use http:// scheme for the test server's jwks_uri
+			// Build baseURL from the actual server URL (not r.Host which lacks scheme)
+			// The issuer field uses a fixed value for backward compatibility with
+			// existing tests that validate against https://test-issuer.example.com
 			baseURL := "http://" + r.Host
 			config := fmt.Sprintf(`{"issuer":"%s","jwks_uri":"%s/jwks"}`, "https://test-issuer.example.com", baseURL)
 			w.Header().Set("Content-Type", "application/json")
@@ -80,6 +82,33 @@ func createTestJWKSServer(t *testing.T, jwkJSON string) *httptest.Server {
 			http.NotFound(w, r)
 		}
 	}))
+}
+
+// createTestJWKSServerWithDiscovery creates a test server that supports OIDC discovery.
+// Unlike createTestJWKSServer, this server returns its own URL as the issuer,
+// enabling tests that exercise the discovery-based JWKS path.
+func createTestJWKSServerWithDiscovery(t *testing.T, jwkJSON string) *httptest.Server {
+	t.Helper()
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			// Use the actual server URL as issuer (self-referential)
+			config := fmt.Sprintf(`{"issuer":"%s","jwks_uri":"%s/jwks"}`, serverURL, serverURL)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(config))
+		case "/jwks":
+			jwks := fmt.Sprintf(`{"keys":[%s]}`, jwkJSON)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(jwks))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	serverURL = server.URL
+	return server
 }
 
 func TestValidator_ValidateRSA(t *testing.T) {
@@ -433,5 +462,58 @@ func TestDiscoverProvider(t *testing.T) {
 
 	if discovery.JWKSURI != server.URL+"/jwks" {
 		t.Errorf("unexpected JWKS URI: %s", discovery.JWKSURI)
+	}
+}
+
+// TestValidator_ValidateWithDiscovery tests token validation using discovery-based JWKS.
+// This exercises the code path where JWKSURI is not configured and the validator
+// must discover it from the issuer's openid-configuration endpoint.
+// Covers issue #62: Add test for discovery-based JWKS path
+func TestValidator_ValidateWithDiscovery(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	privateKey, jwkJSON := createTestRSAKey(t)
+
+	// Use the discovery-aware test server
+	server := createTestJWKSServerWithDiscovery(t, jwkJSON)
+	defer server.Close()
+
+	// Create validator WITHOUT explicit JWKSURI - this forces discovery
+	v := NewValidator(ValidatorConfig{
+		Issuer:   server.URL, // Use the test server URL as issuer
+		Audience: "test-client",
+		// JWKSURI intentionally left empty to trigger discovery path
+	}, nil, logger)
+
+	// Create valid token with issuer matching the test server
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": server.URL, // Must match ValidatorConfig.Issuer
+		"aud": "test-client",
+		"sub": "discovery-user",
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+	}
+
+	tokenString := createTestToken(t, privateKey, claims, jwt.SigningMethodRS256, "test-key")
+
+	// Validate - this should:
+	// 1. See JWKSURI is empty
+	// 2. Fetch /.well-known/openid-configuration from server.URL
+	// 3. Extract jwks_uri from discovery document
+	// 4. Fetch JWKS from that URI
+	// 5. Validate the token
+	ctx := context.Background()
+	result, err := v.Validate(ctx, tokenString)
+	if err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+
+	if result.Subject != "discovery-user" {
+		t.Errorf("expected subject 'discovery-user', got '%s'", result.Subject)
+	}
+
+	if result.Issuer != server.URL {
+		t.Errorf("expected issuer '%s', got '%s'", server.URL, result.Issuer)
 	}
 }

--- a/pkg/oidc/validator_test.go
+++ b/pkg/oidc/validator_test.go
@@ -67,9 +67,10 @@ func createTestJWKSServer(t *testing.T, jwkJSON string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/.well-known/openid-configuration":
-			// Build baseURL from the actual server URL (not r.Host which lacks scheme)
-			// The issuer field uses a fixed value for backward compatibility with
-			// existing tests that validate against https://test-issuer.example.com
+			// Build baseURL from r.Host and add the http scheme, since r.Host does
+			// not include a scheme. The issuer field uses a fixed value for backward
+			// compatibility with existing tests that validate against
+			// https://test-issuer.example.com.
 			baseURL := "http://" + r.Host
 			config := fmt.Sprintf(`{"issuer":"%s","jwks_uri":"%s/jwks"}`, "https://test-issuer.example.com", baseURL)
 			w.Header().Set("Content-Type", "application/json")
@@ -84,21 +85,33 @@ func createTestJWKSServer(t *testing.T, jwkJSON string) *httptest.Server {
 	}))
 }
 
+// discoveryTestServer wraps an httptest.Server with request counters
+// for verifying that discovery and JWKS endpoints were actually called.
+type discoveryTestServer struct {
+	*httptest.Server
+	DiscoveryHits int
+	JWKSHits      int
+}
+
 // createTestJWKSServerWithDiscovery creates a test server that supports OIDC discovery.
 // Unlike createTestJWKSServer, this server returns its own URL as the issuer,
 // enabling tests that exercise the discovery-based JWKS path.
-func createTestJWKSServerWithDiscovery(t *testing.T, jwkJSON string) *httptest.Server {
+// Request counters are exposed via DiscoveryHits and JWKSHits for assertions.
+func createTestJWKSServerWithDiscovery(t *testing.T, jwkJSON string) *discoveryTestServer {
 	t.Helper()
+	ds := &discoveryTestServer{}
 	var serverURL string
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ds.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/.well-known/openid-configuration":
+			ds.DiscoveryHits++
 			// Use the actual server URL as issuer (self-referential)
 			config := fmt.Sprintf(`{"issuer":"%s","jwks_uri":"%s/jwks"}`, serverURL, serverURL)
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(config))
 		case "/jwks":
+			ds.JWKSHits++
 			jwks := fmt.Sprintf(`{"keys":[%s]}`, jwkJSON)
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(jwks))
@@ -107,8 +120,8 @@ func createTestJWKSServerWithDiscovery(t *testing.T, jwkJSON string) *httptest.S
 		}
 	}))
 
-	serverURL = server.URL
-	return server
+	serverURL = ds.Server.URL
+	return ds
 }
 
 func TestValidator_ValidateRSA(t *testing.T) {
@@ -515,5 +528,13 @@ func TestValidator_ValidateWithDiscovery(t *testing.T) {
 
 	if result.Issuer != server.URL {
 		t.Errorf("expected issuer '%s', got '%s'", server.URL, result.Issuer)
+	}
+
+	// Verify the discovery and JWKS endpoints were actually called
+	if server.DiscoveryHits == 0 {
+		t.Error("expected at least one hit to /.well-known/openid-configuration, got 0")
+	}
+	if server.JWKSHits == 0 {
+		t.Error("expected at least one hit to /jwks, got 0")
 	}
 }


### PR DESCRIPTION
## Summary

Improves OIDC/JWKS test coverage by adding a test for the discovery-based JWKS path.

## Changes

### Issue #58: Fix JWKS URI scheme in test helper
- Added clarifying comments to `createTestJWKSServer` explaining why baseURL uses `http://` prefix
- The existing implementation was already correct (uses `"http://" + r.Host`)

### Issue #62: Add test for discovery-based JWKS path
- Added new `createTestJWKSServerWithDiscovery` helper that returns its own URL as the issuer
- Added `TestValidator_ValidateWithDiscovery` that exercises the discovery path:
  1. Creates validator WITHOUT explicit JWKSURI
  2. Triggers discovery by validating a token
  3. Verifies the validator fetches `/.well-known/openid-configuration`
  4. Verifies JWKS is fetched from the discovered URI

## Test Output
```
=== RUN   TestValidator_ValidateWithDiscovery
--- PASS: TestValidator_ValidateWithDiscovery (0.06s)
```

## Related
- Closes #58
- Closes #62
- Both issues from PR #47 review comments