### PR TITLE
feat: GDPR log cleanup, Prometheus metrics, and /healthz endpoint (WS2 C0+C3+C4)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -203,6 +203,11 @@ func main() {
 			logger.Fatal("Failed to create engine provider", zap.Error(err))
 		}
 		mgr.AddProvider(provider)
+
+		// Wire session store into UserService so DeleteUser purges active sessions
+		if backendProvider != nil {
+			backendProvider.Services().User.SetSessionCleaner(provider.SessionStore())
+		}
 	}
 
 	// Admin-only mode: standalone admin API without backend auth/storage routes.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/sirosfoundation/go-cryptoutil v0.5.0
 	github.com/sirosfoundation/go-spocp v0.1.0
@@ -62,7 +63,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -181,8 +181,6 @@ func (h *AuthZENProxyHandler) Evaluate(c *gin.Context) {
 	if err := h.authorizer.Authorize(ctx, authzReq); err != nil {
 		h.logger.Info("query authorization denied",
 			zap.String("tenant_id", tenantID),
-			zap.String("user_id", userID),
-			zap.String("subject_id", req.Subject.ID),
 			zap.String("action", getActionName(&req)),
 			zap.Error(err),
 		)
@@ -226,11 +224,9 @@ func (h *AuthZENProxyHandler) Evaluate(c *gin.Context) {
 		return
 	}
 
-	// Log the decision for audit
+	// Log the decision for audit (no user PII at INFO level)
 	h.logger.Info("trust evaluation completed",
 		zap.String("tenant_id", tenantID),
-		zap.String("user_id", userID),
-		zap.String("subject_id", req.Subject.ID),
 		zap.String("action", getActionName(&req)),
 		zap.Bool("decision", resp.Decision),
 	)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -498,14 +498,6 @@ func (h *Handlers) DeleteCredential(c *gin.Context) {
 
 	tenantID, _ := h.getTenantID(c)
 
-	// Delete associated presentations first (like the reference implementation)
-	if err := h.services.Presentation.DeleteByCredentialID(c.Request.Context(), tenantID, holderDID, credentialID); err != nil {
-		// Log but continue - presentations may not exist
-		h.logger.Warn("Error deleting presentations for credential",
-			zap.String("credential_id", credentialID),
-			zap.Error(err))
-	}
-
 	if err := h.services.Credential.Delete(c.Request.Context(), tenantID, holderDID, credentialID); err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			c.JSON(404, gin.H{"error": "Credential not found"})
@@ -517,114 +509,6 @@ func (h *Handlers) DeleteCredential(c *gin.Context) {
 	}
 
 	c.JSON(200, gin.H{"message": "Verifiable Credential deleted successfully."})
-}
-
-// Presentation handlers
-
-// GetAllPresentations returns all presentations for the authenticated user
-func (h *Handlers) GetAllPresentations(c *gin.Context) {
-	holderDID, ok := h.getHolderDID(c)
-	if !ok {
-		c.JSON(401, gin.H{"error": "Unauthorized"})
-		return
-	}
-
-	tenantID, _ := h.getTenantID(c)
-	presentations, err := h.services.Presentation.GetAll(c.Request.Context(), tenantID, holderDID)
-	if err != nil {
-		h.logger.Error("Failed to get presentations", zap.Error(err))
-		c.JSON(500, gin.H{"error": "Failed to get presentations"})
-		return
-	}
-
-	c.JSON(200, gin.H{"vp_list": presentations})
-}
-
-// StorePresentation stores a new presentation
-func (h *Handlers) StorePresentation(c *gin.Context) {
-	holderDID, ok := h.getHolderDID(c)
-	if !ok {
-		c.JSON(401, gin.H{"error": "Unauthorized"})
-		return
-	}
-
-	var presentation domain.VerifiablePresentation
-	if err := c.ShouldBindJSON(&presentation); err != nil {
-		c.JSON(400, gin.H{"error": err.Error()})
-		return
-	}
-
-	tenantID, _ := h.getTenantID(c)
-	presentation.HolderDID = holderDID
-
-	if err := h.services.Presentation.Store(c.Request.Context(), tenantID, &presentation); err != nil {
-		if errors.Is(err, storage.ErrAlreadyExists) {
-			c.JSON(409, gin.H{"error": "Presentation already exists"})
-			return
-		}
-		h.logger.Error("Failed to store presentation", zap.Error(err))
-		c.JSON(500, gin.H{"error": "Failed to store presentation"})
-		return
-	}
-
-	c.JSON(200, gin.H{})
-}
-
-// GetPresentationByIdentifier retrieves a presentation by identifier
-func (h *Handlers) GetPresentationByIdentifier(c *gin.Context) {
-	presentationID := c.Param("presentation_identifier")
-	if presentationID == "" {
-		c.JSON(400, gin.H{"error": "Presentation ID required"})
-		return
-	}
-
-	holderDID, ok := h.getHolderDID(c)
-	if !ok {
-		c.JSON(401, gin.H{"error": "Unauthorized"})
-		return
-	}
-
-	tenantID, _ := h.getTenantID(c)
-	presentation, err := h.services.Presentation.Get(c.Request.Context(), tenantID, holderDID, presentationID)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			c.JSON(404, gin.H{"error": "Presentation not found"})
-			return
-		}
-		h.logger.Error("Failed to get presentation", zap.Error(err))
-		c.JSON(500, gin.H{"error": "Failed to get presentation"})
-		return
-	}
-
-	c.JSON(200, presentation)
-}
-
-// DeletePresentation deletes a presentation
-func (h *Handlers) DeletePresentation(c *gin.Context) {
-	presentationID := c.Param("presentation_identifier")
-	if presentationID == "" {
-		c.JSON(400, gin.H{"error": "Presentation ID required"})
-		return
-	}
-
-	holderDID, ok := h.getHolderDID(c)
-	if !ok {
-		c.JSON(401, gin.H{"error": "Unauthorized"})
-		return
-	}
-
-	tenantID, _ := h.getTenantID(c)
-	if err := h.services.Presentation.Delete(c.Request.Context(), tenantID, holderDID, presentationID); err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			c.JSON(404, gin.H{"error": "Presentation not found"})
-			return
-		}
-		h.logger.Error("Failed to delete presentation", zap.Error(err))
-		c.JSON(500, gin.H{"error": "Failed to delete presentation"})
-		return
-	}
-
-	c.JSON(204, nil)
 }
 
 // Issuer handlers

--- a/internal/api/handlers_session_test.go
+++ b/internal/api/handlers_session_test.go
@@ -518,29 +518,6 @@ func TestHandlers_GetAllCredentials_Success(t *testing.T) {
 	}
 }
 
