### PR TITLE
refactor: engine vci flow fixing

### DIFF
--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -180,6 +180,10 @@ type FlowStartMessage struct {
 	RequestURIRef      string   `json:"request_uri_ref,omitempty"`      // OID4VP: https://...
 	VCT                string   `json:"vct,omitempty"`                  // VCTM lookup
 	RedirectURI        string   `json:"redirect_uri,omitempty"`         // OAuth redirect URI for authorization code flow
+
+	// Resumption fields (same-tab redirect flow)
+	AuthCode     string `json:"auth_code,omitempty"`     // Authorization code from OAuth redirect
+	CodeVerifier string `json:"code_verifier,omitempty"` // PKCE code verifier (saved by client before redirect)
 }
 
 // FlowProgressMessage reports flow progress to client
@@ -210,9 +214,11 @@ const (
 // FlowCompleteMessage indicates successful flow completion
 type FlowCompleteMessage struct {
 	Message
-	Credentials  []CredentialResult `json:"credentials,omitempty"`
-	RedirectURI  string             `json:"redirect_uri,omitempty"`
-	TypeMetadata json.RawMessage    `json:"type_metadata,omitempty"`
+	Credentials                       []CredentialResult `json:"credentials,omitempty"`
+	RedirectURI                       string             `json:"redirect_uri,omitempty"`
+	TypeMetadata                      json.RawMessage    `json:"type_metadata,omitempty"`
+	CredentialIssuer                  string             `json:"credential_issuer,omitempty"`
+	SelectedCredentialConfigurationID string             `json:"selected_credential_configuration_id,omitempty"`
 }
 
 // FlowErrorMessage indicates a flow error

--- a/internal/engine/messages_test.go
+++ b/internal/engine/messages_test.go
@@ -993,3 +993,146 @@ func TestMatchErrorCodeUserFacingMessage(t *testing.T) {
 		})
 	}
 }
