### PR TITLE
ci: use go-version-file instead of hardcoded version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
 
       - name: Download dependencies
         run: go mod download
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
Replace hardcoded `go-version: '1.26'` with `go-version-file: go.mod` in test, lint, and build jobs so CI always uses the Go version declared in go.mod.