### PR TITLE
feat: Add TLS configuration for admin server

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -154,6 +154,7 @@ func main() {
 		serverCfg.CORS = backendCfg.Server.CORS
 		serverCfg.LoggingLevel = backendCfg.Logging.Level
 		serverCfg.TLS = backendCfg.Server.TLS
+		serverCfg.AdminTLS = backendCfg.Server.AdminTLS
 	} else if registryCfg != nil {
 		// Registry-only mode - use registry server config
 		serverCfg.HTTPAddress = registryCfg.Server.Host

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -410,11 +410,9 @@ func (m *Manager) startAdminServer() error {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	// Use dedicated admin TLS config if provided, otherwise fall back to shared TLS
-	adminTLS := &m.cfg.TLS
-	if m.cfg.AdminTLS != nil {
-		adminTLS = m.cfg.AdminTLS
-	}
+	// Use dedicated admin TLS config only when it is explicitly enabled,
+	// otherwise fall back to the shared TLS configuration.
+	adminTLS := effectiveAdminTLS(&m.cfg.TLS, m.cfg.AdminTLS)
 
 	go func() {
 		m.logger.Info("Admin server listening", zap.String("address", adminAddr), zap.Bool("tls", adminTLS.Enabled))
@@ -430,4 +428,14 @@ func (m *Manager) startAdminServer() error {
 // Useful for modes that need to add routes after construction.
 func (m *Manager) HTTPRouter() *gin.Engine {
 	return m.httpRouter
+}
+
+// effectiveAdminTLS returns the TLS config to use for the admin server.
+// It uses adminTLS only when it is non-nil and explicitly enabled;
+// otherwise it falls back to the shared TLS config.
+func effectiveAdminTLS(shared *config.TLSConfig, admin *config.TLSConfig) *config.TLSConfig {
+	if admin != nil && admin.Enabled {
+		return admin
+	}
+	return shared
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -86,6 +86,7 @@ type ServerConfig struct {
 	// Admin server settings
 	AdminPort  int
 	AdminToken string
+	AdminTLS   *config.TLSConfig // nil = inherit from TLS
 
 	// Common settings
 	CORS         config.CORSConfig
@@ -409,9 +410,15 @@ func (m *Manager) startAdminServer() error {
 		IdleTimeout:  60 * time.Second,
 	}
 
+	// Use dedicated admin TLS config if provided, otherwise fall back to shared TLS
+	adminTLS := &m.cfg.TLS
+	if m.cfg.AdminTLS != nil {
+		adminTLS = m.cfg.AdminTLS
+	}
+
 	go func() {
-		m.logger.Info("Admin server listening", zap.String("address", adminAddr))
-		if err := m.cfg.TLS.ListenAndServe(m.adminServer); err != nil && err != http.ErrServerClosed {
+		m.logger.Info("Admin server listening", zap.String("address", adminAddr), zap.Bool("tls", adminTLS.Enabled))
+		if err := adminTLS.ListenAndServe(m.adminServer); err != nil && err != http.ErrServerClosed {
 			m.logger.Error("Admin server error", zap.Error(err))
 		}
 	}()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -196,32 +196,34 @@ func TestServerConfig_Fields(t *testing.T) {
 	}
 }
 
-func TestServerConfig_AdminTLS_NilInherits(t *testing.T) {
-	cfg := &ServerConfig{
-		TLS: config.TLSConfig{Enabled: true, CertFile: "/main.pem", KeyFile: "/main.key"},
-	}
-	// When AdminTLS is nil, the admin server should inherit the shared TLS config
-	if cfg.AdminTLS != nil {
-		t.Error("AdminTLS should be nil by default")
-	}
-}
+func TestEffectiveAdminTLS(t *testing.T) {
+	shared := &config.TLSConfig{Enabled: true, CertFile: "/main.pem", KeyFile: "/main.key"}
+	adminEnabled := &config.TLSConfig{Enabled: true, CertFile: "/admin.pem", KeyFile: "/admin.key"}
+	adminDisabled := &config.TLSConfig{Enabled: false}
 
-func TestServerConfig_AdminTLS_Override(t *testing.T) {
-	adminTLS := &config.TLSConfig{Enabled: true, CertFile: "/admin.pem", KeyFile: "/admin.key"}
-	cfg := &ServerConfig{
-		TLS:      config.TLSConfig{Enabled: true, CertFile: "/main.pem", KeyFile: "/main.key"},
-		AdminTLS: adminTLS,
-	}
+	t.Run("nil AdminTLS inherits shared", func(t *testing.T) {
+		got := effectiveAdminTLS(shared, nil)
+		if got != shared {
+			t.Error("expected shared TLS config when AdminTLS is nil")
+		}
+	})
 
-	if cfg.AdminTLS == nil {
-		t.Fatal("AdminTLS should not be nil")
-	}
-	if cfg.AdminTLS.CertFile != "/admin.pem" {
-		t.Errorf("AdminTLS.CertFile = %q, want /admin.pem", cfg.AdminTLS.CertFile)
-	}
-	if cfg.AdminTLS.KeyFile != "/admin.key" {
-		t.Errorf("AdminTLS.KeyFile = %q, want /admin.key", cfg.AdminTLS.KeyFile)
-	}
+	t.Run("disabled AdminTLS inherits shared", func(t *testing.T) {
+		got := effectiveAdminTLS(shared, adminDisabled)
+		if got != shared {
+			t.Error("expected shared TLS config when AdminTLS.Enabled is false")
+		}
+	})
+
+	t.Run("enabled AdminTLS overrides shared", func(t *testing.T) {
+		got := effectiveAdminTLS(shared, adminEnabled)
+		if got != adminEnabled {
+			t.Error("expected admin TLS config when AdminTLS.Enabled is true")
+		}
+		if got.CertFile != "/admin.pem" {
+			t.Errorf("CertFile = %q, want /admin.pem", got.CertFile)
+		}
+	})
 }
 
 // Test that status endpoints are added to routers

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -196,6 +196,34 @@ func TestServerConfig_Fields(t *testing.T) {
 	}
 }
 
+func TestServerConfig_AdminTLS_NilInherits(t *testing.T) {
+	cfg := &ServerConfig{
+		TLS: config.TLSConfig{Enabled: true, CertFile: "/main.pem", KeyFile: "/main.key"},
+	}
+	// When AdminTLS is nil, the admin server should inherit the shared TLS config
+	if cfg.AdminTLS != nil {
+		t.Error("AdminTLS should be nil by default")
+	}
+}
+
+func TestServerConfig_AdminTLS_Override(t *testing.T) {
+	adminTLS := &config.TLSConfig{Enabled: true, CertFile: "/admin.pem", KeyFile: "/admin.key"}
+	cfg := &ServerConfig{
+		TLS:      config.TLSConfig{Enabled: true, CertFile: "/main.pem", KeyFile: "/main.key"},
+		AdminTLS: adminTLS,
+	}
+
+	if cfg.AdminTLS == nil {
+		t.Fatal("AdminTLS should not be nil")
+	}
+	if cfg.AdminTLS.CertFile != "/admin.pem" {
+		t.Errorf("AdminTLS.CertFile = %q, want /admin.pem", cfg.AdminTLS.CertFile)
+	}
+	if cfg.AdminTLS.KeyFile != "/admin.key" {
+		t.Errorf("AdminTLS.KeyFile = %q, want /admin.key", cfg.AdminTLS.KeyFile)
+	}
+}
+
 // Test that status endpoints are added to routers
 func TestManager_StatusEndpoints(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,11 @@ type ServerConfig struct {
 
 	// TLS configuration for HTTPS listeners
 	TLS TLSConfig `yaml:"tls" envconfig:"TLS"`
+
+	// AdminTLS provides separate TLS configuration for the admin server.
+	// When set and enabled, the admin server uses its own certificate/key
+	// instead of inheriting the main TLS configuration.
+	AdminTLS *TLSConfig `yaml:"admin_tls,omitempty" envconfig:"ADMIN_TLS"`
 }
 
 // TLSConfig contains TLS configuration for HTTPS listeners
@@ -783,6 +788,16 @@ func (c *Config) Validate() error {
 		}
 		if c.Server.TLS.KeyFile == "" {
 			return fmt.Errorf("server.tls.key_file is required when TLS is enabled")
+		}
+	}
+
+	// Validate admin TLS configuration (if explicitly set)
+	if c.Server.AdminTLS != nil && c.Server.AdminTLS.Enabled {
+		if c.Server.AdminTLS.CertFile == "" {
+			return fmt.Errorf("server.admin_tls.cert_file is required when admin TLS is enabled")
+		}
+		if c.Server.AdminTLS.KeyFile == "" {
+			return fmt.Errorf("server.admin_tls.key_file is required when admin TLS is enabled")
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -720,6 +720,90 @@ func TestConfig_Validate_AdminTLS(t *testing.T) {
 	})
 }
 
+func TestLoad_AdminTLS_FromYAML(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	configYAML := []byte(`
+server:
+  host: localhost
+  port: 8080
+  rp_id: localhost
+  rp_origin: http://localhost:8080
+  admin_tls:
+    enabled: true
+    cert_file: /yaml/cert.pem
+    key_file: /yaml/key.pem
+storage:
+  type: memory
+jwt:
+  secret: test
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Server.AdminTLS == nil {
+		t.Fatal("Load() left Server.AdminTLS nil for YAML admin_tls configuration")
+	}
+	if !cfg.Server.AdminTLS.Enabled {
+		t.Errorf("Server.AdminTLS.Enabled = %v, want true", cfg.Server.AdminTLS.Enabled)
+	}
+	if cfg.Server.AdminTLS.CertFile != "/yaml/cert.pem" {
+		t.Errorf("Server.AdminTLS.CertFile = %q, want %q", cfg.Server.AdminTLS.CertFile, "/yaml/cert.pem")
+	}
+	if cfg.Server.AdminTLS.KeyFile != "/yaml/key.pem" {
+		t.Errorf("Server.AdminTLS.KeyFile = %q, want %q", cfg.Server.AdminTLS.KeyFile, "/yaml/key.pem")
+	}
+}
+
+func TestLoad_AdminTLS_FromEnv(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	configYAML := []byte(`
+server:
+  host: localhost
+  port: 8080
+  rp_id: localhost
+  rp_origin: http://localhost:8080
+storage:
+  type: memory
+jwt:
+  secret: test
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	t.Setenv("WALLET_SERVER_ADMIN_TLS_ENABLED", "true")
+	t.Setenv("WALLET_SERVER_ADMIN_TLS_CERT_FILE", "/env/cert.pem")
+	t.Setenv("WALLET_SERVER_ADMIN_TLS_KEY_FILE", "/env/key.pem")
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Server.AdminTLS == nil {
+		t.Fatal("Load() left Server.AdminTLS nil when admin TLS env vars were set")
+	}
+	if !cfg.Server.AdminTLS.Enabled {
+		t.Errorf("Server.AdminTLS.Enabled = %v, want true", cfg.Server.AdminTLS.Enabled)
+	}
+	if cfg.Server.AdminTLS.CertFile != "/env/cert.pem" {
+		t.Errorf("Server.AdminTLS.CertFile = %q, want %q", cfg.Server.AdminTLS.CertFile, "/env/cert.pem")
+	}
+	if cfg.Server.AdminTLS.KeyFile != "/env/key.pem" {
+		t.Errorf("Server.AdminTLS.KeyFile = %q, want %q", cfg.Server.AdminTLS.KeyFile, "/env/key.pem")
+	}
+}
+
 // =============================================================================
 // ExternalURLsConfig tests
 // =============================================================================

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -666,6 +666,60 @@ func TestConfig_Validate_TLSDisabled_NoRequirements(t *testing.T) {
 	}
 }
 
+func TestConfig_Validate_AdminTLS(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			Server: ServerConfig{
+				Host:     "localhost",
+				Port:     8080,
+				RPID:     "localhost",
+				RPOrigin: "http://localhost:8080",
+			},
+			Storage: StorageConfig{Type: "memory"},
+			JWT:     JWTConfig{Secret: "test"},
+		}
+	}
+
+	t.Run("nil admin_tls is valid", func(t *testing.T) {
+		cfg := base()
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("admin_tls disabled is valid without cert/key", func(t *testing.T) {
+		cfg := base()
+		cfg.Server.AdminTLS = &TLSConfig{Enabled: false}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("admin_tls enabled requires cert_file", func(t *testing.T) {
+		cfg := base()
+		cfg.Server.AdminTLS = &TLSConfig{Enabled: true, KeyFile: "/key.pem"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for missing cert_file")
+		}
+	})
+
+	t.Run("admin_tls enabled requires key_file", func(t *testing.T) {
+		cfg := base()
+		cfg.Server.AdminTLS = &TLSConfig{Enabled: true, CertFile: "/cert.pem"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for missing key_file")
+		}
+	})
+
+	t.Run("admin_tls enabled with both files is valid", func(t *testing.T) {
+		cfg := base()
+		cfg.Server.AdminTLS = &TLSConfig{Enabled: true, CertFile: "/cert.pem", KeyFile: "/key.pem"}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
 // =============================================================================
 // ExternalURLsConfig tests
 // =============================================================================


### PR DESCRIPTION
## Summary

Add a separate `AdminTLS` configuration option for the admin HTTP server, allowing it to use its own certificate and key independently of the main TLS configuration.

## Problem

The admin server was initially designed for loopback-only access where TLS wasn't needed. With upcoming changes (metrics exposure, new tenant management strategy), traffic may flow over untrusted network segments. While the admin server already inherits the shared TLS config, there was no way to configure dedicated admin-only certificates.

## Changes

- **`pkg/config`**: Added `AdminTLS *TLSConfig` field to `ServerConfig` with validation (requires cert_file and key_file when enabled)
- **`internal/server`**: Admin server uses `AdminTLS` when configured, falls back to the shared TLS settings when nil (preserving backward compatibility)
- **`cmd/server`**: Wire `AdminTLS` from config to server manager

## Configuration

Environment variables:
```
WALLET_SERVER_ADMIN_TLS_ENABLED=true
WALLET_SERVER_ADMIN_TLS_CERT_FILE=/path/to/admin-cert.pem
WALLET_SERVER_ADMIN_TLS_KEY_FILE=/path/to/admin-key.pem
WALLET_SERVER_ADMIN_TLS_MIN_VERSION=tls13
```

YAML:
```yaml
server:
  admin_tls:
    enabled: true
    cert_file: /path/to/admin-cert.pem
    key_file: /path/to/admin-key.pem
    min_version: tls13
```

When `admin_tls` is not configured (default), the admin server inherits the main `server.tls` settings — no breaking change.

Closes #95