### PR TITLE
feat: add GET /issuer/:id/metadata endpoint

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -25,6 +26,7 @@ type Handlers struct {
 	logger        *zap.Logger
 	roles         []string
 	metadataCache *issuerMetadataCache
+	httpClient    *http.Client
 }
 
 // NewHandlers creates a new Handlers instance
@@ -35,6 +37,7 @@ func NewHandlers(services *service.Services, cfg *config.Config, logger *zap.Log
 		logger:        logger.Named("handlers"),
 		roles:         roles,
 		metadataCache: newIssuerMetadataCache(),
+		httpClient:    cfg.HTTPClient.NewHTTPClient(0),
 	}
 }
 
@@ -47,6 +50,7 @@ func NewHandlersWithStore(services *service.Services, store storage.Store, cfg *
 		logger:        logger.Named("handlers"),
 		roles:         roles,
 		metadataCache: newIssuerMetadataCache(),
+		httpClient:    cfg.HTTPClient.NewHTTPClient(0),
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -19,31 +19,34 @@ import (
 
 // Handlers aggregates all HTTP handlers
 type Handlers struct {
-	services *service.Services
-	store    storage.Store
-	cfg      *config.Config
-	logger   *zap.Logger
-	roles    []string
+	services      *service.Services
+	store         storage.Store
+	cfg           *config.Config
+	logger        *zap.Logger
+	roles         []string
+	metadataCache *issuerMetadataCache
 }
 
 // NewHandlers creates a new Handlers instance
 func NewHandlers(services *service.Services, cfg *config.Config, logger *zap.Logger, roles []string) *Handlers {
 	return &Handlers{
-		services: services,
-		cfg:      cfg,
-		logger:   logger.Named("handlers"),
-		roles:    roles,
+		services:      services,
+		cfg:           cfg,
+		logger:        logger.Named("handlers"),
+		roles:         roles,
+		metadataCache: newIssuerMetadataCache(),
 	}
 }
 
 // NewHandlersWithStore creates a new Handlers instance with store for health checks
 func NewHandlersWithStore(services *service.Services, store storage.Store, cfg *config.Config, logger *zap.Logger, roles []string) *Handlers {
 	return &Handlers{
-		services: services,
-		store:    store,
-		cfg:      cfg,
-		logger:   logger.Named("handlers"),
-		roles:    roles,
+		services:      services,
+		store:         store,
+		cfg:           cfg,
+		logger:        logger.Named("handlers"),
+		roles:         roles,
+		metadataCache: newIssuerMetadataCache(),
 	}
 }
 

--- a/internal/api/issuer_metadata.go
+++ b/internal/api/issuer_metadata.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -18,13 +18,13 @@ import (
 // credential_issuer_identifier. This avoids hammering upstream well-known
 // endpoints on every frontend page load.
 type issuerMetadataCache struct {
-	mu      sync.RWMutex
+	mu      sync.Mutex
 	entries map[string]*metadataCacheEntry
 	ttl     time.Duration
 }
 
 type metadataCacheEntry struct {
-	result    *metadata.IssuerDiscoveryResult
+	metadata  *metadata.IssuerMetadata
 	fetchedAt time.Time
 }
 
@@ -37,24 +37,36 @@ func newIssuerMetadataCache() *issuerMetadataCache {
 	}
 }
 
-func (c *issuerMetadataCache) get(issuerURL string) (*metadata.IssuerDiscoveryResult, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	entry, ok := c.entries[issuerURL]
-	if !ok || time.Since(entry.fetchedAt) > c.ttl {
-		return nil, false
-	}
-	return entry.result, true
-}
-
-func (c *issuerMetadataCache) put(issuerURL string, result *metadata.IssuerDiscoveryResult) {
+func (c *issuerMetadataCache) get(issuerURL string) (*metadata.IssuerMetadata, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	entry, ok := c.entries[issuerURL]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(entry.fetchedAt) > c.ttl {
+		delete(c.entries, issuerURL)
+		return nil, false
+	}
+	return entry.metadata, true
+}
+
+func (c *issuerMetadataCache) put(issuerURL string, m *metadata.IssuerMetadata) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Evict expired entries on write to keep the map bounded
+	now := time.Now()
+	for url, entry := range c.entries {
+		if now.Sub(entry.fetchedAt) > c.ttl {
+			delete(c.entries, url)
+		}
+	}
+
 	c.entries[issuerURL] = &metadataCacheEntry{
-		result:    result,
-		fetchedAt: time.Now(),
+		metadata:  m,
+		fetchedAt: now,
 	}
 }
 
@@ -69,8 +81,8 @@ func (h *Handlers) GetIssuerMetadata(c *gin.Context) {
 		return
 	}
 
-	var id int64
-	if _, err := fmt.Sscanf(issuerID, "%d", &id); err != nil {
+	id, err := strconv.ParseInt(issuerID, 10, 64)
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issuer ID"})
 		return
 	}
@@ -102,8 +114,7 @@ func (h *Handlers) GetIssuerMetadata(c *gin.Context) {
 	}
 
 	// Fetch metadata server-side
-	httpClient := h.cfg.HTTPClient.NewHTTPClient(0)
-	result := metadata.DiscoverIssuer(c.Request.Context(), issuerURL, httpClient)
+	result := metadata.DiscoverIssuer(c.Request.Context(), issuerURL, h.httpClient)
 	if result.Error != nil && result.Metadata == nil {
 		h.logger.Error("Failed to fetch issuer metadata",
 			zap.String("issuer_url", issuerURL),
@@ -112,8 +123,7 @@ func (h *Handlers) GetIssuerMetadata(c *gin.Context) {
 		return
 	}
 
-	// Cache even partial results (metadata OK, IACA failed)
-	h.metadataCache.put(issuerURL, result)
+	h.metadataCache.put(issuerURL, result.Metadata)
 
-	c.JSON(http.StatusOK, result)
+	c.JSON(http.StatusOK, result.Metadata)
 }

--- a/internal/api/issuer_metadata.go
+++ b/internal/api/issuer_metadata.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/sirosfoundation/go-wallet-backend/internal/metadata"
+	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
+)
+
+// issuerMetadataCache provides a simple TTL cache for issuer metadata keyed by
+// credential_issuer_identifier. This avoids hammering upstream well-known
+// endpoints on every frontend page load.
+type issuerMetadataCache struct {
+	mu      sync.RWMutex
+	entries map[string]*metadataCacheEntry
+	ttl     time.Duration
+}
+
+type metadataCacheEntry struct {
+	result    *metadata.IssuerDiscoveryResult
+	fetchedAt time.Time
+}
+
+const defaultMetadataCacheTTL = 5 * time.Minute
+
+func newIssuerMetadataCache() *issuerMetadataCache {
+	return &issuerMetadataCache{
+		entries: make(map[string]*metadataCacheEntry),
+		ttl:     defaultMetadataCacheTTL,
+	}
+}
+
+func (c *issuerMetadataCache) get(issuerURL string) (*metadata.IssuerDiscoveryResult, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.entries[issuerURL]
+	if !ok || time.Since(entry.fetchedAt) > c.ttl {
+		return nil, false
+	}
+	return entry.result, true
+}
+
+func (c *issuerMetadataCache) put(issuerURL string, result *metadata.IssuerDiscoveryResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[issuerURL] = &metadataCacheEntry{
+		result:    result,
+		fetchedAt: time.Now(),
+	}
+}
+
+// GetIssuerMetadata handles GET /issuer/:id/metadata.
+// It looks up the pre-registered issuer by ID (scoped to the authenticated
+// tenant), fetches the issuer's .well-known/openid-credential-issuer metadata
+// server-side, and returns it to the caller. Results are cached with a TTL.
+func (h *Handlers) GetIssuerMetadata(c *gin.Context) {
+	issuerID := c.Param("id")
+	if issuerID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Issuer ID required"})
+		return
+	}
+
+	var id int64
+	if _, err := fmt.Sscanf(issuerID, "%d", &id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issuer ID"})
+		return
+	}
+
+	tenantID, _ := h.getTenantID(c)
+
+	// Look up the issuer and validate it belongs to this tenant
+	issuer, err := h.services.Issuer.GetByID(c.Request.Context(), tenantID, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Issuer not found"})
+			return
+		}
+		h.logger.Error("Failed to get issuer", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get issuer"})
+		return
+	}
+
+	issuerURL := issuer.CredentialIssuerIdentifier
+	if issuerURL == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Issuer has no credential issuer identifier"})
+		return
+	}
+
+	// Check cache
+	if cached, ok := h.metadataCache.get(issuerURL); ok {
+		c.JSON(http.StatusOK, cached)
+		return
+	}
+
+	// Fetch metadata server-side
+	httpClient := h.cfg.HTTPClient.NewHTTPClient(0)
+	result := metadata.DiscoverIssuer(c.Request.Context(), issuerURL, httpClient)
+	if result.Error != nil && result.Metadata == nil {
+		h.logger.Error("Failed to fetch issuer metadata",
+			zap.String("issuer_url", issuerURL),
+			zap.Error(result.Error))
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to fetch issuer metadata"})
+		return
+	}
+
+	// Cache even partial results (metadata OK, IACA failed)
+	h.metadataCache.put(issuerURL, result)
+
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/api/issuer_metadata_test.go
+++ b/internal/api/issuer_metadata_test.go
@@ -1,0 +1,276 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
+	"github.com/sirosfoundation/go-wallet-backend/internal/metadata"
+	"github.com/sirosfoundation/go-wallet-backend/internal/service"
+	"github.com/sirosfoundation/go-wallet-backend/internal/storage/memory"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+)
+
+func setupIssuerMetadataTest(t *testing.T) (*Handlers, *gin.Engine, *memory.Store) {
+	t.Helper()
+	logger := zap.NewNop()
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Host:     "localhost",
+			Port:     8080,
+			RPID:     "localhost",
+			RPOrigin: "http://localhost:8080",
+			RPName:   "Test Wallet",
+		},
+		JWT: config.JWTConfig{
+			Secret:      "test-secret",
+			ExpiryHours: 24,
+			Issuer:      "test-wallet",
+		},
+	}
+
+	store := memory.NewStore()
+	services := service.NewServices(store, cfg, logger)
+	handlers := NewHandlers(services, cfg, logger, []string{"test"})
+
+	router := gin.New()
+	// Mock auth middleware
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "default")
+		c.Set("user_id", "test-user")
+		c.Next()
+	})
+	router.GET("/issuer/:id/metadata", handlers.GetIssuerMetadata)
+
+	return handlers, router, store
+}
+
+func TestGetIssuerMetadata_InvalidID(t *testing.T) {
+	_, router, _ := setupIssuerMetadataTest(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/issuer/abc/metadata", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+}
+
+func TestGetIssuerMetadata_NotFound(t *testing.T) {
+	_, router, _ := setupIssuerMetadataTest(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/issuer/999/metadata", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusNotFound, w.Code, w.Body.String())
+	}
+}
+
+func TestGetIssuerMetadata_Success(t *testing.T) {
+	// Start a mock issuer metadata server
+	mockIssuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-credential-issuer" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"credential_issuer":   "https://issuer.example.com",
+				"credential_endpoint": "https://issuer.example.com/credential",
+				"credential_configurations_supported": map[string]interface{}{
+					"UniversityDegree": map[string]interface{}{
+						"format": "jwt_vc_json",
+					},
+				},
+			})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer mockIssuer.Close()
+
+	_, router, store := setupIssuerMetadataTest(t)
+
+	// Create a tenant and issuer pointing to our mock server
+	ctx := context.Background()
+	store.Tenants().Create(ctx, &domain.Tenant{
+		ID:      "default",
+		Name:    "Default",
+		Enabled: true,
+	})
+	issuer := &domain.CredentialIssuer{
+		TenantID:                   "default",
+		CredentialIssuerIdentifier: mockIssuer.URL,
+		Visible:                    true,
+	}
+	if err := store.Issuers().Create(ctx, issuer); err != nil {
+		t.Fatal(err)
+	}
+	issuerID := issuer.ID
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/issuer/%d/metadata", issuerID), nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// The result should contain metadata with credential_issuer
+	meta, ok := result["Metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected Metadata field in response")
+	}
+	if meta["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("Expected credential_issuer, got %v", meta["credential_issuer"])
+	}
+}
+
+func TestGetIssuerMetadata_CachesResponses(t *testing.T) {
+	callCount := 0
+	mockIssuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"credential_issuer":   "https://issuer.example.com",
+			"credential_endpoint": "https://issuer.example.com/credential",
+		})
+	}))
+	defer mockIssuer.Close()
+
+	_, router, store := setupIssuerMetadataTest(t)
+
+	ctx := context.Background()
+	store.Tenants().Create(ctx, &domain.Tenant{
+		ID:      "default",
+		Name:    "Default",
+		Enabled: true,
+	})
+	issuer := &domain.CredentialIssuer{
+		TenantID:                   "default",
+		CredentialIssuerIdentifier: mockIssuer.URL,
+		Visible:                    true,
+	}
+	store.Issuers().Create(ctx, issuer)
+
+	path := fmt.Sprintf("/issuer/%d/metadata", issuer.ID)
+
+	// First request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("First request: expected %d, got %d", http.StatusOK, w.Code)
+	}
+
+	// Second request — should be cached
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, path, nil)
+	router.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("Second request: expected %d, got %d", http.StatusOK, w2.Code)
+	}
+
+	if callCount != 1 {
+		t.Errorf("Expected 1 upstream call (cached), got %d", callCount)
+	}
+}
+
+func TestGetIssuerMetadata_UpstreamError(t *testing.T) {
+	mockIssuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer mockIssuer.Close()
+
+	_, router, store := setupIssuerMetadataTest(t)
+
+	ctx := context.Background()
+	store.Tenants().Create(ctx, &domain.Tenant{
+		ID:      "default",
+		Name:    "Default",
+		Enabled: true,
+	})
+	issuer := &domain.CredentialIssuer{
+		TenantID:                   "default",
+		CredentialIssuerIdentifier: mockIssuer.URL,
+		Visible:                    true,
+	}
+	store.Issuers().Create(ctx, issuer)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/issuer/%d/metadata", issuer.ID), nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusBadGateway, w.Code, w.Body.String())
+	}
+}
+
+func TestGetIssuerMetadata_CrossTenantBlocked(t *testing.T) {
+	_, router, store := setupIssuerMetadataTest(t)
+
+	ctx := context.Background()
+	// Create two tenants
+	store.Tenants().Create(ctx, &domain.Tenant{
+		ID: "default", Name: "Default", Enabled: true,
+	})
+	store.Tenants().Create(ctx, &domain.Tenant{
+		ID: "other-tenant", Name: "Other", Enabled: true,
+	})
+
+	// Create issuer under "other-tenant" (not "default")
+	issuer := &domain.CredentialIssuer{
+		TenantID:                   "other-tenant",
+		CredentialIssuerIdentifier: "https://issuer.example.com",
+		Visible:                    true,
+	}
+	store.Issuers().Create(ctx, issuer)
+
+	// Auth middleware sets tenant_id="default", so this issuer should not be found
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/issuer/%d/metadata", issuer.ID), nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status %d (cross-tenant), got %d: %s", http.StatusNotFound, w.Code, w.Body.String())
+	}
+}
+
+func TestIssuerMetadataCache(t *testing.T) {
+	cache := newIssuerMetadataCache()
+
+	// Miss on empty cache
+	_, ok := cache.get("https://example.com")
+	if ok {
+		t.Error("Expected cache miss")
+	}
+
+	// Put and hit
+	result := &metadata.IssuerDiscoveryResult{
+		Metadata: &metadata.IssuerMetadata{
+			CredentialIssuer: "https://example.com",
+		},
+	}
+	cache.put("https://example.com", result)
+
+	cached, ok := cache.get("https://example.com")
+	if !ok {
+		t.Fatal("Expected cache hit")
+	}
+	if cached != result {
+		t.Error("Cached result does not match")
+	}
+}

