### PR TITLE
fix: don't count attestation proofs the same way as jwt proofs, one attestation proof can cover multiple credentials

### DIFF
--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -1299,12 +1299,26 @@ func (h *OID4VCIHandler) requestProofs(ctx context.Context, metadata *IssuerMeta
 		return nil, err
 	}
 
-	if len(resp.Proofs) != count {
-		return nil, fmt.Errorf("frontend returned %d proofs (expected %d)", len(resp.Proofs), count)
+	if len(resp.Proofs) == 0 {
+		return nil, errors.New("frontend returned no proofs")
+	}
+
+	// Determine proof type from first proof
+	proofType := resp.Proofs[0].ProofType
+
+	// Validate proof count based on proof type:
+	// - 'attestation': one proof can cover multiple credentials (batch attestation)
+	// - 'jwt' or other: need one proof per credential in the batch
+	if proofType != "attestation" && len(resp.Proofs) != count {
+		return nil, fmt.Errorf("frontend returned %d %s proofs (expected %d)", len(resp.Proofs), proofType, count)
 	}
 
 	// Validate that every returned proof type is listed in proof_types_supported
+	// and that all proofs are the same type
 	for _, proof := range resp.Proofs {
+		if proof.ProofType != proofType {
+			return nil, fmt.Errorf("mixed proof types not allowed: got %q and %q", proofType, proof.ProofType)
+		}
 		if _, ok := config.ProofTypesSupported[proof.ProofType]; !ok {
 			return nil, fmt.Errorf("unsupported proof type %q: not listed in proof_types_supported", proof.ProofType)
 		}

--- a/internal/engine/oid4vci_test.go
+++ b/internal/engine/oid4vci_test.go
@@ -1883,7 +1883,7 @@ func TestRequestProofs_ErrorOnEmptyProofs(t *testing.T) {
 
 	_, err := h.requestProofs(context.Background(), metadata, config, "nonce")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "frontend returned 0 proofs")
+	assert.Contains(t, err.Error(), "frontend returned no proofs")
 }
 
 func TestCNonceRequiredError_ErrorAndUnwrap(t *testing.T) {


### PR DESCRIPTION
Attestations can cover multiple credentials, so we should not enforce the count like with JWT proofs. 
If using JWT proofs, we need 1 jwt for each instance of the credential in the batch, which does not apply to attestations.

This PR reworks the validation logic to only count jwts, and not attestations. We also validate that all recieved proofs are of the same type.