+
+// ===== FlowCompleteMessage serialization tests =====
+
+func TestFlowCompleteMessage_IncludesIssuerFields(t *testing.T) {
+	msg := FlowCompleteMessage{
+		Message: Message{
+			Type:      TypeFlowComplete,
+			FlowID:    "flow-123",
+			Timestamp: "2024-01-01T00:00:00Z",
+		},
+		Credentials: []CredentialResult{
+			{Format: "dc+sd-jwt", Credential: "eyJ..."},
+		},
+		CredentialIssuer:                  "https://issuer.example.com",
+		SelectedCredentialConfigurationID: "UniversityDegree",
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if parsed["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("credential_issuer = %v, want https://issuer.example.com", parsed["credential_issuer"])
+	}
+	if parsed["selected_credential_configuration_id"] != "UniversityDegree" {
+		t.Errorf("selected_credential_configuration_id = %v, want UniversityDegree", parsed["selected_credential_configuration_id"])
+	}
+}
+
+func TestFlowCompleteMessage_OmitsEmptyIssuerFields(t *testing.T) {
+	msg := FlowCompleteMessage{
+		Message: Message{
+			Type:      TypeFlowComplete,
+			FlowID:    "flow-456",
+			Timestamp: "2024-01-01T00:00:00Z",
+		},
+		// CredentialIssuer and SelectedCredentialConfigurationID left empty
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	if strings.Contains(string(data), "credential_issuer") {
+		t.Error("empty credential_issuer should be omitted (omitempty)")
+	}
+	if strings.Contains(string(data), "selected_credential_configuration_id") {
+		t.Error("empty selected_credential_configuration_id should be omitted (omitempty)")
+	}
+}
+
+func TestFlowCompleteMessage_Roundtrip(t *testing.T) {
+	original := FlowCompleteMessage{
+		Message: Message{
+			Type:      TypeFlowComplete,
+			FlowID:    "flow-rt",
+			Timestamp: Now(),
+		},
+		Credentials: []CredentialResult{
+			{Format: "dc+sd-jwt", Credential: "eyJ...abc"},
+		},
+		CredentialIssuer:                  "https://issuer.example.com",
+		SelectedCredentialConfigurationID: "PID_SD_JWT",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded FlowCompleteMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded.CredentialIssuer != original.CredentialIssuer {
+		t.Errorf("CredentialIssuer = %q, want %q", decoded.CredentialIssuer, original.CredentialIssuer)
+	}
+	if decoded.SelectedCredentialConfigurationID != original.SelectedCredentialConfigurationID {
+		t.Errorf("SelectedCredentialConfigurationID = %q, want %q", decoded.SelectedCredentialConfigurationID, original.SelectedCredentialConfigurationID)
+	}
+	if len(decoded.Credentials) != 1 {
+		t.Fatalf("Credentials length = %d, want 1", len(decoded.Credentials))
+	}
+}
+
+// ===== FlowStartMessage new fields tests =====
+
+func TestFlowStartMessage_AuthCodeFields(t *testing.T) {
+	raw := `{
+		"type": "flow_start",
+		"flow_id": "resume-flow",
+		"protocol": "oid4vci",
+		"auth_code": "SplxlOBeZQQYbYS6WxSbIA",
+		"code_verifier": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+		"redirect_uri": "https://wallet.example.com/cb"
+	}`
+
+	var msg FlowStartMessage
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if msg.AuthCode != "SplxlOBeZQQYbYS6WxSbIA" {
+		t.Errorf("AuthCode = %q, want SplxlOBeZQQYbYS6WxSbIA", msg.AuthCode)
+	}
+	if msg.CodeVerifier != "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk" {
+		t.Errorf("CodeVerifier = %q, want dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk", msg.CodeVerifier)
+	}
+	if msg.RedirectURI != "https://wallet.example.com/cb" {
+		t.Errorf("RedirectURI = %q, want https://wallet.example.com/cb", msg.RedirectURI)
+	}
+}
+
+func TestFlowStartMessage_AuthCodeFieldsOmitEmpty(t *testing.T) {
+	msg := FlowStartMessage{
+		Message: Message{
+			Type:   TypeFlowStart,
+			FlowID: "normal-flow",
+		},
+		Protocol: "oid4vci",
+		// AuthCode and CodeVerifier left empty
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	if strings.Contains(string(data), "auth_code") {
+		t.Error("empty auth_code should be omitted (omitempty)")
+	}
+	if strings.Contains(string(data), "code_verifier") {
+		t.Error("empty code_verifier should be omitted (omitempty)")
+	}
+}

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -392,6 +392,7 @@ func (h *OID4VCIHandler) Execute(ctx context.Context, msg *FlowStartMessage) err
 		return err
 	}
 	h.SetData("offer", offer)
+	h.SetData("credential_issuer", offer.CredentialIssuer)
 
 	// Step 2: Fetch issuer metadata
 	metadata, err := h.fetchMetadata(ctx, offer.CredentialIssuer)
@@ -416,6 +417,7 @@ func (h *OID4VCIHandler) Execute(ctx context.Context, msg *FlowStartMessage) err
 		return err
 	}
 	h.SetData("selected_config", selectedConfig)
+	h.SetData("selected_credential_configuration_id", selectedConfigID)
 
 	// Generate ephemeral DPoP key pair (RFC 9449)
 	h.dpopKey, err = generateDPoPKey()
@@ -425,8 +427,15 @@ func (h *OID4VCIHandler) Execute(ctx context.Context, msg *FlowStartMessage) err
 		return err
 	}
 
-	// Step 5: Handle authorization
-	token, err := h.handleAuthorization(ctx, offer, metadata, selectedConfig)
+	// Step 5: Handle authorization (or resume with provided auth code)
+	var token *TokenResponse
+	if msg.AuthCode != "" {
+		// Resumption: client already completed OAuth and returned with auth code
+		token, err = h.resumeWithAuthCode(ctx, msg, metadata)
+	} else {
+		// Normal flow: handle authorization (pre-auth or auth code grant)
+		token, err = h.handleAuthorization(ctx, offer, metadata, selectedConfig)
+	}
 	if err != nil {
 		return err
 	}
@@ -887,12 +896,22 @@ func (h *OID4VCIHandler) handleAuthorization(ctx context.Context, offer *Credent
 func (h *OID4VCIHandler) handlePreAuthorized(ctx context.Context, metadata *IssuerMetadata, grant map[string]interface{}) (*TokenResponse, error) {
 	preAuthCode, _ := grant["pre-authorized_code"].(string)
 
+	// Fetch OAuth metadata to get token endpoint if not in issuer metadata
+	if metadata.TokenEndpoint == "" {
+		if oauthMeta := h.fetchOAuthMetadata(ctx, metadata); oauthMeta != nil && oauthMeta.TokenEndpoint != "" {
+			metadata.TokenEndpoint = oauthMeta.TokenEndpoint
+		}
+	}
+
 	// Check if TX code required
 	if txCodeRequired, ok := grant["tx_code"]; ok && txCodeRequired != nil {
 		// Request TX code from user
 		_ = h.Progress(StepAuthorizationReq, map[string]interface{}{
-			"type":    "tx_code",
-			"message": "Please enter the transaction code",
+			"type":                "tx_code",
+			"pre_authorized_code": preAuthCode,
+			"tx_code":             txCodeRequired,
+			"credential_issuer":   metadata.CredentialIssuer,
+			"message":             "Please enter the transaction code",
 		})
 
 		action, err := h.WaitForAction(ctx, ActionProvidePin)
@@ -975,42 +994,52 @@ func (h *OID4VCIHandler) exchangePreAuthCode(ctx context.Context, metadata *Issu
 	return nil, errors.New("token request failed after DPoP nonce retry")
 }
 
-func (h *OID4VCIHandler) handleAuthorizationCode(ctx context.Context, offer *CredentialOffer, metadata *IssuerMetadata, selectedConfig *CredentialConfig) (*TokenResponse, error) {
-	// Build authorization URL
+// fetchOAuthMetadata fetches OAuth Authorization Server metadata from the well-known endpoint.
+// Returns nil (not an error) if the metadata cannot be fetched, allowing callers to use fallbacks.
+func (h *OID4VCIHandler) fetchOAuthMetadata(ctx context.Context, metadata *IssuerMetadata) *oauthServerMetadata {
 	authServer := metadata.AuthorizationServer
 	if authServer == "" {
 		authServer = metadata.CredentialIssuer
 	}
 
-	// Fetch OAuth metadata
 	oauthMetadataURL := strings.TrimSuffix(authServer, "/") + "/.well-known/oauth-authorization-server"
-
 	req, err := http.NewRequestWithContext(ctx, "GET", oauthMetadataURL, nil)
 	if err != nil {
-		return nil, err
+		return nil
 	}
-
-	fallbackEndpoint := strings.TrimSuffix(authServer, "/") + "/authorize"
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	var oauthMeta oauthServerMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&oauthMeta); err != nil {
+		return nil
+	}
+	return &oauthMeta
+}
+
+func (h *OID4VCIHandler) handleAuthorizationCode(ctx context.Context, offer *CredentialOffer, metadata *IssuerMetadata, selectedConfig *CredentialConfig) (*TokenResponse, error) {
+	authServer := metadata.AuthorizationServer
+	if authServer == "" {
+		authServer = metadata.CredentialIssuer
+	}
+	fallbackEndpoint := strings.TrimSuffix(authServer, "/") + "/authorize"
+
+	oauthMeta := h.fetchOAuthMetadata(ctx, metadata)
+	if oauthMeta == nil || oauthMeta.AuthorizationEndpoint == "" {
 		// Fallback: construct auth URL directly, no PAR
 		return h.startAuthorizationFlow(ctx, offer, metadata, selectedConfig, &oauthServerMetadata{
 			AuthorizationEndpoint: fallbackEndpoint,
 		})
 	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	if resp.StatusCode == http.StatusOK {
-		var oauthMeta oauthServerMetadata
-		if err := json.NewDecoder(resp.Body).Decode(&oauthMeta); err == nil && oauthMeta.AuthorizationEndpoint != "" {
-			return h.startAuthorizationFlow(ctx, offer, metadata, selectedConfig, &oauthMeta)
-		}
-	}
-
-	return h.startAuthorizationFlow(ctx, offer, metadata, selectedConfig, &oauthServerMetadata{
-		AuthorizationEndpoint: fallbackEndpoint,
-	})
+	return h.startAuthorizationFlow(ctx, offer, metadata, selectedConfig, oauthMeta)
 }
 
 func (h *OID4VCIHandler) startAuthorizationFlow(ctx context.Context, offer *CredentialOffer, metadata *IssuerMetadata, selectedConfig *CredentialConfig, oauthMeta *oauthServerMetadata) (*TokenResponse, error) {
@@ -1105,10 +1134,12 @@ func (h *OID4VCIHandler) startAuthorizationFlow(ctx context.Context, offer *Cred
 
 	// Send authorization URL and PKCE code_verifier to the client.
 	// The client stores code_verifier for flow resume after redirect (option A).
+	// Include the parsed credential offer so client can resume with a stateless backend.
 	progressData := map[string]interface{}{
 		"authorization_url":     authURL,
 		"expected_redirect_uri": redirectURI,
 		"state":                 oauthState,
+		"credential_offer":      offer,
 	}
 	if pkceEnabled {
 		progressData["code_verifier"] = codeVerifier
@@ -1258,6 +1289,32 @@ func (h *OID4VCIHandler) exchangeAuthCode(ctx context.Context, metadata *IssuerM
 	return nil, errors.New("token request failed after DPoP nonce retry")
 }
 
+// resumeWithAuthCode handles flow resumption after same-tab redirect.
+// The client has saved the credential offer and code_verifier, redirected to the AS,
+// and returned with an authorization code. This function skips authorization URL
+// generation and directly exchanges the auth code for a token.
+func (h *OID4VCIHandler) resumeWithAuthCode(ctx context.Context, msg *FlowStartMessage, metadata *IssuerMetadata) (*TokenResponse, error) {
+	h.Logger.Info("Resuming OID4VCI flow with authorization code")
+	_ = h.ProgressMessage(StepAuthorizationReq, "Resuming flow with authorization code")
+
+	// Fetch OAuth metadata to get token endpoint if not in issuer metadata
+	if metadata.TokenEndpoint == "" {
+		if oauthMeta := h.fetchOAuthMetadata(ctx, metadata); oauthMeta != nil && oauthMeta.TokenEndpoint != "" {
+			metadata.TokenEndpoint = oauthMeta.TokenEndpoint
+		}
+	}
+
+	// Use redirect URI from message
+	redirectURI := msg.RedirectURI
+	if redirectURI == "" {
+		_ = h.Error(StepAuthorizationReq, ErrCodeAuthorizationFail, "redirect_uri is required for flow resumption")
+		return nil, errors.New("redirect_uri is required for flow resumption")
+	}
+
+	// Exchange authorization code using provided code_verifier
+	return h.exchangeAuthCode(ctx, metadata, msg.AuthCode, redirectURI, msg.CodeVerifier)
+}
+
 // CNonceRequiredError is returned by requestCredential when the credential
 // endpoint responds with an error that includes a refreshed c_nonce. The
 // engine should re-request all proofs from the frontend using the new nonce
@@ -1395,6 +1452,7 @@ func (h *OID4VCIHandler) requestCredential(ctx context.Context, metadata *Issuer
 				return nil, fmt.Errorf("failed to build encryption JWK: %w", err)
 			}
 			encJWK["use"] = "enc"
+			encJWK["alg"] = selectedAlg
 			reqBody["credential_response_encryption"] = map[string]interface{}{
 				"alg": selectedAlg,
 				"enc": selectedEnc,

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -430,7 +430,12 @@ func (h *OID4VCIHandler) Execute(ctx context.Context, msg *FlowStartMessage) err
 	// Step 5: Handle authorization (or resume with provided auth code)
 	var token *TokenResponse
 	if msg.AuthCode != "" {
-		// Resumption: client already completed OAuth and returned with auth code
+		// Resumption: client already completed OAuth and returned with auth code.
+		// Verify the offer actually supports the authorization_code grant.
+		if _, ok := offer.Grants["authorization_code"]; !ok {
+			_ = h.Error(StepAuthorizationReq, ErrCodeAuthorizationFail, "credential offer does not support authorization_code grant")
+			return errors.New("cannot resume with auth code: credential offer does not support authorization_code grant")
+		}
 		token, err = h.resumeWithAuthCode(ctx, msg, metadata)
 	} else {
 		// Normal flow: handle authorization (pre-auth or auth code grant)
@@ -905,14 +910,19 @@ func (h *OID4VCIHandler) handlePreAuthorized(ctx context.Context, metadata *Issu
 
 	// Check if TX code required
 	if txCodeRequired, ok := grant["tx_code"]; ok && txCodeRequired != nil {
-		// Request TX code from user
-		_ = h.Progress(StepAuthorizationReq, map[string]interface{}{
+		// Use issuer-provided description from tx_code spec (OID4VCI §4.1.1)
+		progressPayload := map[string]interface{}{
 			"type":                "tx_code",
 			"pre_authorized_code": preAuthCode,
 			"tx_code":             txCodeRequired,
 			"credential_issuer":   metadata.CredentialIssuer,
-			"message":             "Please enter the transaction code",
-		})
+		}
+		if txMap, ok := txCodeRequired.(map[string]interface{}); ok {
+			if desc, ok := txMap["description"].(string); ok && desc != "" {
+				progressPayload["message"] = desc
+			}
+		}
+		_ = h.Progress(StepAuthorizationReq, progressPayload)
 
 		action, err := h.WaitForAction(ctx, ActionProvidePin)
 		if err != nil {
@@ -1297,11 +1307,20 @@ func (h *OID4VCIHandler) resumeWithAuthCode(ctx context.Context, msg *FlowStartM
 	h.Logger.Info("Resuming OID4VCI flow with authorization code")
 	_ = h.ProgressMessage(StepAuthorizationReq, "Resuming flow with authorization code")
 
-	// Fetch OAuth metadata to get token endpoint if not in issuer metadata
-	if metadata.TokenEndpoint == "" {
-		if oauthMeta := h.fetchOAuthMetadata(ctx, metadata); oauthMeta != nil && oauthMeta.TokenEndpoint != "" {
-			metadata.TokenEndpoint = oauthMeta.TokenEndpoint
-		}
+	// Fetch OAuth metadata to get token endpoint and check PKCE requirements
+	oauthMeta := h.fetchOAuthMetadata(ctx, metadata)
+	if oauthMeta != nil && oauthMeta.TokenEndpoint != "" && metadata.TokenEndpoint == "" {
+		metadata.TokenEndpoint = oauthMeta.TokenEndpoint
+	}
+
+	// Validate code_verifier: PKCE defaults to enabled (OID4VCI spec), so if the
+	// AS requires it the token exchange will fail without a verifier. Catch this
+	// early with a clear error rather than an opaque OAuth error from the AS.
+	pkceRequired := oauthMeta == nil || oauthMeta.supportsPKCE()
+	codeVerifier := strings.TrimSpace(msg.CodeVerifier)
+	if pkceRequired && codeVerifier == "" {
+		_ = h.Error(StepAuthorizationReq, ErrCodeAuthorizationFail, "code_verifier is required for flow resumption")
+		return nil, errors.New("code_verifier is required for flow resumption")
 	}
 
 	// Use redirect URI from message
@@ -1312,7 +1331,7 @@ func (h *OID4VCIHandler) resumeWithAuthCode(ctx context.Context, msg *FlowStartM
 	}
 
 	// Exchange authorization code using provided code_verifier
-	return h.exchangeAuthCode(ctx, metadata, msg.AuthCode, redirectURI, msg.CodeVerifier)
+	return h.exchangeAuthCode(ctx, metadata, msg.AuthCode, redirectURI, codeVerifier)
 }
 
 // CNonceRequiredError is returned by requestCredential when the credential

--- a/internal/engine/oid4vci_test.go
+++ b/internal/engine/oid4vci_test.go
@@ -1945,3 +1945,287 @@ func TestSignResponseMessage_ProofsField(t *testing.T) {
 	assert.Equal(t, "attestation", decoded.Proofs[1].ProofType)
 	assert.Equal(t, "attest-xyz", decoded.Proofs[1].Attestation)
 }
+
+// ===== fetchOAuthMetadata tests =====
+
+func TestFetchOAuthMetadata_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/.well-known/oauth-authorization-server")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"authorization_endpoint":                "https://as.example.com/authorize",
+			"token_endpoint":                        "https://as.example.com/token",
+			"pushed_authorization_request_endpoint":  "https://as.example.com/par",
+		})
+	}))
+	defer server.Close()
+
+	h := &OID4VCIHandler{httpClient: server.Client()}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+
+	meta := h.fetchOAuthMetadata(context.Background(), &IssuerMetadata{
+		CredentialIssuer: server.URL,
+	})
+	require.NotNil(t, meta)
+	assert.Equal(t, "https://as.example.com/authorize", meta.AuthorizationEndpoint)
+	assert.Equal(t, "https://as.example.com/token", meta.TokenEndpoint)
+	assert.Equal(t, "https://as.example.com/par", meta.PushedAuthorizationRequestEndpoint)
+}
+
+func TestFetchOAuthMetadata_UsesAuthorizationServer(t *testing.T) {
+	var requestedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedURL = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"authorization_endpoint": "https://as.example.com/authorize",
+			"token_endpoint":         "https://as.example.com/token",
+		})
+	}))
+	defer server.Close()
+
+	h := &OID4VCIHandler{httpClient: server.Client()}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+
+	meta := h.fetchOAuthMetadata(context.Background(), &IssuerMetadata{
+		CredentialIssuer:    "https://issuer.example.com",
+		AuthorizationServer: server.URL,
+	})
+	require.NotNil(t, meta)
+	assert.Equal(t, "/.well-known/oauth-authorization-server", requestedURL)
+}
+
+func TestFetchOAuthMetadata_FallbackToCredentialIssuer(t *testing.T) {
+	var requestedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedURL = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token_endpoint": "https://issuer.example.com/token",
+		})
+	}))
+	defer server.Close()
+
+	h := &OID4VCIHandler{httpClient: server.Client()}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+
+	meta := h.fetchOAuthMetadata(context.Background(), &IssuerMetadata{
+		CredentialIssuer: server.URL,
+		// AuthorizationServer intentionally empty
+	})
+	require.NotNil(t, meta)
+	assert.Equal(t, "/.well-known/oauth-authorization-server", requestedURL)
+}
+
+func TestFetchOAuthMetadata_404ReturnsNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	h := &OID4VCIHandler{httpClient: server.Client()}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+
+	meta := h.fetchOAuthMetadata(context.Background(), &IssuerMetadata{
+		CredentialIssuer: server.URL,
+	})
+	assert.Nil(t, meta)
+}
+
+func TestFetchOAuthMetadata_NetworkErrorReturnsNil(t *testing.T) {
+	h := &OID4VCIHandler{
+		httpClient: &http.Client{Transport: &errRoundTripper{}},
+	}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+
+	meta := h.fetchOAuthMetadata(context.Background(), &IssuerMetadata{
+		CredentialIssuer: "https://unreachable.example.com",
+	})
+	assert.Nil(t, meta)
+}
+
+func TestFetchOAuthMetadata_MalformedJSONReturnsNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{not valid json`))
+	}))
+	defer server.Close()
+
+	h := &OID4VCIHandler{httpClient: server.Client()}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+
+	meta := h.fetchOAuthMetadata(context.Background(), &IssuerMetadata{
+		CredentialIssuer: server.URL,
+	})
+	assert.Nil(t, meta)
+}
+
+// ===== resumeWithAuthCode tests =====
+
+func TestResumeWithAuthCode_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+		require.NoError(t, err)
+		assert.Equal(t, "authorization_code", r.FormValue("grant_type"))
+		assert.Equal(t, "test-auth-code", r.FormValue("code"))
+		assert.Equal(t, "test-verifier", r.FormValue("code_verifier"))
+		assert.Equal(t, "https://wallet.example.com/cb", r.FormValue("redirect_uri"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: "resumed-access-token",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+			CNonce:      "resumed-nonce",
+		})
+	}))
+	defer tokenServer.Close()
+
+	h, cleanup := testOID4VCIHandler(t, tokenServer.Client())
+	defer cleanup()
+
+	metadata := &IssuerMetadata{
+		CredentialIssuer: "https://issuer.example.com",
+		TokenEndpoint:    tokenServer.URL,
+	}
+	msg := &FlowStartMessage{
+		AuthCode:     "test-auth-code",
+		CodeVerifier: "test-verifier",
+		RedirectURI:  "https://wallet.example.com/cb",
+	}
+
+	token, err := h.resumeWithAuthCode(context.Background(), msg, metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "resumed-access-token", token.AccessToken)
+	assert.Equal(t, "resumed-nonce", token.CNonce)
+}
+
+func TestResumeWithAuthCode_MissingRedirectURI(t *testing.T) {
+	h, cleanup := testOID4VCIHandler(t, http.DefaultClient)
+	defer cleanup()
+
+	metadata := &IssuerMetadata{
+		CredentialIssuer: "https://issuer.example.com",
+		TokenEndpoint:    "https://issuer.example.com/token",
+	}
+	msg := &FlowStartMessage{
+		AuthCode:     "test-auth-code",
+		CodeVerifier: "test-verifier",
+		// RedirectURI intentionally empty
+	}
+
+	_, err := h.resumeWithAuthCode(context.Background(), msg, metadata)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "redirect_uri is required")
+}
+
+func TestResumeWithAuthCode_FetchesTokenEndpointFromOAuthMetadata(t *testing.T) {
+	// OAuth metadata server returns token endpoint
+	var tokenRequested bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// The token_endpoint will be set dynamically after server starts
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token_endpoint": "http://" + r.Host + "/token",
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		tokenRequested = true
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: "discovered-token",
+			TokenType:   "Bearer",
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	h, cleanup := testOID4VCIHandler(t, server.Client())
+	defer cleanup()
+
+	metadata := &IssuerMetadata{
+		CredentialIssuer: server.URL,
+		// TokenEndpoint intentionally empty — should be discovered
+	}
+	msg := &FlowStartMessage{
+		AuthCode:     "test-code",
+		CodeVerifier: "test-verifier",
+		RedirectURI:  "https://wallet.example.com/cb",
+	}
+
+	token, err := h.resumeWithAuthCode(context.Background(), msg, metadata)
+	require.NoError(t, err)
+	assert.True(t, tokenRequested, "token endpoint should have been called")
+	assert.Equal(t, "discovered-token", token.AccessToken)
+}
+
+// ===== handleAuthorization grants fallback tests =====
+
+func TestHandleAuthorization_NoGrantsFallsThrough(t *testing.T) {
+	// When offer.Grants is empty, handleAuthorization should return an error
+	// (current behavior — grants fallback not yet implemented)
+	h, cleanup := testOID4VCIHandler(t, http.DefaultClient)
+	defer cleanup()
+
+	offer := &CredentialOffer{
+		CredentialIssuer:           "https://issuer.example.com",
+		CredentialConfigurationIDs: []string{"test-config"},
+		Grants:                     map[string]interface{}{}, // empty
+	}
+	metadata := &IssuerMetadata{
+		CredentialIssuer: "https://issuer.example.com",
+	}
+	config := &CredentialConfig{}
+
+	_, err := h.handleAuthorization(context.Background(), offer, metadata, config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no supported grant type")
+}
+
+func TestHandleAuthorization_NilGrantsFallsThrough(t *testing.T) {
+	h, cleanup := testOID4VCIHandler(t, http.DefaultClient)
+	defer cleanup()
+
+	offer := &CredentialOffer{
+		CredentialIssuer:           "https://issuer.example.com",
+		CredentialConfigurationIDs: []string{"test-config"},
+		Grants:                     nil, // nil
+	}
+	metadata := &IssuerMetadata{
+		CredentialIssuer: "https://issuer.example.com",
+	}
+	config := &CredentialConfig{}
+
+	_, err := h.handleAuthorization(context.Background(), offer, metadata, config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no supported grant type")
+}
+
+func TestHandleAuthorization_PreAuthGrantSelected(t *testing.T) {
+	// Verify pre-auth grant path is selected when present (even though
+	// the flow will fail without a real token endpoint, we verify dispatch)
+	h, cleanup := testOID4VCIHandler(t, &http.Client{Transport: &errRoundTripper{}})
+	defer cleanup()
+
+	offer := &CredentialOffer{
+		CredentialIssuer:           "https://issuer.example.com",
+		CredentialConfigurationIDs: []string{"test-config"},
+		Grants: map[string]interface{}{
+			"urn:ietf:params:oauth:grant-type:pre-authorized_code": map[string]interface{}{
+				"pre-authorized_code": "pre-auth-123",
+			},
+		},
+	}
+	metadata := &IssuerMetadata{
+		CredentialIssuer: "https://issuer.example.com",
+		TokenEndpoint:    "https://issuer.example.com/token",
+	}
+	config := &CredentialConfig{}
+
+	// Will fail at token exchange (network error), but proves the pre-auth path was taken
+	_, err := h.handleAuthorization(context.Background(), offer, metadata, config)
+	require.Error(t, err)
+	// Should NOT be "no supported grant type" — the pre-auth path was dispatched
+	assert.NotContains(t, err.Error(), "no supported grant type")
+}

--- a/internal/engine/oid4vci_test.go
+++ b/internal/engine/oid4vci_test.go
@@ -1955,7 +1955,7 @@ func TestFetchOAuthMetadata_Success(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"authorization_endpoint":                "https://as.example.com/authorize",
 			"token_endpoint":                        "https://as.example.com/token",
-			"pushed_authorization_request_endpoint":  "https://as.example.com/par",
+			"pushed_authorization_request_endpoint": "https://as.example.com/par",
 		})
 	}))
 	defer server.Close()
@@ -2160,6 +2160,66 @@ func TestResumeWithAuthCode_FetchesTokenEndpointFromOAuthMetadata(t *testing.T) 
 	assert.Equal(t, "discovered-token", token.AccessToken)
 }
 
+func TestResumeWithAuthCode_MissingCodeVerifier(t *testing.T) {
+	// When OAuth metadata is unreachable, PKCE defaults to required.
+	// An empty code_verifier should produce a clear error.
+	h, cleanup := testOID4VCIHandler(t, http.DefaultClient)
+	defer cleanup()
+
+	metadata := &IssuerMetadata{
+		CredentialIssuer: "https://issuer.example.com",
+		TokenEndpoint:    "https://issuer.example.com/token",
+	}
+	msg := &FlowStartMessage{
+		AuthCode:    "test-auth-code",
+		RedirectURI: "https://wallet.example.com/cb",
+		// CodeVerifier intentionally empty
+	}
+
+	_, err := h.resumeWithAuthCode(context.Background(), msg, metadata)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "code_verifier is required")
+}
+
+func TestResumeWithAuthCode_PKCENotRequired(t *testing.T) {
+	// When AS explicitly declares empty code_challenge_methods_supported,
+	// PKCE is not required and an empty code_verifier should be allowed.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Explicitly declare empty list → PKCE not supported
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token_endpoint":                   "http://" + r.Host + "/token",
+			"code_challenge_methods_supported": []string{},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: "no-pkce-token",
+			TokenType:   "Bearer",
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	h, cleanup := testOID4VCIHandler(t, server.Client())
+	defer cleanup()
+
+	metadata := &IssuerMetadata{
+		CredentialIssuer: server.URL,
+	}
+	msg := &FlowStartMessage{
+		AuthCode:    "test-auth-code",
+		RedirectURI: "https://wallet.example.com/cb",
+		// CodeVerifier intentionally empty — PKCE not required
+	}
+
+	token, err := h.resumeWithAuthCode(context.Background(), msg, metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "no-pkce-token", token.AccessToken)
+}
+
 // ===== handleAuthorization grants fallback tests =====
 
 func TestHandleAuthorization_NoGrantsFallsThrough(t *testing.T) {
@@ -2228,4 +2288,66 @@ func TestHandleAuthorization_PreAuthGrantSelected(t *testing.T) {
 	require.Error(t, err)
 	// Should NOT be "no supported grant type" — the pre-auth path was dispatched
 	assert.NotContains(t, err.Error(), "no supported grant type")
+}
+
+// ===== tx_code description extraction tests =====
+
+func TestTxCodeDescriptionExtraction(t *testing.T) {
+	// Verify that the tx_code description field is correctly extracted
+	// from the grant's tx_code spec object (OID4VCI §4.1.1).
+	tests := []struct {
+		name        string
+		txCode      interface{}
+		wantDesc    string
+		wantHasDesc bool
+	}{
+		{
+			name: "description present",
+			txCode: map[string]interface{}{
+				"input_mode":  "numeric",
+				"length":      6,
+				"description": "Enter the code from your email",
+			},
+			wantDesc:    "Enter the code from your email",
+			wantHasDesc: true,
+		},
+		{
+			name: "description absent",
+			txCode: map[string]interface{}{
+				"input_mode": "numeric",
+				"length":     6,
+			},
+			wantDesc:    "",
+			wantHasDesc: false,
+		},
+		{
+			name: "description empty string",
+			txCode: map[string]interface{}{
+				"description": "",
+			},
+			wantDesc:    "",
+			wantHasDesc: false,
+		},
+		{
+			name:        "tx_code not a map",
+			txCode:      true,
+			wantDesc:    "",
+			wantHasDesc: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc := ""
+			hasDesc := false
+			if txMap, ok := tt.txCode.(map[string]interface{}); ok {
+				if d, ok := txMap["description"].(string); ok && d != "" {
+					desc = d
+					hasDesc = true
+				}
+			}
+			assert.Equal(t, tt.wantDesc, desc)
+			assert.Equal(t, tt.wantHasDesc, hasDesc)
+		})
+	}
 }

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -600,6 +600,10 @@ func (s *Session) SendProgress(flowID string, step FlowStep, payload interface{}
 
 // SendFlowComplete sends a flow completion message
 func (s *Session) SendFlowComplete(flowID string, credentials []CredentialResult, redirectURI string) error {
+	s.flowsMu.RLock()
+	flow := s.flows[flowID]
+	s.flowsMu.RUnlock()
+
 	msg := FlowCompleteMessage{
 		Message: Message{
 			Type:      TypeFlowComplete,
@@ -608,6 +612,16 @@ func (s *Session) SendFlowComplete(flowID string, credentials []CredentialResult
 		},
 		Credentials: credentials,
 		RedirectURI: redirectURI,
+	}
+	if flow != nil {
+		flow.mu.RLock()
+		if v, ok := flow.Data["credential_issuer"]; ok {
+			msg.CredentialIssuer, _ = v.(string)
+		}
+		if v, ok := flow.Data["selected_credential_configuration_id"]; ok {
+			msg.SelectedCredentialConfigurationID, _ = v.(string)
+		}
+		flow.mu.RUnlock()
 	}
 	return s.Send(&msg)
 }

--- a/internal/engine/session_test.go
+++ b/internal/engine/session_test.go
@@ -1,10 +1,12 @@
 package engine
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -163,4 +165,127 @@ func TestManager_validateToken_WrongSecret(t *testing.T) {
 
 	_, _, err = m.validateToken(tokenString)
 	assert.Error(t, err)
+}
+
+// ===== SendFlowComplete tests =====
+
+func TestSendFlowComplete_IncludesDataMapFields(t *testing.T) {
+	// Server side: read the flow_complete message and verify it has issuer fields
+	conn, cleanup := wsTestServer(t, func(srvConn *websocket.Conn) {
+		defer srvConn.Close()
+		_, data, err := srvConn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var msg map[string]interface{}
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return
+		}
+		// Write the parsed message back so the test client can read it
+		_ = srvConn.WriteJSON(msg)
+	})
+	defer cleanup()
+
+	session := testSession(conn)
+	flow := &Flow{
+		ID:      "test-flow-complete",
+		Session: session,
+		Data:    make(map[string]interface{}),
+	}
+	flow.Data["credential_issuer"] = "https://issuer.example.com"
+	flow.Data["selected_credential_configuration_id"] = "PID_SD_JWT"
+
+	session.flowsMu.Lock()
+	session.flows["test-flow-complete"] = flow
+	session.flowsMu.Unlock()
+
+	credentials := []CredentialResult{
+		{Format: "dc+sd-jwt", Credential: "eyJ..."},
+	}
+
+	err := session.SendFlowComplete("test-flow-complete", credentials, "")
+	require.NoError(t, err)
+
+	// Read the echoed message from server
+	var received map[string]interface{}
+	err = conn.ReadJSON(&received)
+	require.NoError(t, err)
+
+	assert.Equal(t, "flow_complete", received["type"])
+	assert.Equal(t, "test-flow-complete", received["flow_id"])
+	assert.Equal(t, "https://issuer.example.com", received["credential_issuer"])
+	assert.Equal(t, "PID_SD_JWT", received["selected_credential_configuration_id"])
+}
+
+func TestSendFlowComplete_NoFlowOmitsIssuerFields(t *testing.T) {
+	conn, cleanup := wsTestServer(t, func(srvConn *websocket.Conn) {
+		defer srvConn.Close()
+		_, data, err := srvConn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var msg map[string]interface{}
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return
+		}
+		_ = srvConn.WriteJSON(msg)
+	})
+	defer cleanup()
+
+	session := testSession(conn)
+	// No flow registered for this ID
+
+	err := session.SendFlowComplete("nonexistent-flow", nil, "https://redirect.example.com")
+	require.NoError(t, err)
+
+	var received map[string]interface{}
+	err = conn.ReadJSON(&received)
+	require.NoError(t, err)
+
+	assert.Equal(t, "flow_complete", received["type"])
+	assert.Equal(t, "https://redirect.example.com", received["redirect_uri"])
+	// Issuer fields should not be present (no flow, so no Data map)
+	_, hasIssuer := received["credential_issuer"]
+	_, hasConfig := received["selected_credential_configuration_id"]
+	assert.False(t, hasIssuer, "credential_issuer should not be present when flow is nil")
+	assert.False(t, hasConfig, "selected_credential_configuration_id should not be present when flow is nil")
+}
+
+func TestSendFlowComplete_EmptyDataMapOmitsIssuerFields(t *testing.T) {
+	conn, cleanup := wsTestServer(t, func(srvConn *websocket.Conn) {
+		defer srvConn.Close()
+		_, data, err := srvConn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var msg map[string]interface{}
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return
+		}
+		_ = srvConn.WriteJSON(msg)
+	})
+	defer cleanup()
+
+	session := testSession(conn)
+	flow := &Flow{
+		ID:      "empty-data-flow",
+		Session: session,
+		Data:    make(map[string]interface{}),
+		// Data map empty — no credential_issuer or selected_credential_configuration_id
+	}
+	session.flowsMu.Lock()
+	session.flows["empty-data-flow"] = flow
+	session.flowsMu.Unlock()
+
+	err := session.SendFlowComplete("empty-data-flow", nil, "")
+	require.NoError(t, err)
+
+	var received map[string]interface{}
+	err = conn.ReadJSON(&received)
+	require.NoError(t, err)
+
+	_, hasIssuer := received["credential_issuer"]
+	_, hasConfig := received["selected_credential_configuration_id"]
+	assert.False(t, hasIssuer, "credential_issuer should not be present when Data map is empty")
+	assert.False(t, hasConfig, "selected_credential_configuration_id should not be present when Data map is empty")
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->
Various fixes needed to get VCI flow working properly.
Might not be the cleanest implementation.

## Type of change
<!-- Check all that apply -->
- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Changes
1. **Flow resumption fields** — `AuthCode` and `CodeVerifier` added to `FlowStartMessage`
2. **`resumeWithAuthCode()`** — New method that skips authorization and directly exchanges an auth code for a token
3. **`Execute()` branching** — Routes to `resumeWithAuthCode()` when `AuthCode` is present, otherwise normal `handleAuthorization()`
4. **`credential_issuer` propagation** — `SetData("credential_issuer", offer.CredentialIssuer)` after parsing offer
5. **`selected_credential_configuration_id` propagation** — `SetData("selected_credential_configuration_id", selectedConfigID)` after credential selection
6. **`FlowCompleteMessage` fields** — `CredentialIssuer` and `SelectedCredentialConfigurationID` added
7. **`SendFlowComplete()` reads from `flow.Data`** — Populates the new `FlowCompleteMessage` fields from the flow's Data map
8. **`fetchOAuthMetadata()` extracted** — Refactored from inline code in `handleAuthorizationCode()` into a reusable method
9. **`handlePreAuthorized()` token endpoint discovery** — Now calls `fetchOAuthMetadata()` to find token endpoint when `metadata.TokenEndpoint` is empty
10. **Richer pre-auth progress payload** — `tx_code` progress event now includes `pre_authorized_code`, `tx_code` spec object, and `credential_issuer`
11. **`credential_offer` in auth progress payload** — `startAuthorizationFlow()` sends the parsed credential offer back to the client for stateless resumption
12. **Encryption JWK `alg` fix** — `encJWK["alg"] = selectedAlg` added in `requestCredential()` for `credential_response_encryption`
<!-- Bullet list of the key changes -->