--- a/internal/api/issuer_metadata_test.go
+++ b/internal/api/issuer_metadata_test.go
@@ -128,13 +128,9 @@ func TestGetIssuerMetadata_Success(t *testing.T) {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
 
-	// The result should contain metadata with credential_issuer
-	meta, ok := result["Metadata"].(map[string]interface{})
-	if !ok {
-		t.Fatal("Expected Metadata field in response")
-	}
-	if meta["credential_issuer"] != "https://issuer.example.com" {
-		t.Errorf("Expected credential_issuer, got %v", meta["credential_issuer"])
+	// The response should be the IssuerMetadata directly with proper JSON keys
+	if result["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("Expected credential_issuer, got %v", result["credential_issuer"])
 	}
 }
 
@@ -259,18 +255,16 @@ func TestIssuerMetadataCache(t *testing.T) {
 	}
 
 	// Put and hit
-	result := &metadata.IssuerDiscoveryResult{
-		Metadata: &metadata.IssuerMetadata{
-			CredentialIssuer: "https://example.com",
-		},
+	m := &metadata.IssuerMetadata{
+		CredentialIssuer: "https://example.com",
 	}
-	cache.put("https://example.com", result)
+	cache.put("https://example.com", m)
 
 	cached, ok := cache.get("https://example.com")
 	if !ok {
 		t.Fatal("Expected cache hit")
 	}
-	if cached != result {
+	if cached != m {
 		t.Error("Cached result does not match")
 	}
 }

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -124,6 +124,7 @@ func (p *AuthProvider) RegisterRoutes(router *gin.Engine) {
 		issuerGroup := protected.Group("/issuer")
 		{
 			issuerGroup.GET("/all", p.handlers.GetAllIssuers)
+			issuerGroup.GET("/:id/metadata", p.handlers.GetIssuerMetadata)
 		}
 
 		// Verifier routes


### PR DESCRIPTION
Closes #121

## Summary

Adds an authenticated `GET /issuer/:id/metadata` endpoint that fetches OpenID4VCI issuer metadata (`.well-known/openid-credential-issuer`) server-side, so the frontend doesn't need to go through the HTTP proxy (which doesn't work with WebSocket transport).

## Changes

- **issuer_metadata.go**: New `GetIssuerMetadata` handler + in-memory cache with 5-minute TTL
- **handlers.go**: Added `metadataCache` field to `Handlers` struct, initialized in both constructors
- **providers.go**: Registered `GET /issuer/:id/metadata` in the authenticated issuer route group
- **issuer_metadata_test.go**: 7 tests covering invalid ID, not found, success, caching, upstream error, cross-tenant isolation, cache unit

## Security

- Endpoint requires JWT authentication (sits behind `AuthMiddleware`)
- Tenant isolation enforced: issuer must belong to the authenticated user's tenant
- Only fetches metadata for pre-registered issuers (not arbitrary URLs)
- Uses configured HTTP client with proxy/TLS settings

## Usage

```
GET /issuer/42/metadata
Authorization: Bearer <jwt>
```

Returns `IssuerDiscoveryResult` with metadata and optional IACA certificates.