-func TestHandlers_GetAllPresentations_Success(t *testing.T) {
-	handlers, router, user := setupTestHandlersWithUser(t)
-	router.GET("/vp", authMiddlewareForUser(user), handlers.GetAllPresentations)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/vp", nil)
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-
-	// Verify response contains vp_list
-	var response map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("Failed to parse response: %v. Body: %s", err, w.Body.String())
-	}
-
-	if _, ok := response["vp_list"]; !ok {
-		t.Errorf("Expected vp_list in response, got: %v", response)
-	}
-}
-
 func TestHandlers_StoreAndGetCredential(t *testing.T) {
 	handlers, router, user := setupTestHandlersWithUser(t)
 	router.POST("/vc", authMiddlewareForUser(user), handlers.StoreCredential)
@@ -613,29 +590,6 @@ func TestHandlers_DeleteCredential_Success(t *testing.T) {
 
 	if w2.Code != http.StatusOK {
 		t.Errorf("Delete failed with status %d: %s", w2.Code, w2.Body.String())
-	}
-}
-
-func TestHandlers_StorePresentation_Success(t *testing.T) {
-	handlers, router, user := setupTestHandlersWithUser(t)
-	router.POST("/vp", authMiddlewareForUser(user), handlers.StorePresentation)
-
-	body, _ := json.Marshal(domain.StorePresentationRequest{
-		PresentationIdentifier:                  "pres-123",
-		Presentation:                            `{"@context":["https://www.w3.org/2018/credentials/v1"]}`,
-		PresentationSubmission:                  `{"id":"submission"}`,
-		IncludedVerifiableCredentialIdentifiers: []string{"cred-1"},
-		Audience:                                "verifier-1",
-		IssuanceDate:                            time.Now(),
-	})
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/vp", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 }
 
@@ -775,122 +729,6 @@ func TestHandlers_DeleteCredential_NotFound(t *testing.T) {
 }
 
 // ====================
-// Additional Presentation Tests
-// ====================
-
-func TestHandlers_GetPresentationByIdentifier_Success(t *testing.T) {
-	handlers, router, user := setupTestHandlersWithUser(t)
-	router.POST("/vp", authMiddlewareForUser(user), handlers.StorePresentation)
-	router.GET("/vp/:presentation_identifier", authMiddlewareForUser(user), handlers.GetPresentationByIdentifier)
-
-	// First store a presentation
-	storeBody, _ := json.Marshal(domain.StorePresentationRequest{
-		PresentationIdentifier:                  "pres-get-test",
-		Presentation:                            `{"@context":["https://www.w3.org/2018/credentials/v1"]}`,
-		IncludedVerifiableCredentialIdentifiers: []string{"cred-1"},
-		Audience:                                "verifier-1",
-	})
-
-	w1 := httptest.NewRecorder()
-	req1 := httptest.NewRequest(http.MethodPost, "/vp", bytes.NewBuffer(storeBody))
-	req1.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w1, req1)
-
-	// Get by identifier
-	w2 := httptest.NewRecorder()
-	req2 := httptest.NewRequest(http.MethodGet, "/vp/pres-get-test", nil)
-	router.ServeHTTP(w2, req2)
-
-	if w2.Code != http.StatusOK {
-		t.Errorf("Expected status %d, got %d: %s", http.StatusOK, w2.Code, w2.Body.String())
-	}
-
-	var pres domain.VerifiablePresentation
-	if err := json.Unmarshal(w2.Body.Bytes(), &pres); err != nil {
-		t.Fatalf("Failed to parse response: %v", err)
-	}
-
-	if pres.PresentationIdentifier != "pres-get-test" {
-		t.Errorf("Expected identifier 'pres-get-test', got '%s'", pres.PresentationIdentifier)
-	}
-}
-
-func TestHandlers_GetPresentationByIdentifier_NotFound(t *testing.T) {
-	handlers, router, user := setupTestHandlersWithUser(t)
-	router.GET("/vp/:presentation_identifier", authMiddlewareForUser(user), handlers.GetPresentationByIdentifier)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/vp/nonexistent", nil)
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusNotFound {
-		t.Errorf("Expected status %d, got %d: %s", http.StatusNotFound, w.Code, w.Body.String())
-	}
-}
-
-func TestHandlers_DeletePresentation_Success(t *testing.T) {
-	handlers, router, user := setupTestHandlersWithUser(t)
-	router.POST("/vp", authMiddlewareForUser(user), handlers.StorePresentation)
-	router.DELETE("/vp/:presentation_identifier", authMiddlewareForUser(user), handlers.DeletePresentation)
-
-	// First store a presentation
-	storeBody, _ := json.Marshal(domain.StorePresentationRequest{
-		PresentationIdentifier:                  "pres-delete-test",
-		Presentation:                            `{"@context":["https://www.w3.org/2018/credentials/v1"]}`,
-		IncludedVerifiableCredentialIdentifiers: []string{"cred-1"},
-	})
-
-	w1 := httptest.NewRecorder()
-	req1 := httptest.NewRequest(http.MethodPost, "/vp", bytes.NewBuffer(storeBody))
-	req1.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w1, req1)
-
-	// Delete presentation
-	w2 := httptest.NewRecorder()
-	req2 := httptest.NewRequest(http.MethodDelete, "/vp/pres-delete-test", nil)
-	router.ServeHTTP(w2, req2)
-
-	// Handler returns 204 No Content on success
-	if w2.Code != http.StatusNoContent {
-		t.Errorf("Expected status %d, got %d: %s", http.StatusNoContent, w2.Code, w2.Body.String())
-	}
-}
-
-func TestHandlers_DeletePresentation_NotFound(t *testing.T) {
-	handlers, router, user := setupTestHandlersWithUser(t)
-	router.DELETE("/vp/:presentation_identifier", authMiddlewareForUser(user), handlers.DeletePresentation)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodDelete, "/vp/nonexistent", nil)
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusNotFound {
-		t.Errorf("Expected status %d, got %d: %s", http.StatusNotFound, w.Code, w.Body.String())
-	}
-}
-
-func TestHandlers_StorePresentation_Invalid(t *testing.T) {
-	handlers, router, user := setupTestHandlersWithUser(t)
-	router.POST("/vp", authMiddlewareForUser(user), handlers.StorePresentation)
-
-	// Missing required fields - service layer validation returns error, handler returns 500
-	body, _ := json.Marshal(map[string]interface{}{
-		"presentation": `{"test": true}`,
-		// Missing presentationIdentifier
-	})
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/vp", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-
-	// Handler returns 500 for service-layer validation errors
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("Expected status %d, got %d: %s", http.StatusInternalServerError, w.Code, w.Body.String())
-	}
-}
-
-// ====================
 // Issuer and Verifier Tests
 // ====================
 
@@ -979,67 +817,5 @@ func TestHandlers_StoreCredential_MissingFormat(t *testing.T) {
 	// Handler accepts credentials without format (format validation is lenient)
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-}
-
-func TestHandlers_DeleteCredential_CascadesPresentations(t *testing.T) {
-	handlers, router, user := setupTestHandlersWithUser(t)
-	router.POST("/vc", authMiddlewareForUser(user), handlers.StoreCredential)
-	router.POST("/vp", authMiddlewareForUser(user), handlers.StorePresentation)
-	router.DELETE("/vc/:credential_identifier", authMiddlewareForUser(user), handlers.DeleteCredential)
-	router.GET("/vp", authMiddlewareForUser(user), handlers.GetAllPresentations)
-
-	// Store a credential
-	storeCredBody, _ := json.Marshal(map[string]interface{}{
-		"credentials": []map[string]interface{}{
-			{
-				"credentialIdentifier": "cascade-test-cred",
-				"credential":           `{"test": true}`,
-				"format":               "jwt_vc",
-			},
-		},
-	})
-
-	w1 := httptest.NewRecorder()
-	req1 := httptest.NewRequest(http.MethodPost, "/vc", bytes.NewBuffer(storeCredBody))
-	req1.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w1, req1)
-
-	// Store a presentation that includes the credential
-	storePresBody, _ := json.Marshal(domain.StorePresentationRequest{
-		PresentationIdentifier:                  "cascade-test-pres",
-		Presentation:                            `{"test": true}`,
-		IncludedVerifiableCredentialIdentifiers: []string{"cascade-test-cred"},
-	})
-
-	w2 := httptest.NewRecorder()
-	req2 := httptest.NewRequest(http.MethodPost, "/vp", bytes.NewBuffer(storePresBody))
-	req2.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w2, req2)
-
-	// Delete the credential - should cascade to presentation
-	w3 := httptest.NewRecorder()
-	req3 := httptest.NewRequest(http.MethodDelete, "/vc/cascade-test-cred", nil)
-	router.ServeHTTP(w3, req3)
-
-	if w3.Code != http.StatusOK {
-		t.Errorf("Delete credential failed: %s", w3.Body.String())
-	}
-
-	// Check that presentation was also deleted
-	w4 := httptest.NewRecorder()
-	req4 := httptest.NewRequest(http.MethodGet, "/vp", nil)
-	router.ServeHTTP(w4, req4)
-
-	var vpResponse struct {
-		VPList []domain.VerifiablePresentation `json:"vp_list"`
-	}
-	if err := json.Unmarshal(w4.Body.Bytes(), &vpResponse); err != nil {
-		t.Fatalf("Failed to parse vp response: %v", err)
-	}
-
-	// Presentation should have been deleted (or vp_list should be empty/nil)
-	if len(vpResponse.VPList) != 0 {
-		t.Errorf("Expected 0 presentations after cascade delete, got %d", len(vpResponse.VPList))
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -148,35 +148,7 @@ func TestHandlers_WebAuthn(t *testing.T) {
 	})
 }
 
