### PR TITLE
feat: support local VCTM file overrides

### DIFF
--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -75,6 +75,11 @@ type SourceConfig struct {
 	// URL of the upstream registry index (e.g., https://registry.siros.org/.well-known/vctm-registry.json)
 	URL string `yaml:"url"`
 
+	// LocalOverrides is a list of local file or directory paths containing VCTM JSON files.
+	// These are loaded at startup and take priority over entries fetched from the remote registry.
+	// Directories are scanned for *.json files. Entries are keyed by their "vct" field.
+	LocalOverrides []string `yaml:"local_overrides" envconfig:"LOCAL_OVERRIDES"`
+
 	// PollInterval is how often to poll the upstream registry for updates
 	PollInterval time.Duration `yaml:"poll_interval" envconfig:"POLL_INTERVAL"`
 

--- a/internal/registry/local.go
+++ b/internal/registry/local.go
@@ -76,11 +76,12 @@ func loadFile(store *Store, path string, logger *zap.Logger) error {
 		return fmt.Errorf("invalid JSON")
 	}
 
-	// Extract the top-level "vct" and optional "name" / "description" fields.
+	// Extract the top-level "vct" and optional display fields.
 	var header struct {
-		VCT         string `json:"vct"`
-		Name        string `json:"name"`
-		Description string `json:"description"`
+		VCT          string `json:"vct"`
+		Name         string `json:"name"`
+		Description  string `json:"description"`
+		Organization string `json:"organization"`
 	}
 	if err := json.Unmarshal(data, &header); err != nil {
 		return fmt.Errorf("unmarshal header: %w", err)
@@ -90,12 +91,13 @@ func loadFile(store *Store, path string, logger *zap.Logger) error {
 	}
 
 	entry := &VCTMEntry{
-		VCT:         header.VCT,
-		Name:        header.Name,
-		Description: header.Description,
-		Metadata:    json.RawMessage(data),
-		FetchedAt:   time.Now(),
-		IsLocal:     true,
+		VCT:          header.VCT,
+		Name:         header.Name,
+		Description:  header.Description,
+		Organization: header.Organization,
+		Metadata:     json.RawMessage(data),
+		FetchedAt:    time.Now(),
+		IsLocal:      true,
 	}
 
 	store.Put(entry)

--- a/internal/registry/local.go
+++ b/internal/registry/local.go
@@ -1,0 +1,106 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// LoadLocalOverrides reads VCTM JSON files from the configured paths and
+// inserts them into the store with IsLocal=true. Each path may be a regular
+// file or a directory; directories are scanned for *.json files (non-recursive).
+// The "vct" field in each JSON document is used as the store key.
+func LoadLocalOverrides(store *Store, paths []string, logger *zap.Logger) error {
+	var loaded int
+	for _, p := range paths {
+		n, err := loadPath(store, p, logger)
+		if err != nil {
+			return fmt.Errorf("loading %s: %w", p, err)
+		}
+		loaded += n
+	}
+	if loaded > 0 {
+		logger.Info("Loaded local VCTM overrides", zap.Int("entries", loaded))
+	}
+	return nil
+}
+
+// loadPath handles a single path which may be a file or directory.
+func loadPath(store *Store, p string, logger *zap.Logger) (int, error) {
+	info, err := os.Stat(p)
+	if err != nil {
+		return 0, fmt.Errorf("stat: %w", err)
+	}
+
+	if !info.IsDir() {
+		if err := loadFile(store, p, logger); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
+
+	entries, err := os.ReadDir(p)
+	if err != nil {
+		return 0, fmt.Errorf("reading directory: %w", err)
+	}
+
+	var count int
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		fp := filepath.Join(p, e.Name())
+		if err := loadFile(store, fp, logger); err != nil {
+			logger.Warn("Skipping invalid local VCTM file",
+				zap.String("path", fp), zap.Error(err))
+			continue
+		}
+		count++
+	}
+	return count, nil
+}
+
+// loadFile reads a single VCTM JSON file, extracts the "vct" field, and puts
+// it into the store as a local override.
+func loadFile(store *Store, path string, logger *zap.Logger) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+
+	if !json.Valid(data) {
+		return fmt.Errorf("invalid JSON")
+	}
+
+	// Extract the top-level "vct" and optional "name" / "description" fields.
+	var header struct {
+		VCT         string `json:"vct"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return fmt.Errorf("unmarshal header: %w", err)
+	}
+	if header.VCT == "" {
+		return fmt.Errorf("missing or empty \"vct\" field")
+	}
+
+	entry := &VCTMEntry{
+		VCT:         header.VCT,
+		Name:        header.Name,
+		Description: header.Description,
+		Metadata:    json.RawMessage(data),
+		FetchedAt:   time.Now(),
+		IsLocal:     true,
+	}
+
+	store.Put(entry)
+	logger.Debug("Loaded local VCTM override",
+		zap.String("vct", header.VCT),
+		zap.String("path", path))
+	return nil
+}

--- a/internal/registry/local_test.go
+++ b/internal/registry/local_test.go
@@ -1,0 +1,174 @@
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func testVCTMJSON(vct, name string) []byte {
+	m := map[string]interface{}{
+		"vct":         vct,
+		"name":        name,
+		"description": "test credential",
+		"claims":      []interface{}{},
+	}
+	b, _ := json.Marshal(m)
+	return b
+}
+
+func TestLoadLocalOverrides_SingleFile(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "test.json")
+	if err := os.WriteFile(fp, testVCTMJSON("urn:test:1", "Test Cred"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	if err := LoadLocalOverrides(store, []string{fp}, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entry, ok := store.Get("urn:test:1")
+	if !ok {
+		t.Fatal("entry not found in store")
+	}
+	if !entry.IsLocal {
+		t.Error("expected IsLocal=true")
+	}
+	if entry.Name != "Test Cred" {
+		t.Errorf("Name = %q, want %q", entry.Name, "Test Cred")
+	}
+	if entry.Metadata == nil {
+		t.Error("Metadata should not be nil")
+	}
+}
+
+func TestLoadLocalOverrides_Directory(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.json"), testVCTMJSON("urn:test:a", "A"), 0644)
+	os.WriteFile(filepath.Join(dir, "b.json"), testVCTMJSON("urn:test:b", "B"), 0644)
+	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not json"), 0644) // should be skipped
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	if err := LoadLocalOverrides(store, []string{dir}, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.Count() != 2 {
+		t.Errorf("Count = %d, want 2", store.Count())
+	}
+	if _, ok := store.Get("urn:test:a"); !ok {
+		t.Error("entry urn:test:a not found")
+	}
+	if _, ok := store.Get("urn:test:b"); !ok {
+		t.Error("entry urn:test:b not found")
+	}
+}
+
+func TestLoadLocalOverrides_SkipsInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "good.json"), testVCTMJSON("urn:test:good", "Good"), 0644)
+	os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{not valid json"), 0644)
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	// Directory loading skips invalid files with a warning
+	if err := LoadLocalOverrides(store, []string{dir}, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.Count() != 1 {
+		t.Errorf("Count = %d, want 1", store.Count())
+	}
+}
+
+func TestLoadLocalOverrides_MissingVCT(t *testing.T) {
+	dir := t.TempDir()
+	noVCT := []byte(`{"name": "no vct field"}`)
+	os.WriteFile(filepath.Join(dir, "novct.json"), noVCT, 0644)
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	// In directory mode, files without vct are skipped
+	if err := LoadLocalOverrides(store, []string{dir}, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store.Count() != 0 {
+		t.Errorf("Count = %d, want 0", store.Count())
+	}
+}
+
+func TestLoadLocalOverrides_FileError(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "cache.json"))
+	logger := zap.NewNop()
+
+	err := LoadLocalOverrides(store, []string{"/nonexistent/path"}, logger)
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+}
+
+func TestLocalOverrides_SurvivePolling(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "local.json")
+	os.WriteFile(fp, testVCTMJSON("urn:test:local", "Local"), 0644)
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	if err := LoadLocalOverrides(store, []string{fp}, logger); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a remote poll that brings entries including a conflicting VCT
+	remoteEntries := map[string]*VCTMEntry{
+		"urn:test:remote": {
+			VCT:  "urn:test:remote",
+			Name: "Remote Only",
+		},
+		"urn:test:local": {
+			VCT:  "urn:test:local",
+			Name: "Remote Version",
+		},
+	}
+	store.Update(remoteEntries, "https://example.com/registry.json")
+
+	// Local entry should survive and override the remote one
+	entry, ok := store.Get("urn:test:local")
+	if !ok {
+		t.Fatal("local entry lost after Update")
+	}
+	if !entry.IsLocal {
+		t.Error("expected IsLocal=true after Update")
+	}
+	if entry.Name != "Local" {
+		t.Errorf("Name = %q, want %q (local should override remote)", entry.Name, "Local")
+	}
+
+	// Remote-only entry should also be present
+	if _, ok := store.Get("urn:test:remote"); !ok {
+		t.Error("remote entry should be present")
+	}
+}
+
+func TestLoadLocalOverrides_EmptyPaths(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "cache.json"))
+	logger := zap.NewNop()
+
+	if err := LoadLocalOverrides(store, []string{}, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store.Count() != 0 {
+		t.Errorf("Count = %d, want 0", store.Count())
+	}
+}

--- a/internal/registry/local_test.go
+++ b/internal/registry/local_test.go
@@ -51,9 +51,15 @@ func TestLoadLocalOverrides_SingleFile(t *testing.T) {
 
 func TestLoadLocalOverrides_Directory(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "a.json"), testVCTMJSON("urn:test:a", "A"), 0644)
-	os.WriteFile(filepath.Join(dir, "b.json"), testVCTMJSON("urn:test:b", "B"), 0644)
-	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not json"), 0644) // should be skipped
+	if err := os.WriteFile(filepath.Join(dir, "a.json"), testVCTMJSON("urn:test:a", "A"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.json"), testVCTMJSON("urn:test:b", "B"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not json"), 0644); err != nil { // should be skipped
+		t.Fatal(err)
+	}
 
 	store := NewStore(filepath.Join(dir, "cache.json"))
 	logger := zap.NewNop()
@@ -75,8 +81,12 @@ func TestLoadLocalOverrides_Directory(t *testing.T) {
 
 func TestLoadLocalOverrides_SkipsInvalidJSON(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "good.json"), testVCTMJSON("urn:test:good", "Good"), 0644)
-	os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{not valid json"), 0644)
+	if err := os.WriteFile(filepath.Join(dir, "good.json"), testVCTMJSON("urn:test:good", "Good"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{not valid json"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	store := NewStore(filepath.Join(dir, "cache.json"))
 	logger := zap.NewNop()
@@ -94,7 +104,9 @@ func TestLoadLocalOverrides_SkipsInvalidJSON(t *testing.T) {
 func TestLoadLocalOverrides_MissingVCT(t *testing.T) {
 	dir := t.TempDir()
 	noVCT := []byte(`{"name": "no vct field"}`)
-	os.WriteFile(filepath.Join(dir, "novct.json"), noVCT, 0644)
+	if err := os.WriteFile(filepath.Join(dir, "novct.json"), noVCT, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	store := NewStore(filepath.Join(dir, "cache.json"))
 	logger := zap.NewNop()
@@ -121,7 +133,9 @@ func TestLoadLocalOverrides_FileError(t *testing.T) {
 func TestLocalOverrides_SurvivePolling(t *testing.T) {
 	dir := t.TempDir()
 	fp := filepath.Join(dir, "local.json")
-	os.WriteFile(fp, testVCTMJSON("urn:test:local", "Local"), 0644)
+	if err := os.WriteFile(fp, testVCTMJSON("urn:test:local", "Local"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	store := NewStore(filepath.Join(dir, "cache.json"))
 	logger := zap.NewNop()
@@ -170,5 +184,58 @@ func TestLoadLocalOverrides_EmptyPaths(t *testing.T) {
 	}
 	if store.Count() != 0 {
 		t.Errorf("Count = %d, want 0", store.Count())
+	}
+}
+
+func TestClearLocal_RemovesOnlyLocalEntries(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "cache.json"))
+
+	// Add a local entry and a remote entry
+	store.Put(&VCTMEntry{VCT: "urn:test:local", Name: "Local", IsLocal: true})
+	store.Put(&VCTMEntry{VCT: "urn:test:remote", Name: "Remote"})
+	store.Put(&VCTMEntry{VCT: "urn:test:dynamic", Name: "Dynamic", IsDynamic: true})
+
+	if store.Count() != 3 {
+		t.Fatalf("Count = %d, want 3", store.Count())
+	}
+
+	store.ClearLocal()
+
+	if store.Count() != 2 {
+		t.Errorf("Count = %d, want 2 after ClearLocal", store.Count())
+	}
+	if _, ok := store.Get("urn:test:local"); ok {
+		t.Error("local entry should have been removed")
+	}
+	if _, ok := store.Get("urn:test:remote"); !ok {
+		t.Error("remote entry should still be present")
+	}
+	if _, ok := store.Get("urn:test:dynamic"); !ok {
+		t.Error("dynamic entry should still be present")
+	}
+}
+
+func TestLoadLocalOverrides_ExtractsOrganization(t *testing.T) {
+	dir := t.TempDir()
+
+	data := []byte(`{"vct": "urn:test:org", "name": "Org Test", "description": "desc", "organization": "ACME Corp"}`)
+	fp := filepath.Join(dir, "org.json")
+	if err := os.WriteFile(fp, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	if err := LoadLocalOverrides(store, []string{fp}, logger); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, ok := store.Get("urn:test:org")
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.Organization != "ACME Corp" {
+		t.Errorf("Organization = %q, want %q", entry.Organization, "ACME Corp")
 	}
 }

--- a/internal/registry/store.go
+++ b/internal/registry/store.go
@@ -35,6 +35,10 @@ type VCTMEntry struct {
 	// IsDynamic indicates if this entry was fetched on-demand (not from registry)
 	IsDynamic bool `json:"is_dynamic,omitempty"`
 
+	// IsLocal indicates if this entry was loaded from a local file override.
+	// Local entries take priority over remote entries and survive polling cycles.
+	IsLocal bool `json:"is_local,omitempty"`
+
 	// ExpiresAt is when this entry should be considered stale
 	ExpiresAt time.Time `json:"expires_at,omitempty"`
 
@@ -208,15 +212,21 @@ func (s *Store) Delete(vctID string) {
 }
 
 // Update atomically replaces all registry-sourced entries and updates metadata.
-// Dynamically-fetched entries (IsDynamic == true) that are not present in the
-// new set are preserved so that on-demand fetches survive polling cycles.
+// Dynamically-fetched entries (IsDynamic == true) and local file overrides
+// (IsLocal == true) that are not present in the new set are preserved so that
+// on-demand fetches and local overrides survive polling cycles.
+// When a local override exists for the same VCT as a remote entry, the local
+// entry takes priority.
 func (s *Store) Update(entries map[string]*VCTMEntry, sourceURL string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Carry over dynamic entries that are not in the new registry set
+	// Carry over dynamic and local entries.
+	// Local entries always win over remote entries with the same VCT.
 	for id, existing := range s.entries {
-		if existing.IsDynamic {
+		if existing.IsLocal {
+			entries[id] = existing // local overrides remote
+		} else if existing.IsDynamic {
 			if _, overwritten := entries[id]; !overwritten {
 				entries[id] = existing
 			}

--- a/internal/registry/store.go
+++ b/internal/registry/store.go
@@ -211,6 +211,20 @@ func (s *Store) Delete(vctID string) {
 	delete(s.entries, vctID)
 }
 
+// ClearLocal removes all entries with IsLocal=true from the store.
+// This should be called before reloading local overrides so that removed
+// override files don't persist via the cache.
+func (s *Store) ClearLocal() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, entry := range s.entries {
+		if entry.IsLocal {
+			delete(s.entries, id)
+		}
+	}
+}
+
 // Update atomically replaces all registry-sourced entries and updates metadata.
 // Dynamically-fetched entries (IsDynamic == true) and local file overrides
 // (IsLocal == true) that are not present in the new set are preserved so that

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -481,6 +481,13 @@ func NewRegistryProvider(cfg *registry.Config, logger *zap.Logger) (*RegistryPro
 			zap.Time("last_updated", store.LastUpdated()))
 	}
 
+	// Load local VCTM overrides (before remote fetching so they take priority)
+	if len(cfg.Source.LocalOverrides) > 0 {
+		if err := registry.LoadLocalOverrides(store, cfg.Source.LocalOverrides, logger); err != nil {
+			return nil, fmt.Errorf("failed to load local VCTM overrides: %w", err)
+		}
+	}
+
 	// Create centralized HTTP client using config
 	httpClient := cfg.HTTPClient.NewHTTPClient(cfg.Source.Timeout)
 

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -481,8 +481,11 @@ func NewRegistryProvider(cfg *registry.Config, logger *zap.Logger) (*RegistryPro
 			zap.Time("last_updated", store.LastUpdated()))
 	}
 
-	// Load local VCTM overrides (before remote fetching so they take priority)
+	// Load local VCTM overrides (before remote fetching so they take priority).
+	// Clear any stale cached local entries first so removed override files
+	// don't persist through the cache.
 	if len(cfg.Source.LocalOverrides) > 0 {
+		store.ClearLocal()
 		if err := registry.LoadLocalOverrides(store, cfg.Source.LocalOverrides, logger); err != nil {
 			return nil, fmt.Errorf("failed to load local VCTM overrides: %w", err)
 		}


### PR DESCRIPTION
Closes #119

## Summary

Adds the ability to load VCTM entries from local JSON files that take priority over entries fetched from the remote registry.

## Changes

- **config.go**: Add `LocalOverrides []string` to `SourceConfig` (`yaml: local_overrides`, env: `LOCAL_OVERRIDES`)
- **store.go**: Add `IsLocal` flag to `VCTMEntry`; local entries survive polling cycles and override remote entries with the same VCT
- **local.go**: New `LoadLocalOverrides()` function — loads files or directories of `*.json`, extracts `vct` field as key, sets `IsLocal=true`
- **providers.go**: Wire local loading into `RegistryProvider` after cache load but before remote fetching
- **local_test.go**: 7 tests covering file/directory loading, invalid JSON skipping, missing vct, polling survival, and error handling

## Usage

```yaml
registry:
  source:
    url: https://registry.siros.org/.well-known/vctm-registry.json
    local_overrides:
      - /path/to/custom-vctm.json
      - /path/to/vctm-directory/
```

Or via environment variable: `REGISTRY_SOURCE_LOCAL_OVERRIDES=/path/to/file.json,/path/to/dir`