-// Test Presentation handlers (now implemented)
-func TestHandlers_Presentation_Unauthorized(t *testing.T) {
-	handlers, router := setupTestHandlers(t)
-	router.GET("/presentations", handlers.GetAllPresentations)
-	router.POST("/presentations", handlers.StorePresentation)
-	router.GET("/presentations/:presentation_identifier", handlers.GetPresentationByIdentifier)
-
-	tests := []struct {
-		method   string
-		endpoint string
-	}{
-		{http.MethodGet, "/presentations"},
-		{http.MethodPost, "/presentations"},
-		{http.MethodGet, "/presentations/123"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.method+" "+tt.endpoint, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			req := httptest.NewRequest(tt.method, tt.endpoint, nil)
-			router.ServeHTTP(w, req)
-
-			// Requires authentication - should return 401
-			if w.Code != http.StatusUnauthorized {
-				t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, w.Code)
-			}
-		})
-	}
-}
+// Test Presentation handlers (removed — VP endpoints are no longer registered)
 
 // authMiddleware is a test helper that sets auth context
 func authMiddleware(userID, did string) gin.HandlerFunc {
@@ -422,63 +394,6 @@ func TestHandlers_DeleteCredential_BadRequest(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodDelete, "/credentials/test-id", nil)
-	router.ServeHTTP(w, req)
-
-	// Returns 400 due to missing user context
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-}
-
-// Test presentation handlers
-func TestHandlers_GetAllPresentations_Unauthorized(t *testing.T) {
-	handlers, router := setupTestHandlers(t)
-	router.GET("/presentations", handlers.GetAllPresentations)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/presentations", nil)
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, w.Code)
-	}
-}
-
-func TestHandlers_StorePresentation_Unauthorized(t *testing.T) {
-	handlers, router := setupTestHandlers(t)
-	router.POST("/presentations", handlers.StorePresentation)
-
-	w := httptest.NewRecorder()
-	body := `{"vp": "test"}`
-	req := httptest.NewRequest(http.MethodPost, "/presentations", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, w.Code)
-	}
-}
-
-func TestHandlers_DeletePresentation_BadRequest(t *testing.T) {
-	handlers, router := setupTestHandlers(t)
-	router.DELETE("/presentations/:id", handlers.DeletePresentation)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodDelete, "/presentations/test-id", nil)
-	router.ServeHTTP(w, req)
-
-	// Returns 400 due to missing user context
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-}
-
-func TestHandlers_GetPresentationByIdentifier_BadRequest(t *testing.T) {
-	handlers, router := setupTestHandlers(t)
-	router.GET("/presentations/:id", handlers.GetPresentationByIdentifier)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/presentations/test-id", nil)
 	router.ServeHTTP(w, req)
 
 	// Returns 400 due to missing user context

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -111,6 +111,11 @@ func (m *Manager) SetSessionStore(store SessionStore) {
 	m.sessionStore = store
 }
 
+// SessionStore returns the session store instance.
+func (m *Manager) SessionStore() SessionStore {
+	return m.sessionStore
+}
+
 // SetVerifierStore sets the verifier store for trust caching
 func (m *Manager) SetVerifierStore(store storage.VerifierStore) {
 	m.verifierStore = store

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -52,6 +52,9 @@ func NewAuthProvider(cfg *config.Config, store backend.Backend, logger *zap.Logg
 func (p *AuthProvider) Transport() Transport { return TransportHTTP }
 func (p *AuthProvider) Name() string         { return "auth" }
 
+// Services returns the auth provider's service aggregate.
+func (p *AuthProvider) Services() *service.Services { return p.services }
+
 func (p *AuthProvider) RegisterRoutes(router *gin.Engine) {
 	// Create HTTP client and OIDC validator cache for gate middleware
 	httpClient := p.cfg.HTTPClient.NewHTTPClient(0)
@@ -248,6 +251,11 @@ func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.Ver
 func (p *EngineProvider) Transport() Transport { return TransportWebSocket }
 func (p *EngineProvider) Name() string         { return "engine" }
 
+// SessionStore returns the engine's session store for cross-provider wiring.
+func (p *EngineProvider) SessionStore() wsengine.SessionStore {
+	return p.manager.SessionStore()
+}
+
 func (p *EngineProvider) RegisterRoutes(router *gin.Engine) {
 	// WebSocket v2 endpoint
 	router.GET("/api/v2/wallet", func(c *gin.Context) {
@@ -330,6 +338,9 @@ func NewBackendProvider(cfg *config.Config, logger *zap.Logger, roles []string) 
 
 func (p *BackendProvider) Transport() Transport { return TransportHTTP }
 func (p *BackendProvider) Name() string         { return "backend" }
+
+// Services returns the backend's service aggregate (via the auth provider).
+func (p *BackendProvider) Services() *service.Services { return p.auth.Services() }
 
 func (p *BackendProvider) RegisterRoutes(router *gin.Engine) {
 	// Register both auth and storage routes

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -183,17 +183,14 @@ func (p *StorageProvider) RegisterRoutes(router *gin.Engine) {
 	protected := router.Group("/storage")
 	protected.Use(middleware.AuthMiddleware(p.cfg, p.store, p.logger))
 	{
-		// Credential storage
-		protected.GET("/vc", p.handlers.GetAllCredentials)
-		protected.POST("/vc", p.handlers.StoreCredential)
-		protected.POST("/vc/update", p.handlers.UpdateCredential)
-		protected.GET("/vc/:credential_identifier", p.handlers.GetCredentialByIdentifier)
-		protected.DELETE("/vc/:credential_identifier", p.handlers.DeleteCredential)
-
-		// Presentation storage
-		protected.GET("/vp", p.handlers.GetAllPresentations)
-		protected.POST("/vp", p.handlers.StorePresentation)
-		protected.GET("/vp/:presentation_identifier", p.handlers.GetPresentationByIdentifier)
+		// Credential storage (gated)
+		if p.cfg.Features.CredentialStorageEnabled {
+			protected.GET("/vc", p.handlers.GetAllCredentials)
+			protected.POST("/vc", p.handlers.StoreCredential)
+			protected.POST("/vc/update", p.handlers.UpdateCredential)
+			protected.GET("/vc/:credential_identifier", p.handlers.GetCredentialByIdentifier)
+			protected.DELETE("/vc/:credential_identifier", p.handlers.DeleteCredential)
+		}
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 
 	"github.com/sirosfoundation/go-wallet-backend/internal/api"
@@ -318,7 +319,8 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 func (m *Manager) buildRouter() *gin.Engine {
 	router := gin.New()
 	router.Use(gin.Recovery())
-	router.Use(middleware.Logger(m.logger, "/status", "/health", "/readyz"))
+	router.Use(middleware.Prometheus("/status", "/health", "/healthz", "/readyz"))
+	router.Use(middleware.Logger(m.logger, "/status", "/health", "/healthz", "/readyz"))
 	router.Use(cors.New(cors.Config{
 		AllowOrigins:     m.cfg.CORS.AllowedOrigins,
 		AllowMethods:     m.cfg.CORS.AllowedMethods,
@@ -343,6 +345,7 @@ func (m *Manager) addStatusEndpoints(router *gin.Engine) {
 		})
 	}
 	router.GET("/health", statusHandler)
+	router.GET("/healthz", statusHandler)
 	router.GET("/status", statusHandler)
 
 	// /readyz - Kubernetes-style readiness probe
@@ -376,8 +379,8 @@ func (m *Manager) startAdminServer() error {
 		if err != nil {
 			return fmt.Errorf("failed to generate admin token: %w", err)
 		}
-		// Never log the token value — even at DEBUG level it may be captured
-		// by log aggregators.
+		m.logger.Debug("Generated admin API token (development mode)",
+			zap.String("token", token))
 		m.logger.Warn("Auto-generated admin token — this is disabled in production")
 	}
 
@@ -393,6 +396,9 @@ func (m *Manager) startAdminServer() error {
 			Roles:   m.cfg.Roles,
 		})
 	})
+
+	// Prometheus metrics endpoint (no auth required — scraped by monitoring)
+	adminRouter.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
 	// Protected admin routes with token auth
 	adminGroup := adminRouter.Group("/admin")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -397,7 +397,12 @@ func (m *Manager) startAdminServer() error {
 		})
 	})
 
-	// Prometheus metrics endpoint (no auth required — scraped by monitoring)
+	// Prometheus metrics endpoint — intentionally unauthenticated.
+	// The admin port MUST be bound to a private/loopback interface or
+	// firewalled so only the monitoring stack (e.g. Prometheus) can reach it.
+	// Adding Bearer-token auth here would require every Prometheus scrape
+	// config to carry the admin secret, which provides little benefit when
+	// the port is already network-isolated.
 	adminRouter.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
 	// Protected admin routes with token auth

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -376,8 +376,8 @@ func (m *Manager) startAdminServer() error {
 		if err != nil {
 			return fmt.Errorf("failed to generate admin token: %w", err)
 		}
-		m.logger.Debug("Generated admin API token (development mode)",
-			zap.String("token", token))
+		// Never log the token value — even at DEBUG level it may be captured
+		// by log aggregators.
 		m.logger.Warn("Auto-generated admin token — this is disabled in production")
 	}
 

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -61,7 +61,6 @@ func (s *CredentialService) Store(ctx context.Context, tenantID domain.TenantID,
 
 	s.logger.Info("Stored credential",
 		zap.String("tenant_id", string(tenantID)),
-		zap.String("holder_did", req.HolderDID),
 		zap.String("credential_id", req.CredentialIdentifier))
 
 	return credential, nil
@@ -76,8 +75,7 @@ func (s *CredentialService) GetAll(ctx context.Context, tenantID domain.TenantID
 	credentials, err := s.store.Credentials().GetAllByHolder(ctx, tenantID, holderDID)
 	if err != nil {
 		s.logger.Error("Failed to get credentials", zap.Error(err),
-			zap.String("tenant_id", string(tenantID)),
-			zap.String("holder_did", holderDID))
+			zap.String("tenant_id", string(tenantID)))
 		return nil, err
 	}
 

--- a/internal/service/presentation.go
+++ b/internal/service/presentation.go
@@ -53,7 +53,6 @@ func (s *PresentationService) Store(ctx context.Context, tenantID domain.TenantI
 
 	s.logger.Info("Presentation stored",
 		zap.String("tenant_id", string(tenantID)),
-		zap.String("holder_did", presentation.HolderDID),
 		zap.String("presentation_id", presentation.PresentationIdentifier))
 
 	return nil

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -14,7 +14,6 @@ type Services struct {
 	UserTenant       *UserTenantService
 	WebAuthn         *WebAuthnService
 	Credential       *CredentialService
-	Presentation     *PresentationService
 	Issuer           *IssuerService
 	Verifier         *VerifierService
 	Keystore         *KeystoreService
@@ -43,7 +42,6 @@ func NewServices(store storage.Store, cfg *config.Config, logger *zap.Logger) *S
 		UserTenant:       NewUserTenantService(store, logger),
 		WebAuthn:         webauthnSvc,
 		Credential:       NewCredentialService(store, cfg, logger),
-		Presentation:     NewPresentationService(store, logger),
 		Issuer:           NewIssuerService(store, logger),
 		Verifier:         NewVerifierService(store, logger),
 		Keystore:         NewKeystoreService(store, cfg, logger),

--- a/internal/service/services_test.go
+++ b/internal/service/services_test.go
@@ -49,9 +49,6 @@ func TestNewServices(t *testing.T) {
 	if services.Credential == nil {
 		t.Error("expected Credential service to be initialized")
 	}
-	if services.Presentation == nil {
-		t.Error("expected Presentation service to be initialized")
-	}
 	if services.Issuer == nil {
 		t.Error("expected Issuer service to be initialized")
 	}

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -233,9 +233,8 @@ func (s *UserService) DeleteUser(ctx context.Context, userID domain.UserID, hold
 		tenantIDs = []domain.TenantID{domain.DefaultTenantID}
 	}
 
-	// Delete credentials and presentations from each tenant
+	// Delete credentials from each tenant (only relevant when credential storage is enabled)
 	for _, tenantID := range tenantIDs {
-		// Delete all credentials in this tenant
 		credentials, err := s.store.Credentials().GetAllByHolder(ctx, tenantID, holderDID)
 		if err != nil && !errors.Is(err, storage.ErrNotFound) {
 			s.logger.Warn("Failed to get credentials for tenant", zap.Error(err), zap.String("tenant_id", string(tenantID)))
@@ -246,21 +245,20 @@ func (s *UserService) DeleteUser(ctx context.Context, userID domain.UserID, hold
 			}
 		}
 
-		// Delete all presentations in this tenant
-		presentations, err := s.store.Presentations().GetAllByHolder(ctx, tenantID, holderDID)
-		if err != nil && !errors.Is(err, storage.ErrNotFound) {
-			s.logger.Warn("Failed to get presentations for tenant", zap.Error(err), zap.String("tenant_id", string(tenantID)))
-		}
-		for _, pres := range presentations {
-			if err := s.store.Presentations().Delete(ctx, tenantID, holderDID, pres.PresentationIdentifier); err != nil {
-				s.logger.Warn("Failed to delete presentation", zap.Error(err))
-			}
-		}
-
 		// Remove tenant membership
 		if err := s.store.UserTenants().RemoveMembership(ctx, userID, tenantID); err != nil {
 			s.logger.Warn("Failed to remove tenant membership", zap.Error(err), zap.String("tenant_id", string(tenantID)))
 		}
+	}
+
+	// Delete pending WebAuthn challenges (defense-in-depth; TTL handles expiry)
+	if err := s.store.Challenges().DeleteByUserID(ctx, userID.String()); err != nil {
+		s.logger.Warn("Failed to delete challenges for user", zap.Error(err))
+	}
+
+	// Clear user reference from consumed invites
+	if err := s.store.Invites().ClearUsedBy(ctx, userID); err != nil {
+		s.logger.Warn("Failed to clear invite used_by references", zap.Error(err))
 	}
 
 	// Delete the user

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -24,11 +24,18 @@ var (
 	ErrLastWebAuthnCredential = errors.New("cannot delete last webauthn credential")
 )
 
+// SessionCleaner can remove sessions for a user.
+// Implemented by engine.SessionStore (memory or Redis).
+type SessionCleaner interface {
+	DeleteByUser(ctx context.Context, userID string) error
+}
+
 // UserService handles user-related operations
 type UserService struct {
-	store  storage.Store
-	cfg    *config.Config
-	logger *zap.Logger
+	store          storage.Store
+	cfg            *config.Config
+	logger         *zap.Logger
+	sessionCleaner SessionCleaner
 }
 
 // NewUserService creates a new UserService
@@ -38,6 +45,12 @@ func NewUserService(store storage.Store, cfg *config.Config, logger *zap.Logger)
 		cfg:    cfg,
 		logger: logger.Named("user-service"),
 	}
+}
+
+// SetSessionCleaner sets the session cleanup implementation.
+// When set, DeleteUser will purge active sessions for the deleted user.
+func (s *UserService) SetSessionCleaner(sc SessionCleaner) {
+	s.sessionCleaner = sc
 }
 
 // Register registers a new user
@@ -233,7 +246,8 @@ func (s *UserService) DeleteUser(ctx context.Context, userID domain.UserID, hold
 		tenantIDs = []domain.TenantID{domain.DefaultTenantID}
 	}
 
-	// Delete credentials from each tenant (only relevant when credential storage is enabled)
+	// Delete any legacy server-side stored credentials from each tenant, regardless
+	// of whether credential/VC endpoints are currently enabled.
 	for _, tenantID := range tenantIDs {
 		credentials, err := s.store.Credentials().GetAllByHolder(ctx, tenantID, holderDID)
 		if err != nil && !errors.Is(err, storage.ErrNotFound) {
@@ -259,6 +273,13 @@ func (s *UserService) DeleteUser(ctx context.Context, userID domain.UserID, hold
 	// Clear user reference from consumed invites
 	if err := s.store.Invites().ClearUsedBy(ctx, userID); err != nil {
 		s.logger.Warn("Failed to clear invite used_by references", zap.Error(err))
+	}
+
+	// Purge active WebSocket sessions (Redis or memory)
+	if s.sessionCleaner != nil {
+		if err := s.sessionCleaner.DeleteByUser(ctx, userID.String()); err != nil {
+			s.logger.Warn("Failed to delete sessions for user", zap.Error(err))
+		}
 	}
 
 	// Delete the user

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -98,7 +98,7 @@ func (s *UserService) Register(ctx context.Context, req *domain.RegisterRequest)
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
-	s.logger.Info("User registered")
+	s.logger.Debug("User registered", zap.String("user_id", user.UUID.String()))
 	return user, nil
 }
 

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -245,9 +245,14 @@ func (s *UserService) DeleteUser(ctx context.Context, userID domain.UserID, hold
 		// Continue with user deletion even if we can't get tenants
 		tenantIDs = []domain.TenantID{domain.DefaultTenantID}
 	}
+	if len(tenantIDs) == 0 {
+		// User may have been registered without an explicit tenant membership;
+		// always clean up the default tenant as a fallback.
+		tenantIDs = []domain.TenantID{domain.DefaultTenantID}
+	}
 
-	// Delete any legacy server-side stored credentials from each tenant, regardless
-	// of whether credential/VC endpoints are currently enabled.
+	// Delete any legacy server-side stored credentials and presentations from
+	// each tenant, regardless of whether credential/VC endpoints are currently enabled.
 	for _, tenantID := range tenantIDs {
 		credentials, err := s.store.Credentials().GetAllByHolder(ctx, tenantID, holderDID)
 		if err != nil && !errors.Is(err, storage.ErrNotFound) {
@@ -256,6 +261,17 @@ func (s *UserService) DeleteUser(ctx context.Context, userID domain.UserID, hold
 		for _, cred := range credentials {
 			if err := s.store.Credentials().Delete(ctx, tenantID, holderDID, cred.CredentialIdentifier); err != nil {
 				s.logger.Warn("Failed to delete credential", zap.Error(err))
+			}
+		}
+
+		// Delete any server-side stored presentations (VPs) for GDPR compliance
+		presentations, err := s.store.Presentations().GetAllByHolder(ctx, tenantID, holderDID)
+		if err != nil && !errors.Is(err, storage.ErrNotFound) {
+			s.logger.Warn("Failed to get presentations for tenant", zap.Error(err), zap.String("tenant_id", string(tenantID)))
+		}
+		for _, pres := range presentations {
+			if err := s.store.Presentations().Delete(ctx, tenantID, holderDID, pres.PresentationIdentifier); err != nil {
+				s.logger.Warn("Failed to delete presentation", zap.Error(err))
 			}
 		}
 

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -98,7 +98,7 @@ func (s *UserService) Register(ctx context.Context, req *domain.RegisterRequest)
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
-	s.logger.Info("User registered", zap.String("user_id", user.UUID.String()))
+	s.logger.Info("User registered")
 	return user, nil
 }
 
@@ -129,7 +129,7 @@ func (s *UserService) Login(ctx context.Context, username, password string) (*do
 		return nil, "", fmt.Errorf("failed to generate token: %w", err)
 	}
 
-	s.logger.Info("User logged in", zap.String("user_id", user.UUID.String()))
+	s.logger.Info("User logged in")
 	return user, token, nil
 }
 
@@ -287,7 +287,7 @@ func (s *UserService) DeleteUser(ctx context.Context, userID domain.UserID, hold
 		return fmt.Errorf("failed to delete user: %w", err)
 	}
 
-	s.logger.Info("User deleted", zap.String("user_id", userID.String()))
+	s.logger.Info("User deleted")
 	return nil
 }
 

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -585,6 +586,57 @@ func TestUserService_DeleteUser_CleansUpChallengesAndInvites(t *testing.T) {
 	}
 	if got.UsedBy != nil {
 		t.Error("Invite used_by should be cleared after DeleteUser")
+	}
+}
+
+// mockSessionCleaner records calls to DeleteByUser for test assertions.
+type mockSessionCleaner struct {
+	called bool
+	userID string
+}
+
+func (m *mockSessionCleaner) DeleteByUser(_ context.Context, userID string) error {
+	m.called = true
+	m.userID = userID
+	return nil
+}
+
+func TestUserService_DeleteUser_CleansUpSessions(t *testing.T) {
+	ctx := t.Context()
+	store := memory.NewStore()
+	cfg := testConfig()
+	logger := testLogger()
+	svc := NewUserService(store, cfg, logger)
+
+	// Wire mock session cleaner
+	mock := &mockSessionCleaner{}
+	svc.SetSessionCleaner(mock)
+
+	// Register user
+	username := "session-cleanup-user"
+	password := "password123"
+	req := &domain.RegisterRequest{
+		Username:    &username,
+		DisplayName: "Session Cleanup User",
+		Password:    &password,
+		WalletType:  domain.WalletTypeDB,
+	}
+	user, err := svc.Register(ctx, req)
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	// Delete user
+	if err := svc.DeleteUser(ctx, user.UUID, user.DID); err != nil {
+		t.Fatalf("DeleteUser() error = %v", err)
+	}
+
+	// Verify session cleaner was called with correct user ID
+	if !mock.called {
+		t.Error("SessionCleaner.DeleteByUser should be called during DeleteUser")
+	}
+	if mock.userID != user.UUID.String() {
+		t.Errorf("SessionCleaner.DeleteByUser called with %q, want %q", mock.userID, user.UUID.String())
 	}
 }
 

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -640,6 +640,78 @@ func TestUserService_DeleteUser_CleansUpSessions(t *testing.T) {
 	}
 }
 
+func TestUserService_DeleteUser_CleansUpCredentialsAndPresentations(t *testing.T) {
+	ctx := t.Context()
+	store := memory.NewStore()
+	cfg := testConfig()
+	logger := testLogger()
+	svc := NewUserService(store, cfg, logger)
+
+	// Register user
+	username := "vp-cleanup-user"
+	password := "password123"
+	req := &domain.RegisterRequest{
+		Username:    &username,
+		DisplayName: "VP Cleanup User",
+		Password:    &password,
+		WalletType:  domain.WalletTypeDB,
+	}
+	user, err := svc.Register(ctx, req)
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	// Store a credential for this user
+	cred := &domain.VerifiableCredential{
+		TenantID:             domain.DefaultTenantID,
+		HolderDID:            user.DID,
+		CredentialIdentifier: "cred-001",
+		Credential:           `{"@context":["https://www.w3.org/2018/credentials/v1"]}`,
+		Format:               "jwt_vc_json",
+	}
+	if err := store.Credentials().Create(ctx, cred); err != nil {
+		t.Fatalf("Create credential error = %v", err)
+	}
+
+	// Store a presentation for this user
+	pres := &domain.VerifiablePresentation{
+		TenantID:               domain.DefaultTenantID,
+		HolderDID:              user.DID,
+		PresentationIdentifier: "pres-001",
+		Presentation:           `{"@context":["https://www.w3.org/2018/credentials/v1"]}`,
+	}
+	if err := store.Presentations().Create(ctx, pres); err != nil {
+		t.Fatalf("Create presentation error = %v", err)
+	}
+
+	// Verify they exist before deletion
+	creds, err := store.Credentials().GetAllByHolder(ctx, domain.DefaultTenantID, user.DID)
+	if err != nil || len(creds) == 0 {
+		t.Fatal("Expected credential to exist before deletion")
+	}
+	preses, err := store.Presentations().GetAllByHolder(ctx, domain.DefaultTenantID, user.DID)
+	if err != nil || len(preses) == 0 {
+		t.Fatal("Expected presentation to exist before deletion")
+	}
+
+	// Delete user
+	if err := svc.DeleteUser(ctx, user.UUID, user.DID); err != nil {
+		t.Fatalf("DeleteUser() error = %v", err)
+	}
+
+	// Verify credential is deleted
+	creds, _ = store.Credentials().GetAllByHolder(ctx, domain.DefaultTenantID, user.DID)
+	if len(creds) != 0 {
+		t.Errorf("Expected 0 credentials after deletion, got %d", len(creds))
+	}
+
+	// Verify presentation is deleted
+	preses, _ = store.Presentations().GetAllByHolder(ctx, domain.DefaultTenantID, user.DID)
+	if len(preses) != 0 {
+		t.Errorf("Expected 0 presentations after deletion, got %d", len(preses))
+	}
+}
+
 func TestUserService_GenerateTokenForUser(t *testing.T) {
 	ctx := t.Context()
 	store := memory.NewStore()

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -517,6 +518,73 @@ func TestUserService_DeleteUser(t *testing.T) {
 	_, err = service.GetUserByID(ctx, user.UUID)
 	if err == nil {
 		t.Error("GetUserByID() after deletion should return error")
+	}
+}
+
+func TestUserService_DeleteUser_CleansUpChallengesAndInvites(t *testing.T) {
+	ctx := t.Context()
+	store := memory.NewStore()
+	cfg := testConfig()
+	logger := testLogger()
+	service := NewUserService(store, cfg, logger)
+
+	// Register user
+	username := "cleanup-user"
+	password := "password123"
+	req := &domain.RegisterRequest{
+		Username:    &username,
+		DisplayName: "Cleanup User",
+		Password:    &password,
+		WalletType:  domain.WalletTypeDB,
+	}
+	user, err := service.Register(ctx, req)
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	// Create a pending challenge for this user
+	challenge := &domain.WebauthnChallenge{
+		ID:        "test-challenge",
+		UserID:    user.UUID.String(),
+		TenantID:  string(domain.DefaultTenantID),
+		Challenge: "random-nonce",
+		Action:    "register",
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	if err := store.Challenges().Create(ctx, challenge); err != nil {
+		t.Fatalf("Create challenge error = %v", err)
+	}
+
+	// Create an invite consumed by this user
+	invite := &domain.Invite{
+		ID:       "test-invite",
+		TenantID: domain.DefaultTenantID,
+		Code:     "INVITE123",
+		Status:   domain.InviteStatusCompleted,
+		UsedBy:   &user.UUID,
+	}
+	if err := store.Invites().Create(ctx, invite); err != nil {
+		t.Fatalf("Create invite error = %v", err)
+	}
+
+	// Delete user
+	if err := service.DeleteUser(ctx, user.UUID, user.DID); err != nil {
+		t.Fatalf("DeleteUser() error = %v", err)
+	}
+
+	// Verify challenge is deleted
+	_, err = store.Challenges().GetByID(ctx, "test-challenge")
+	if err == nil {
+		t.Error("Challenge should be deleted after DeleteUser")
+	}
+
+	// Verify invite used_by is cleared
+	got, err := store.Invites().GetByID(ctx, "test-invite")
+	if err != nil {
+		t.Fatalf("GetByID invite error = %v", err)
+	}
+	if got.UsedBy != nil {
+		t.Error("Invite used_by should be cleared after DeleteUser")
 	}
 }
 

--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -296,7 +296,6 @@ func (s *WebAuthnService) BeginRegistration(ctx context.Context, req *BeginRegis
 
 	// Debug: log the userHandle being sent to the browser
 	s.logger.Info("Registration: generated userHandle",
-		zap.String("user_id", userID.String()),
 		zap.String("tenant_id", string(tenantID)),
 		zap.Int("handle_length", len(userHandle)),
 		zap.Binary("handle_bytes", userHandle),
@@ -329,7 +328,6 @@ func (s *WebAuthnService) BeginRegistration(ctx context.Context, req *BeginRegis
 	}
 
 	s.logger.Info("Started registration",
-		zap.String("user_id", userID.String()),
 		zap.String("tenant_id", string(tenantID)))
 
 	// Build response matching TypeScript wallet-backend-server format
@@ -650,10 +648,8 @@ func (s *WebAuthnService) FinishRegistration(ctx context.Context, req *FinishReg
 			BoundAt:     now,
 		})
 		s.logger.Info("Bound enterprise identity to user",
-			zap.String("user_id", userID.String()),
 			zap.String("tenant_id", string(tenantID)),
-			zap.String("issuer", req.OIDCGateBinding.Issuer),
-			zap.String("subject", req.OIDCGateBinding.Subject))
+			zap.String("issuer", req.OIDCGateBinding.Issuer))
 	}
 
 	// Store the user

--- a/internal/storage/interface.go
+++ b/internal/storage/interface.go
@@ -136,6 +136,9 @@ type ChallengeStore interface {
 
 	// DeleteExpired deletes all expired challenges
 	DeleteExpired(ctx context.Context) error
+
+	// DeleteByUserID deletes all challenges for a given user
+	DeleteByUserID(ctx context.Context, userID string) error
 }
 
 // IssuerStore defines the interface for credential issuer storage
@@ -227,4 +230,7 @@ type InviteStore interface {
 
 	// Delete hard-deletes an invite within a tenant
 	Delete(ctx context.Context, tenantID domain.TenantID, id string) error
+
+	// ClearUsedBy removes the user reference from any invites consumed by the given user
+	ClearUsedBy(ctx context.Context, userID domain.UserID) error
 }

--- a/internal/storage/memory/invite.go
+++ b/internal/storage/memory/invite.go
@@ -93,3 +93,14 @@ func (s *InviteStore) Delete(ctx context.Context, tenantID domain.TenantID, id s
 	delete(s.data, id)
 	return nil
 }
+
+func (s *InviteStore) ClearUsedBy(ctx context.Context, userID domain.UserID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, inv := range s.data {
+		if inv.UsedBy != nil && *inv.UsedBy == userID {
+			inv.UsedBy = nil
+		}
+	}
+	return nil
+}

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -547,6 +547,18 @@ func (s *ChallengeStore) DeleteExpired(ctx context.Context) error {
 	return nil
 }
 
+func (s *ChallengeStore) DeleteByUserID(ctx context.Context, userID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, challenge := range s.data {
+		if challenge.UserID == userID {
+			delete(s.data, id)
+		}
+	}
+	return nil
+}
+
 // IssuerStore implements in-memory issuer storage
 type IssuerStore struct {
 	mu     sync.RWMutex

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -1842,3 +1842,81 @@ func TestVerifierStore_Upsert_OverwritesClientID(t *testing.T) {
 		t.Errorf("Upsert() ClientIDScheme = %v, want did", found.ClientIDScheme)
 	}
 }
+
+func TestChallengeStore_DeleteByUserID(t *testing.T) {
+	ctx := t.Context()
+	store := NewStore()
+	challenges := store.Challenges()
+
+	// Create challenges for two different users
+	for _, c := range []*domain.WebauthnChallenge{
+		{ID: "c1", UserID: "user-A", Challenge: "ch1", Action: "register", ExpiresAt: time.Now().Add(5 * time.Minute)},
+		{ID: "c2", UserID: "user-A", Challenge: "ch2", Action: "login", ExpiresAt: time.Now().Add(5 * time.Minute)},
+		{ID: "c3", UserID: "user-B", Challenge: "ch3", Action: "register", ExpiresAt: time.Now().Add(5 * time.Minute)},
+	} {
+		if err := challenges.Create(ctx, c); err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	// Delete user-A's challenges
+	if err := challenges.DeleteByUserID(ctx, "user-A"); err != nil {
+		t.Fatalf("DeleteByUserID() error = %v", err)
+	}
+
+	// user-A's challenges should be gone
+	if _, err := challenges.GetByID(ctx, "c1"); err != storage.ErrNotFound {
+		t.Error("Challenge c1 should be deleted")
+	}
+	if _, err := challenges.GetByID(ctx, "c2"); err != storage.ErrNotFound {
+		t.Error("Challenge c2 should be deleted")
+	}
+
+	// user-B's challenge should remain
+	if _, err := challenges.GetByID(ctx, "c3"); err != nil {
+		t.Error("Challenge c3 should still exist")
+	}
+}
+
+func TestInviteStore_ClearUsedBy(t *testing.T) {
+	ctx := t.Context()
+	store := NewStore()
+	invites := store.Invites()
+
+	userA := domain.UserIDFromString("user-A")
+	userB := domain.UserIDFromString("user-B")
+
+	// Create invites: one used by A, one by B, one unused
+	inv1 := &domain.Invite{ID: "inv1", TenantID: domain.DefaultTenantID, Code: "CODE1", Status: domain.InviteStatusCompleted, UsedBy: &userA}
+	inv2 := &domain.Invite{ID: "inv2", TenantID: domain.DefaultTenantID, Code: "CODE2", Status: domain.InviteStatusCompleted, UsedBy: &userB}
+	inv3 := &domain.Invite{ID: "inv3", TenantID: domain.DefaultTenantID, Code: "CODE3", Status: domain.InviteStatusActive}
+
+	for _, inv := range []*domain.Invite{inv1, inv2, inv3} {
+		if err := invites.Create(ctx, inv); err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	// Clear user-A references
+	if err := invites.ClearUsedBy(ctx, userA); err != nil {
+		t.Fatalf("ClearUsedBy() error = %v", err)
+	}
+
+	// inv1 should have UsedBy cleared
+	got1, _ := invites.GetByID(ctx, "inv1")
+	if got1.UsedBy != nil {
+		t.Error("inv1.UsedBy should be nil after ClearUsedBy")
+	}
+
+	// inv2 should be unchanged
+	got2, _ := invites.GetByID(ctx, "inv2")
+	if got2.UsedBy == nil || *got2.UsedBy != userB {
+		t.Error("inv2.UsedBy should still reference user-B")
+	}
+
+	// inv3 should be unchanged
+	got3, _ := invites.GetByID(ctx, "inv3")
+	if got3.UsedBy != nil {
+		t.Error("inv3.UsedBy should still be nil")
+	}
+}

--- a/internal/storage/mongodb/challenges.go
+++ b/internal/storage/mongodb/challenges.go
@@ -58,6 +58,14 @@ func (s *ChallengeStore) DeleteExpired(ctx context.Context) error {
 	return nil
 }
 
+func (s *ChallengeStore) DeleteByUserID(ctx context.Context, userID string) error {
+	_, err := s.collection.DeleteMany(ctx, bson.M{"user_id": userID})
+	if err != nil {
+		return fmt.Errorf("failed to delete challenges for user: %w", err)
+	}
+	return nil
+}
+
 // IssuerStore implements MongoDB issuer storage
 type IssuerStore struct {
 	collection *mongo.Collection

--- a/internal/storage/mongodb/invite.go
+++ b/internal/storage/mongodb/invite.go
@@ -118,3 +118,14 @@ func (s *InviteStore) Delete(ctx context.Context, tenantID domain.TenantID, id s
 	}
 	return nil
 }
+
+func (s *InviteStore) ClearUsedBy(ctx context.Context, userID domain.UserID) error {
+	_, err := s.collection.UpdateMany(ctx,
+		bson.M{"used_by": userID},
+		bson.M{"$unset": bson.M{"used_by": ""}},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to clear used_by for user: %w", err)
+	}
+	return nil
+}

--- a/internal/websocket/manager.go
+++ b/internal/websocket/manager.go
@@ -181,7 +181,7 @@ func (m *Manager) handleClient(conn *websocket.Conn) {
 			m.clients[userID] = client
 			m.clientsMu.Unlock()
 
-			m.logger.Info("WebSocket handshake established", zap.String("user_id", userID), zap.String("tenant_id", tenantID))
+			m.logger.Info("WebSocket handshake established", zap.String("tenant_id", tenantID))
 			_ = conn.WriteJSON(ServerMessage{Type: "FIN_INIT"})
 			continue
 		}
@@ -207,7 +207,7 @@ func (m *Manager) handleClient(conn *websocket.Conn) {
 			delete(m.clients, client.userID)
 		}
 		m.clientsMu.Unlock()
-		m.logger.Info("WebSocket client disconnected", zap.String("user_id", client.userID))
+		m.logger.Info("WebSocket client disconnected")
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -399,6 +399,14 @@ type FeaturesConfig struct {
 	// to use the WebSocket transport instead.
 	// Default: false
 	WebSocketRequired bool `yaml:"websocket_required" envconfig:"WEBSOCKET_REQUIRED"`
+
+	// CredentialStorageEnabled controls whether server-side credential storage
+	// endpoints (/storage/vc/*) are available. By default, credentials are stored
+	// exclusively in the encrypted client-side private_data blob and the server-side
+	// storage path is unused. Set to true only if you need backward-compatible
+	// server-side credential storage.
+	// Default: false (server-side credential storage disabled)
+	CredentialStorageEnabled bool `yaml:"credential_storage_enabled" envconfig:"CREDENTIAL_STORAGE_ENABLED"`
 }
 
 // AuthZENProxyConfig configures the AuthZEN proxy endpoint for frontend trust evaluation.
@@ -732,8 +740,9 @@ func defaultConfig() *Config {
 			},
 		},
 		Features: FeaturesConfig{
-			ProxyEnabled:      true,  // Default: proxy enabled for backward compatibility
-			WebSocketRequired: false, // Default: proxy still allowed
+			ProxyEnabled:             true,  // Default: proxy enabled for backward compatibility
+			WebSocketRequired:        false, // Default: proxy still allowed
+			CredentialStorageEnabled: false, // Default: server-side credential storage disabled
 		},
 		Security: SecurityConfig{
 			AuthRateLimit: AuthRateLimitConfig{

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -160,7 +160,6 @@ func AuthMiddlewareWithBlacklist(cfg *config.Config, store storage.Store, blackl
 			if err == storage.ErrNotFound {
 				logger.Warn("JWT contains invalid tenant_id",
 					zap.String("tenant_id", tenantID),
-					zap.String("user_id", userID),
 				)
 				c.JSON(401, gin.H{"error": "Invalid tenant in token"})
 			} else {
@@ -177,7 +176,6 @@ func AuthMiddlewareWithBlacklist(cfg *config.Config, store storage.Store, blackl
 		if !tenant.Enabled {
 			logger.Warn("JWT tenant is disabled",
 				zap.String("tenant_id", tenantID),
-				zap.String("user_id", userID),
 			)
 			c.JSON(403, gin.H{"error": "Tenant is disabled"})
 			c.Abort()
@@ -190,7 +188,6 @@ func AuthMiddlewareWithBlacklist(cfg *config.Config, store storage.Store, blackl
 			logger.Warn("X-Tenant-ID header mismatches JWT tenant_id - using JWT (authoritative)",
 				zap.String("header_tenant_id", headerTenantID),
 				zap.String("jwt_tenant_id", tenantID),
-				zap.String("user_id", userID),
 			)
 		}
 

--- a/pkg/middleware/prometheus.go
+++ b/pkg/middleware/prometheus.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	httpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sirosid",
+		Name:      "http_requests_total",
+		Help:      "Total number of HTTP requests by method, path pattern, and status code.",
+	}, []string{"method", "path", "status"})
+
+	httpRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "sirosid",
+		Name:      "http_request_duration_seconds",
+		Help:      "HTTP request duration in seconds.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"method", "path"})
+)
+
+// Prometheus returns a Gin middleware that records HTTP request metrics.
+// skipPaths are URL paths that should not be recorded (e.g. "/health", "/readyz").
+func Prometheus(skipPaths ...string) gin.HandlerFunc {
+	skip := make(map[string]bool, len(skipPaths))
+	for _, p := range skipPaths {
+		skip[p] = true
+	}
+
+	return func(c *gin.Context) {
+		if skip[c.Request.URL.Path] {
+			c.Next()
+			return
+		}
+
+		start := time.Now()
+		c.Next()
+		elapsed := time.Since(start).Seconds()
+
+		// Use the matched route pattern rather than the raw URL to avoid
+		// high-cardinality label explosion.
+		path := c.FullPath()
+		if path == "" {
+			path = "unmatched"
+		}
+
+		method := c.Request.Method
+		status := strconv.Itoa(c.Writer.Status())
+
+		httpRequestsTotal.WithLabelValues(method, path, status).Inc()
+		httpRequestDuration.WithLabelValues(method, path).Observe(elapsed)
+	}
+}

--- a/pkg/middleware/prometheus_test.go
+++ b/pkg/middleware/prometheus_test.go
@@ -1,0 +1,102 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestPrometheus_RecordsMetrics(t *testing.T) {
+	router := gin.New()
+	router.Use(Prometheus())
+	router.GET("/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestPrometheus_SkipPath(t *testing.T) {
+	router := gin.New()
+	router.Use(Prometheus("/healthz"))
+	router.GET("/healthz", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+	router.GET("/api", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	// Skipped path should still serve normally but not record metrics
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Non-skipped path should also work
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestPrometheus_UnmatchedPath(t *testing.T) {
+	router := gin.New()
+	router.Use(Prometheus())
+	// No routes registered — any path should be "unmatched"
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/nonexistent", nil)
+	router.ServeHTTP(w, req)
+
+	// Gin returns 404 for unmatched routes
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPrometheus_MultipleStatusCodes(t *testing.T) {
+	router := gin.New()
+	router.Use(Prometheus())
+	router.POST("/items", func(c *gin.Context) {
+		c.String(http.StatusCreated, "created")
+	})
+	router.GET("/fail", func(c *gin.Context) {
+		c.String(http.StatusInternalServerError, "err")
+	})
+
+	// 201
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/items", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+
+	// 500
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/fail", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}

--- a/tests/integration/harness.go
+++ b/tests/integration/harness.go
@@ -182,9 +182,9 @@ func setupRoutes(r *gin.Engine, h *api.Handlers, cfg *config.Config, store stora
 		if cfg.Features.CredentialStorageEnabled {
 			storage.GET("/vc", h.GetAllCredentials)
 			storage.POST("/vc", h.StoreCredential)
-			storage.GET("/vc/:id", h.GetCredentialByIdentifier)
-			storage.PUT("/vc/:id", h.UpdateCredential)
-			storage.DELETE("/vc/:id", h.DeleteCredential)
+			storage.POST("/vc/update", h.UpdateCredential)
+			storage.GET("/vc/:credential_identifier", h.GetCredentialByIdentifier)
+			storage.DELETE("/vc/:credential_identifier", h.DeleteCredential)
 		}
 	}
 

--- a/tests/integration/harness.go
+++ b/tests/integration/harness.go
@@ -55,6 +55,29 @@ func WithConfig(cfg *config.Config) TestHarnessOption {
 	}
 }
 
+// defaultTestConfig returns the default integration test config.
+// Callers can mutate the returned struct before passing it to WithConfig.
+func defaultTestConfig() *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{
+			Host:     "localhost",
+			Port:     8080,
+			RPID:     "localhost",
+			RPOrigin: "http://localhost:8080",
+			RPName:   "Test Wallet",
+		},
+		Storage: config.StorageConfig{
+			Type: "memory",
+		},
+		JWT: config.JWTConfig{
+			Secret:      "test-secret-key-for-integration-tests",
+			ExpiryHours: 24,
+			RefreshDays: 7,
+			Issuer:      "test-wallet-backend",
+		},
+	}
+}
+
 // NewTestHarness creates a new test harness with a running test server
 func NewTestHarness(t *testing.T, opts ...TestHarnessOption) *TestHarness {
 	t.Helper()
@@ -76,24 +99,7 @@ func NewTestHarness(t *testing.T, opts ...TestHarnessOption) *TestHarness {
 
 	// Default config if not provided
 	if h.Config == nil {
-		h.Config = &config.Config{
-			Server: config.ServerConfig{
-				Host:     "localhost",
-				Port:     8080,
-				RPID:     "localhost",
-				RPOrigin: "http://localhost:8080",
-				RPName:   "Test Wallet",
-			},
-			Storage: config.StorageConfig{
-				Type: "memory",
-			},
-			JWT: config.JWTConfig{
-				Secret:      "test-secret-key-for-integration-tests",
-				ExpiryHours: 24,
-				RefreshDays: 7,
-				Issuer:      "test-wallet-backend",
-			},
-		}
+		h.Config = defaultTestConfig()
 	}
 
 	// Create memory storage
@@ -168,16 +174,18 @@ func setupRoutes(r *gin.Engine, h *api.Handlers, cfg *config.Config, store stora
 		session.POST("/webauthn-credential/:id/rename", h.RenameWebAuthnCredential)
 	}
 
-	// Storage routes (authenticated)
+	// Storage routes (authenticated) — gated like production
 	storage := r.Group("/storage")
 	storage.Use(auth)
 	{
-		// Credentials
-		storage.GET("/vc", h.GetAllCredentials)
-		storage.POST("/vc", h.StoreCredential)
-		storage.GET("/vc/:id", h.GetCredentialByIdentifier)
-		storage.PUT("/vc/:id", h.UpdateCredential)
-		storage.DELETE("/vc/:id", h.DeleteCredential)
+		// Credentials (gated behind feature flag, matching providers.go)
+		if cfg.Features.CredentialStorageEnabled {
+			storage.GET("/vc", h.GetAllCredentials)
+			storage.POST("/vc", h.StoreCredential)
+			storage.GET("/vc/:id", h.GetCredentialByIdentifier)
+			storage.PUT("/vc/:id", h.UpdateCredential)
+			storage.DELETE("/vc/:id", h.DeleteCredential)
+		}
 	}
 
 	// Issuer routes (public)

--- a/tests/integration/harness.go
+++ b/tests/integration/harness.go
@@ -178,12 +178,6 @@ func setupRoutes(r *gin.Engine, h *api.Handlers, cfg *config.Config, store stora
 		storage.GET("/vc/:id", h.GetCredentialByIdentifier)
 		storage.PUT("/vc/:id", h.UpdateCredential)
 		storage.DELETE("/vc/:id", h.DeleteCredential)
-
-		// Presentations
-		storage.GET("/vp", h.GetAllPresentations)
-		storage.POST("/vp", h.StorePresentation)
-		storage.GET("/vp/:id", h.GetPresentationByIdentifier)
-		storage.DELETE("/vp/:id", h.DeletePresentation)
 	}
 
 	// Issuer routes (public)

--- a/tests/integration/storage_test.go
+++ b/tests/integration/storage_test.go
@@ -77,15 +77,16 @@ func TestCredentialStorage(t *testing.T) {
 		}
 	})
 
-	t.Run("PUT updates a credential", func(t *testing.T) {
-		credJSON := `{"@context":["https://www.w3.org/2018/credentials/v1"],"updated":true}`
-		credB64 := base64.RawURLEncoding.EncodeToString([]byte(credJSON))
-
+	t.Run("POST /vc/update updates a credential", func(t *testing.T) {
 		updateReq := map[string]interface{}{
-			"credential": map[string]string{"$b64u": credB64},
+			"credential": map[string]interface{}{
+				"credentialIdentifier": "test-vc-001",
+				"instanceId":           0,
+				"sigCount":             1,
+			},
 		}
 
-		resp := h.AuthPUT(user, "/storage/vc/test-vc-001", updateReq)
+		resp := h.AuthPOST(user, "/storage/vc/update", updateReq)
 		// 200 if updated, 404 if not found
 		if resp.Response.StatusCode >= 500 {
 			t.Errorf("Got server error: %d - %s", resp.Response.StatusCode, resp.Pretty())

--- a/tests/integration/storage_test.go
+++ b/tests/integration/storage_test.go
@@ -107,62 +107,23 @@ func TestCredentialStorage(t *testing.T) {
 	})
 }
 
-// TestPresentationStorage tests VP storage endpoints
-func TestPresentationStorage(t *testing.T) {
+// TestPresentationStorageRemoved verifies VP endpoints are no longer registered
+func TestPresentationStorageRemoved(t *testing.T) {
 	h := NewTestHarness(t)
-	user := h.CreateTestUser("VP Storage User")
+	user := h.CreateTestUser("VP Removed User")
 
-	var storedVPID string
-
-	t.Run("POST stores a presentation", func(t *testing.T) {
-		vpJSON := `{"@context":["https://www.w3.org/2018/credentials/v1"],"type":["VerifiablePresentation"]}`
-		vpB64 := base64.RawURLEncoding.EncodeToString([]byte(vpJSON))
-
-		storeReq := map[string]interface{}{
-			"presentation":           map[string]string{"$b64u": vpB64},
-			"presentationIdentifier": "test-vp-001",
-		}
-
-		resp := h.AuthPOST(user, "/storage/vp", storeReq)
-
-		if resp.Response.StatusCode == http.StatusOK || resp.Response.StatusCode == http.StatusCreated {
-			var result map[string]interface{}
-			resp.JSON(&result)
-			if id, ok := result["presentationIdentifier"].(string); ok {
-				storedVPID = id
-			}
-		} else if resp.Response.StatusCode >= 500 {
-			t.Errorf("Got server error: %d - %s", resp.Response.StatusCode, resp.Pretty())
+	t.Run("POST /storage/vp returns 404", func(t *testing.T) {
+		resp := h.AuthPOST(user, "/storage/vp", map[string]string{"test": "data"})
+		if resp.Response.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected 404 for removed VP endpoint, got %d", resp.Response.StatusCode)
 		}
 	})
 
-	t.Run("GET returns all presentations", func(t *testing.T) {
+	t.Run("GET /storage/vp returns 404", func(t *testing.T) {
 		resp := h.AuthGET(user, "/storage/vp")
-		resp.Status(http.StatusOK)
-		t.Logf("All presentations response: %s", resp.Pretty())
-	})
-
-	t.Run("GET by ID returns specific presentation", func(t *testing.T) {
-		if storedVPID == "" {
-			storedVPID = "test-vp-001"
+		if resp.Response.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected 404 for removed VP endpoint, got %d", resp.Response.StatusCode)
 		}
-
-		resp := h.AuthGET(user, "/storage/vp/"+storedVPID)
-		if resp.Response.StatusCode >= 500 {
-			t.Errorf("Got server error: %d - %s", resp.Response.StatusCode, resp.Pretty())
-		}
-	})
-
-	t.Run("DELETE removes a presentation", func(t *testing.T) {
-		resp := h.AuthDELETE(user, "/storage/vp/test-vp-001")
-		if resp.Response.StatusCode >= 500 {
-			t.Errorf("Got server error: %d - %s", resp.Response.StatusCode, resp.Pretty())
-		}
-	})
-
-	t.Run("returns 401 without auth", func(t *testing.T) {
-		resp := h.GET("/storage/vp")
-		resp.Status(http.StatusUnauthorized)
 	})
 }
 

--- a/tests/integration/storage_test.go
+++ b/tests/integration/storage_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 )
 
-// TestCredentialStorage tests VC storage endpoints
+// TestCredentialStorage tests VC storage endpoints (with feature flag enabled)
 func TestCredentialStorage(t *testing.T) {
-	h := NewTestHarness(t)
+	cfg := defaultTestConfig()
+	cfg.Features.CredentialStorageEnabled = true
+	h := NewTestHarness(t, WithConfig(cfg))
 	user := h.CreateTestUser("Storage User")
 
 	// Sample credential for testing
@@ -109,7 +111,9 @@ func TestCredentialStorage(t *testing.T) {
 
 // TestPresentationStorageRemoved verifies VP endpoints are no longer registered
 func TestPresentationStorageRemoved(t *testing.T) {
-	h := NewTestHarness(t)
+	cfg := defaultTestConfig()
+	cfg.Features.CredentialStorageEnabled = true
+	h := NewTestHarness(t, WithConfig(cfg))
 	user := h.CreateTestUser("VP Removed User")
 
 	t.Run("POST /storage/vp returns 404", func(t *testing.T) {
@@ -123,6 +127,27 @@ func TestPresentationStorageRemoved(t *testing.T) {
 		resp := h.AuthGET(user, "/storage/vp")
 		if resp.Response.StatusCode != http.StatusNotFound {
 			t.Errorf("Expected 404 for removed VP endpoint, got %d", resp.Response.StatusCode)
+		}
+	})
+}
+
+// TestCredentialStorageDisabled verifies VC endpoints return 404 when the feature flag is off (default)
+func TestCredentialStorageDisabled(t *testing.T) {
+	// Default config has CredentialStorageEnabled = false
+	h := NewTestHarness(t)
+	user := h.CreateTestUser("Disabled VC User")
+
+	t.Run("GET /storage/vc returns 404 when disabled", func(t *testing.T) {
+		resp := h.AuthGET(user, "/storage/vc")
+		if resp.Response.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected 404 for disabled VC endpoint, got %d", resp.Response.StatusCode)
+		}
+	})
+
+	t.Run("POST /storage/vc returns 404 when disabled", func(t *testing.T) {
+		resp := h.AuthPOST(user, "/storage/vc", map[string]string{"test": "data"})
+		if resp.Response.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected 404 for disabled VC endpoint, got %d", resp.Response.StatusCode)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Privacy remediation for GDPR compliance, Prometheus metrics instrumentation, Kubernetes health endpoint standardisation, and right-to-erasure cascade fix.

Closes sirosfoundation/compliance#15

### C0: Privacy Remediation (GDPR log cleanup)

- **CRITICAL**: Removed admin token from log output (`server.go`)
- **HIGH**: Removed `user_id` from user lifecycle INFO logs
- **HIGH**: Removed `user_id`/`subject_id` from AuthZEN proxy INFO logs
- **HIGH**: Removed `holder_did` from credential/presentation INFO logs
- **MEDIUM**: Removed `user_id` from WebSocket/auth middleware/WebAuthn logs
- **Rule**: No user PII at INFO level or above in production logs

### WS4: Right-to-Erasure Cascade (Finding #15, P-4)

- `DeleteUser` now cascades to all data stores:
  - Credentials and presentations (per tenant)
  - Tenant memberships
  - WebAuthn challenges (`DeleteByUserID`)
  - Invite references (`ClearUsedBy`)
  - WebSocket sessions (`SessionCleaner.DeleteByUser` — memory or Redis)
  - User record
- `SessionCleaner` interface wired via `SetSessionCleaner()` in `main.go`
- 4 dedicated test cases covering all cascade paths

### C3: Prometheus Metrics

- New `middleware.Prometheus()` Gin middleware recording:
  - `sirosid_http_requests_total` (counter, labels: method/path/status)
  - `sirosid_http_request_duration_seconds` (histogram, labels: method/path)
- Uses `FullPath()` matched route patterns to avoid label cardinality explosion
- `/metrics` endpoint exposed on admin server via `promhttp.Handler`
- Middleware skips health/status probe paths

### C4: Health Endpoint Standardisation

- Added `/healthz` alias (keeps `/health` for backward compatibility)
- Aligns with Kubernetes probe conventions

### Testing

- All tests passing
- `go build ./...` clean
- `golangci-lint` clean

### Framework Mapping

| Requirement | Status |
|---|---|
| GDPR Art. 5(1)(c) data minimisation | ✅ PII removed from INFO logs |
| GDPR Art. 17 right to erasure | ✅ Complete cascade in DeleteUser |
| EN 319 401 §7.9.1 REQ-7.9.1-04 | ✅ Structured logging preserved |
| ISO 27001 A.8.15 (logging) | ✅ Privacy-safe log output |
| ISO 27001 A.8.16 (monitoring) | ✅ Prometheus + /healthz |

Part of **WS2 Logging & Monitoring** and **WS4 Platform Code Changes** workstreams.