### PR TITLE
feat: add DCQL query support to OID4VP engine

### DIFF
--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -70,9 +70,8 @@ func (h *BaseHandler) RequestSign(ctx context.Context, action SignAction, params
 }
 
 // RequestMatch requests client-side credential matching (privacy-preserving).
-// Accepts either a PresentationDefinition or a DCQL query.
-func (h *BaseHandler) RequestMatch(ctx context.Context, pd *PresentationDefinition, dcql json.RawMessage) (*MatchResponseMessage, error) {
-	return h.Flow.Session.RequestMatch(ctx, h.Flow.ID, pd, dcql)
+func (h *BaseHandler) RequestMatch(ctx context.Context, dcql json.RawMessage) (*MatchResponseMessage, error) {
+	return h.Flow.Session.RequestMatch(ctx, h.Flow.ID, dcql)
 }
 
 // WaitForAction waits for a client action

--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 
 	"go.uber.org/zap"
 
@@ -68,9 +69,10 @@ func (h *BaseHandler) RequestSign(ctx context.Context, action SignAction, params
 	return h.Flow.Session.RequestSign(ctx, h.Flow.ID, action, params)
 }
 
-// RequestMatch requests client-side credential matching (privacy-preserving)
-func (h *BaseHandler) RequestMatch(ctx context.Context, pd *PresentationDefinition) (*MatchResponseMessage, error) {
-	return h.Flow.Session.RequestMatch(ctx, h.Flow.ID, pd)
+// RequestMatch requests client-side credential matching (privacy-preserving).
+// Accepts either a PresentationDefinition or a DCQL query.
+func (h *BaseHandler) RequestMatch(ctx context.Context, pd *PresentationDefinition, dcql json.RawMessage) (*MatchResponseMessage, error) {
+	return h.Flow.Session.RequestMatch(ctx, h.Flow.ID, pd, dcql)
 }
 
 // WaitForAction waits for a client action

--- a/internal/engine/match_test.go
+++ b/internal/engine/match_test.go
@@ -104,7 +104,7 @@ func TestSession_RequestMatch_Success(t *testing.T) {
 		},
 	}
 
-	resp, err := session.RequestMatch(ctx, "flow-1", pd)
+	resp, err := session.RequestMatch(ctx, "flow-1", pd, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Len(t, resp.Matches, 1)
@@ -130,7 +130,7 @@ func TestSession_RequestMatch_Timeout(t *testing.T) {
 	defer cancel()
 
 	pd := &PresentationDefinition{ID: "timeout-pd"}
-	_, err := session.RequestMatch(ctx, "flow-timeout", pd)
+	_, err := session.RequestMatch(ctx, "flow-timeout", pd, nil)
 	require.Error(t, err)
 	// Either context deadline or match timeout, both are acceptable
 	assert.True(t, err == context.DeadlineExceeded || err == ErrMatchTimeout,
@@ -178,7 +178,7 @@ func TestSession_RequestMatch_ErrorInResponse(t *testing.T) {
 
 	ctx := context.Background()
 	pd := &PresentationDefinition{ID: "error-pd"}
-	_, err := session.RequestMatch(ctx, "flow-error", pd)
+	_, err := session.RequestMatch(ctx, "flow-error", pd, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "client-side matching failed")
 }
@@ -224,7 +224,7 @@ func TestSession_RequestMatch_NoMatchReason(t *testing.T) {
 
 	ctx := context.Background()
 	pd := &PresentationDefinition{ID: "nomatch-pd"}
-	resp, err := session.RequestMatch(ctx, "flow-nomatch", pd)
+	resp, err := session.RequestMatch(ctx, "flow-nomatch", pd, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Empty(t, resp.Matches)
@@ -249,7 +249,7 @@ func TestSession_RequestMatch_SessionClosed(t *testing.T) {
 
 	ctx := context.Background()
 	pd := &PresentationDefinition{ID: "close-pd"}
-	_, err := session.RequestMatch(ctx, "flow-close", pd)
+	_, err := session.RequestMatch(ctx, "flow-close", pd, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "session closed")
 }
@@ -309,7 +309,7 @@ func TestSession_RequestMatch_WrongFlowID_Ignored(t *testing.T) {
 
 	ctx := context.Background()
 	pd := &PresentationDefinition{ID: "filter-pd"}
-	resp, err := session.RequestMatch(ctx, "flow-filter", pd)
+	resp, err := session.RequestMatch(ctx, "flow-filter", pd, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, "correct-cred", resp.Matches[0].CredentialID)
@@ -428,7 +428,7 @@ func TestBaseHandler_RequestMatch(t *testing.T) {
 
 	ctx := context.Background()
 	pd := &PresentationDefinition{ID: "handler-pd"}
-	resp, err := handler.RequestMatch(ctx, pd)
+	resp, err := handler.RequestMatch(ctx, pd, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, "handler-cred", resp.Matches[0].CredentialID)
@@ -447,6 +447,6 @@ func TestSession_RequestMatch_SendError(t *testing.T) {
 
 	ctx := context.Background()
 	pd := &PresentationDefinition{ID: "send-error-pd"}
-	_, err := session.RequestMatch(ctx, "flow-send-err", pd)
+	_, err := session.RequestMatch(ctx, "flow-send-err", pd, nil)
 	require.Error(t, err)
 }

--- a/internal/engine/match_test.go
+++ b/internal/engine/match_test.go
@@ -73,7 +73,7 @@ func TestSession_RequestMatch_Success(t *testing.T) {
 				Timestamp: Now(),
 			},
 			Matches: []CredentialMatch{
-				{InputDescriptorID: "id-1", CredentialID: "cred-abc"},
+				{CredentialQueryID: "id-1", CredentialID: "cred-abc"},
 			},
 		}
 		_ = srvConn.WriteJSON(resp)
@@ -97,14 +97,9 @@ func TestSession_RequestMatch_Success(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	pd := &PresentationDefinition{
-		ID: "test-pd",
-		InputDescriptors: []InputDescriptor{
-			{ID: "id-1"},
-		},
-	}
+	dcql := json.RawMessage(`{"credentials":[{"id":"id-1"}]}`)
 
-	resp, err := session.RequestMatch(ctx, "flow-1", pd, nil)
+	resp, err := session.RequestMatch(ctx, "flow-1", dcql)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Len(t, resp.Matches, 1)
@@ -129,8 +124,8 @@ func TestSession_RequestMatch_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	pd := &PresentationDefinition{ID: "timeout-pd"}
-	_, err := session.RequestMatch(ctx, "flow-timeout", pd, nil)
+	pd := json.RawMessage(`{"credentials":[{"id":"timeout"}]}`)
+	_, err := session.RequestMatch(ctx, "flow-timeout", pd)
 	require.Error(t, err)
 	// Either context deadline or match timeout, both are acceptable
 	assert.True(t, err == context.DeadlineExceeded || err == ErrMatchTimeout,
@@ -177,8 +172,8 @@ func TestSession_RequestMatch_ErrorInResponse(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	pd := &PresentationDefinition{ID: "error-pd"}
-	_, err := session.RequestMatch(ctx, "flow-error", pd, nil)
+	dcql := json.RawMessage(`{"credentials":[{"id":"error"}]}`)
+	_, err := session.RequestMatch(ctx, "flow-error", dcql)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "client-side matching failed")
 }
@@ -223,8 +218,8 @@ func TestSession_RequestMatch_NoMatchReason(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	pd := &PresentationDefinition{ID: "nomatch-pd"}
-	resp, err := session.RequestMatch(ctx, "flow-nomatch", pd, nil)
+	dcql := json.RawMessage(`{"credentials":[{"id":"nomatch"}]}`)
+	resp, err := session.RequestMatch(ctx, "flow-nomatch", dcql)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Empty(t, resp.Matches)
@@ -248,8 +243,8 @@ func TestSession_RequestMatch_SessionClosed(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	pd := &PresentationDefinition{ID: "close-pd"}
-	_, err := session.RequestMatch(ctx, "flow-close", pd, nil)
+	dcql := json.RawMessage(`{"credentials":[{"id":"close"}]}`)
+	_, err := session.RequestMatch(ctx, "flow-close", dcql)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "session closed")
 }
@@ -308,8 +303,8 @@ func TestSession_RequestMatch_WrongFlowID_Ignored(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	pd := &PresentationDefinition{ID: "filter-pd"}
-	resp, err := session.RequestMatch(ctx, "flow-filter", pd, nil)
+	dcql := json.RawMessage(`{"credentials":[{"id":"filter"}]}`)
+	resp, err := session.RequestMatch(ctx, "flow-filter", dcql)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, "correct-cred", resp.Matches[0].CredentialID)
@@ -332,7 +327,7 @@ func TestMatchResponseChannelRouting(t *testing.T) {
 			MessageID: "msg-1",
 		},
 		Matches: []CredentialMatch{
-			{InputDescriptorID: "id-1", CredentialID: "cred-1"},
+			{CredentialQueryID: "id-1", CredentialID: "cred-1"},
 		},
 	}
 
@@ -427,8 +422,8 @@ func TestBaseHandler_RequestMatch(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	pd := &PresentationDefinition{ID: "handler-pd"}
-	resp, err := handler.RequestMatch(ctx, pd, nil)
+	dcql := json.RawMessage(`{"credentials":[{"id":"handler"}]}`)
+	resp, err := handler.RequestMatch(ctx, dcql)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, "handler-cred", resp.Matches[0].CredentialID)
@@ -446,7 +441,7 @@ func TestSession_RequestMatch_SendError(t *testing.T) {
 	conn.Close()
 
 	ctx := context.Background()
-	pd := &PresentationDefinition{ID: "send-error-pd"}
-	_, err := session.RequestMatch(ctx, "flow-send-err", pd, nil)
+	dcql := json.RawMessage(`{"credentials":[{"id":"send-error"}]}`)
+	_, err := session.RequestMatch(ctx, "flow-send-err", dcql)
 	require.Error(t, err)
 }

--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -279,10 +279,11 @@ type SignResponseMessage struct {
 	Proofs []ProofObject `json:"proofs,omitempty"`
 }
 
-// MatchRequestMessage requests client-side credential matching
+// MatchRequestMessage requests client-side credential matching.
 // This is the privacy-preserving protocol: credentials are matched locally
 // and only matching credential IDs/metadata are sent back to the server.
-// Exactly one of PresentationDefinition or DCQLQuery will be set.
+// At most one of PresentationDefinition or DCQLQuery should be set;
+// the sender enforces this before constructing the message.
 type MatchRequestMessage struct {
 	Message
 	PresentationDefinition *PresentationDefinition `json:"presentation_definition,omitempty"`

--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -282,12 +282,9 @@ type SignResponseMessage struct {
 // MatchRequestMessage requests client-side credential matching.
 // This is the privacy-preserving protocol: credentials are matched locally
 // and only matching credential IDs/metadata are sent back to the server.
-// At most one of PresentationDefinition or DCQLQuery should be set;
-// the sender enforces this before constructing the message.
 type MatchRequestMessage struct {
 	Message
-	PresentationDefinition *PresentationDefinition `json:"presentation_definition,omitempty"`
-	DCQLQuery              json.RawMessage         `json:"dcql_query,omitempty"`
+	DCQLQuery json.RawMessage `json:"dcql_query,omitempty"`
 }
 
 // MatchResponseMessage is the client's matching response
@@ -342,11 +339,8 @@ type LogoInfo struct {
 	URI string `json:"uri"`
 }
 
-// CredentialMatch represents a credential that matches a presentation request.
-// For Presentation Definition requests, InputDescriptorID is set.
-// For DCQL requests, CredentialQueryID is set.
+// CredentialMatch represents a credential that matches a DCQL query.
 type CredentialMatch struct {
-	InputDescriptorID string   `json:"input_descriptor_id,omitempty"`
 	CredentialQueryID string   `json:"credential_query_id,omitempty"`
 	CredentialID      string   `json:"credential_id"`
 	Format            string   `json:"format"`
@@ -354,17 +348,13 @@ type CredentialMatch struct {
 	AvailableClaims   []string `json:"available_claims,omitempty"`
 }
 
-// QueryID returns the appropriate query identifier (InputDescriptorID or CredentialQueryID).
+// QueryID returns the credential query identifier.
 func (m CredentialMatch) QueryID() string {
-	if m.CredentialQueryID != "" {
-		return m.CredentialQueryID
-	}
-	return m.InputDescriptorID
+	return m.CredentialQueryID
 }
 
 // MatchedCredential represents a credential with consent info
 type MatchedCredential struct {
-	InputDescriptorID string          `json:"input_descriptor_id,omitempty"`
 	CredentialQueryID string          `json:"credential_query_id,omitempty"`
 	CredentialID      string          `json:"credential_id"`
 	CredentialDisplay json.RawMessage `json:"credential_display,omitempty"`

--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -282,9 +282,11 @@ type SignResponseMessage struct {
 // MatchRequestMessage requests client-side credential matching
 // This is the privacy-preserving protocol: credentials are matched locally
 // and only matching credential IDs/metadata are sent back to the server.
+// Exactly one of PresentationDefinition or DCQLQuery will be set.
 type MatchRequestMessage struct {
 	Message
-	PresentationDefinition *PresentationDefinition `json:"presentation_definition"`
+	PresentationDefinition *PresentationDefinition `json:"presentation_definition,omitempty"`
+	DCQLQuery              json.RawMessage         `json:"dcql_query,omitempty"`
 }
 
 // MatchResponseMessage is the client's matching response
@@ -339,18 +341,30 @@ type LogoInfo struct {
 	URI string `json:"uri"`
 }
 
-// CredentialMatch represents a credential that matches a presentation request
+// CredentialMatch represents a credential that matches a presentation request.
+// For Presentation Definition requests, InputDescriptorID is set.
+// For DCQL requests, CredentialQueryID is set.
 type CredentialMatch struct {
-	InputDescriptorID string   `json:"input_descriptor_id"`
+	InputDescriptorID string   `json:"input_descriptor_id,omitempty"`
+	CredentialQueryID string   `json:"credential_query_id,omitempty"`
 	CredentialID      string   `json:"credential_id"`
 	Format            string   `json:"format"`
 	VCT               string   `json:"vct,omitempty"`
 	AvailableClaims   []string `json:"available_claims,omitempty"`
 }
 
+// QueryID returns the appropriate query identifier (InputDescriptorID or CredentialQueryID).
+func (m CredentialMatch) QueryID() string {
+	if m.CredentialQueryID != "" {
+		return m.CredentialQueryID
+	}
+	return m.InputDescriptorID
+}
+
 // MatchedCredential represents a credential with consent info
 type MatchedCredential struct {
-	InputDescriptorID string          `json:"input_descriptor_id"`
+	InputDescriptorID string          `json:"input_descriptor_id,omitempty"`
+	CredentialQueryID string          `json:"credential_query_id,omitempty"`
 	CredentialID      string          `json:"credential_id"`
 	CredentialDisplay json.RawMessage `json:"credential_display,omitempty"`
 	DisclosableClaims []string        `json:"disclosable_claims,omitempty"`

--- a/internal/engine/messages_test.go
+++ b/internal/engine/messages_test.go
@@ -823,17 +823,7 @@ func TestMatchRequestMessageJSON(t *testing.T) {
 			MessageID: "msg-456",
 			Timestamp: "2024-01-01T00:00:00Z",
 		},
-		PresentationDefinition: &PresentationDefinition{
-			ID:   "pd-1",
-			Name: "Test Presentation",
-			InputDescriptors: []InputDescriptor{
-				{
-					ID:      "id-1",
-					Name:    "Identity",
-					Purpose: "Verify identity",
-				},
-			},
-		},
+		DCQLQuery: json.RawMessage(`{"credentials":[{"id":"id-1"}]}`),
 	}
 
 	data, err := json.Marshal(msg)
@@ -851,8 +841,8 @@ func TestMatchRequestMessageJSON(t *testing.T) {
 	if !strings.Contains(string(data), `"message_id":"msg-456"`) {
 		t.Errorf("Missing message_id field in JSON: %s", data)
 	}
-	if !strings.Contains(string(data), `"presentation_definition"`) {
-		t.Errorf("Missing presentation_definition field in JSON: %s", data)
+	if !strings.Contains(string(data), `"dcql_query"`) {
+		t.Errorf("Missing dcql_query field in JSON: %s", data)
 	}
 }
 
@@ -866,7 +856,7 @@ func TestMatchResponseMessageJSON(t *testing.T) {
 		},
 		Matches: []CredentialMatch{
 			{
-				InputDescriptorID: "id-1",
+				CredentialQueryID: "id-1",
 				CredentialID:      "cred-abc",
 				Format:            "vc+sd-jwt",
 				VCT:               "urn:eu.europa.ec.eudi:pid:1",

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -73,9 +73,11 @@ type AuthorizationRequest struct {
 	RequestJWT string `json:"-"`
 }
 
-// IsDCQL returns true if this request uses a DCQL query instead of a Presentation Definition.
+// IsDCQL returns true if this request uses a non-null DCQL query
+// instead of a Presentation Definition.
 func (r *AuthorizationRequest) IsDCQL() bool {
-	return len(r.DCQLQuery) > 0
+	trimmed := strings.TrimSpace(string(r.DCQLQuery))
+	return trimmed != "" && trimmed != "null"
 }
 
 // PresentationDefinition represents a DIF Presentation Definition
@@ -283,6 +285,9 @@ func (h *OID4VPHandler) parseRequestFromURL(u *url.URL) (*AuthorizationRequest, 
 			return nil, fmt.Errorf("invalid dcql_query: not valid JSON")
 		}
 		authReq.DCQLQuery = json.RawMessage(dcqlStr)
+		// DCQL and PD are mutually exclusive; clear PD fields
+		authReq.PresentationDefinition = nil
+		authReq.PresentationDefinitionURI = ""
 	}
 
 	// Parse client_metadata if inline
@@ -798,8 +803,16 @@ func (h *OID4VPHandler) extractRequestedClaims(pd *PresentationDefinition) []Req
 
 func (h *OID4VPHandler) requestCredentialMatching(ctx context.Context, authReq *AuthorizationRequest) ([]CredentialMatch, error) {
 	// Send match_request to client for local matching (privacy-preserving)
-	// The client matches credentials locally and returns only the matching credential IDs/metadata
-	resp, err := h.RequestMatch(ctx, authReq.PresentationDefinition, authReq.DCQLQuery)
+	// The client matches credentials locally and returns only the matching credential IDs/metadata.
+	// Enforce mutual exclusivity: send only one query format.
+	var pd *PresentationDefinition
+	var dcql json.RawMessage
+	if authReq.IsDCQL() {
+		dcql = authReq.DCQLQuery
+	} else {
+		pd = authReq.PresentationDefinition
+	}
+	resp, err := h.RequestMatch(ctx, pd, dcql)
 	if err != nil {
 		if errors.Is(err, ErrMatchTimeout) {
 			h.Logger.Warn("Credential matching timed out")

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -54,61 +54,21 @@ const (
 
 // AuthorizationRequest represents an OpenID4VP authorization request
 type AuthorizationRequest struct {
-	ResponseType              string                  `json:"response_type"`
-	ClientID                  string                  `json:"client_id"`
-	ClientIDScheme            string                  `json:"client_id_scheme,omitempty"`
-	ResponseMode              string                  `json:"response_mode,omitempty"`
-	ResponseURI               string                  `json:"response_uri,omitempty"`
-	RedirectURI               string                  `json:"redirect_uri,omitempty"`
-	Nonce                     string                  `json:"nonce,omitempty"`
-	State                     string                  `json:"state,omitempty"`
-	Scope                     string                  `json:"scope,omitempty"`
-	PresentationDefinition    *PresentationDefinition `json:"presentation_definition,omitempty"`
-	PresentationDefinitionURI string                  `json:"presentation_definition_uri,omitempty"`
-	DCQLQuery                 json.RawMessage         `json:"dcql_query,omitempty"`
-	ClientMetadata            *ClientMetadata         `json:"client_metadata,omitempty"`
-	ClientMetadataURI         string                  `json:"client_metadata_uri,omitempty"`
+	ResponseType      string          `json:"response_type"`
+	ClientID          string          `json:"client_id"`
+	ClientIDScheme    string          `json:"client_id_scheme,omitempty"`
+	ResponseMode      string          `json:"response_mode,omitempty"`
+	ResponseURI       string          `json:"response_uri,omitempty"`
+	RedirectURI       string          `json:"redirect_uri,omitempty"`
+	Nonce             string          `json:"nonce,omitempty"`
+	State             string          `json:"state,omitempty"`
+	Scope             string          `json:"scope,omitempty"`
+	DCQLQuery         json.RawMessage `json:"dcql_query,omitempty"`
+	ClientMetadata    *ClientMetadata `json:"client_metadata,omitempty"`
+	ClientMetadataURI string          `json:"client_metadata_uri,omitempty"`
 	// RequestJWT stores the raw request JWT (if the request was JWT-secured).
 	// Used to extract x5c/jwk key material from the JWT header for trust evaluation.
 	RequestJWT string `json:"-"`
-}
-
-// IsDCQL returns true if this request uses a non-null DCQL query
-// instead of a Presentation Definition.
-func (r *AuthorizationRequest) IsDCQL() bool {
-	trimmed := strings.TrimSpace(string(r.DCQLQuery))
-	return trimmed != "" && trimmed != "null"
-}
-
-// PresentationDefinition represents a DIF Presentation Definition
-type PresentationDefinition struct {
-	ID               string                 `json:"id"`
-	Name             string                 `json:"name,omitempty"`
-	Purpose          string                 `json:"purpose,omitempty"`
-	InputDescriptors []InputDescriptor      `json:"input_descriptors"`
-	Format           map[string]interface{} `json:"format,omitempty"`
-}
-
-// InputDescriptor represents a single input requirement
-type InputDescriptor struct {
-	ID          string                 `json:"id"`
-	Name        string                 `json:"name,omitempty"`
-	Purpose     string                 `json:"purpose,omitempty"`
-	Format      map[string]interface{} `json:"format,omitempty"`
-	Constraints *Constraints           `json:"constraints,omitempty"`
-}
-
-// Constraints represents input descriptor constraints
-type Constraints struct {
-	LimitDisclosure string  `json:"limit_disclosure,omitempty"`
-	Fields          []Field `json:"fields,omitempty"`
-}
-
-// Field represents a required field in credentials
-type Field struct {
-	Path     []string               `json:"path"`
-	Filter   map[string]interface{} `json:"filter,omitempty"`
-	Optional bool                   `json:"optional,omitempty"`
 }
 
 // ClientMetadata represents verifier/client metadata
@@ -121,12 +81,6 @@ type ClientMetadata struct {
 	JWKS    json.RawMessage `json:"jwks,omitempty"`
 	JWKsURI string          `json:"jwks_uri,omitempty"`
 	X5C     []string        `json:"x5c,omitempty"`
-}
-
-// RequestedClaim describes a claim being requested
-type RequestedClaim struct {
-	Path     string `json:"path"`
-	Required bool   `json:"required"`
 }
 
 // CredentialsMatchedPayload is the payload for credentials_matched action
@@ -175,17 +129,10 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 	}
 
 	// Step 3: Send parsed request info to client
-	progressPayload := map[string]interface{}{
-		"verifier": verifier,
-	}
-	if authReq.IsDCQL() {
-		progressPayload["dcql_query"] = authReq.DCQLQuery
-	} else {
-		requestedClaims := h.extractRequestedClaims(authReq.PresentationDefinition)
-		progressPayload["presentation_definition"] = authReq.PresentationDefinition
-		progressPayload["requested_claims"] = requestedClaims
-	}
-	_ = h.Progress(StepRequestParsed, progressPayload)
+	_ = h.Progress(StepRequestParsed, map[string]interface{}{
+		"verifier":   verifier,
+		"dcql_query": authReq.DCQLQuery,
+	})
 
 	// Step 4: Request client-side credential matching (privacy-preserving)
 	matches, err := h.requestCredentialMatching(ctx, authReq)
@@ -269,25 +216,12 @@ func (h *OID4VPHandler) parseRequestFromURL(u *url.URL) (*AuthorizationRequest, 
 		Scope:          q.Get("scope"),
 	}
 
-	// Parse presentation_definition if inline
-	if pdStr := q.Get("presentation_definition"); pdStr != "" {
-		var pd PresentationDefinition
-		if err := json.Unmarshal([]byte(pdStr), &pd); err != nil {
-			return nil, fmt.Errorf("invalid presentation_definition: %w", err)
-		}
-		authReq.PresentationDefinition = &pd
-	}
-	authReq.PresentationDefinitionURI = q.Get("presentation_definition_uri")
-
-	// Parse dcql_query if inline (DCQL takes precedence over presentation_definition)
+	// Parse dcql_query
 	if dcqlStr := q.Get("dcql_query"); dcqlStr != "" {
 		if !json.Valid([]byte(dcqlStr)) {
 			return nil, fmt.Errorf("invalid dcql_query: not valid JSON")
 		}
 		authReq.DCQLQuery = json.RawMessage(dcqlStr)
-		// DCQL and PD are mutually exclusive; clear PD fields
-		authReq.PresentationDefinition = nil
-		authReq.PresentationDefinitionURI = ""
 	}
 
 	// Parse client_metadata if inline
@@ -382,15 +316,6 @@ func (h *OID4VPHandler) evaluateVerifierTrust(ctx context.Context, authReq *Auth
 		} else {
 			clientMeta = cm
 		}
-	}
-
-	// Fetch presentation_definition if needed (not applicable for DCQL)
-	if !authReq.IsDCQL() && authReq.PresentationDefinition == nil && authReq.PresentationDefinitionURI != "" {
-		pd, err := h.fetchPresentationDefinition(ctx, authReq.PresentationDefinitionURI)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch presentation definition: %w", err)
-		}
-		authReq.PresentationDefinition = pd
 	}
 
 	// Build verifier info with name and logo from metadata
@@ -746,73 +671,10 @@ func (h *OID4VPHandler) fetchClientMetadata(ctx context.Context, uri string) (*C
 	return &cm, nil
 }
 
-func (h *OID4VPHandler) fetchPresentationDefinition(ctx context.Context, uri string) (*PresentationDefinition, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("presentation definition fetch returned status %d", resp.StatusCode)
-	}
-
-	var pd PresentationDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&pd); err != nil {
-		return nil, err
-	}
-
-	return &pd, nil
-}
-
-func (h *OID4VPHandler) extractRequestedClaims(pd *PresentationDefinition) []RequestedClaim {
-	if pd == nil {
-		return nil
-	}
-
-	var claims []RequestedClaim
-	seen := make(map[string]bool)
-
-	for _, desc := range pd.InputDescriptors {
-		if desc.Constraints == nil {
-			continue
-		}
-		for _, field := range desc.Constraints.Fields {
-			for _, path := range field.Path {
-				// Normalize path (remove $. prefix if present)
-				normalizedPath := strings.TrimPrefix(path, "$.")
-				if seen[normalizedPath] {
-					continue
-				}
-				seen[normalizedPath] = true
-				claims = append(claims, RequestedClaim{
-					Path:     normalizedPath,
-					Required: !field.Optional,
-				})
-			}
-		}
-	}
-
-	return claims
-}
-
 func (h *OID4VPHandler) requestCredentialMatching(ctx context.Context, authReq *AuthorizationRequest) ([]CredentialMatch, error) {
 	// Send match_request to client for local matching (privacy-preserving)
 	// The client matches credentials locally and returns only the matching credential IDs/metadata.
-	// Enforce mutual exclusivity: send only one query format.
-	var pd *PresentationDefinition
-	var dcql json.RawMessage
-	if authReq.IsDCQL() {
-		dcql = authReq.DCQLQuery
-	} else {
-		pd = authReq.PresentationDefinition
-	}
-	resp, err := h.RequestMatch(ctx, pd, dcql)
+	resp, err := h.RequestMatch(ctx, authReq.DCQLQuery)
 	if err != nil {
 		if errors.Is(err, ErrMatchTimeout) {
 			h.Logger.Warn("Credential matching timed out")
@@ -836,7 +698,6 @@ func (h *OID4VPHandler) requestConsent(ctx context.Context, matches []Credential
 	matchedCredentials := make([]MatchedCredential, len(matches))
 	for i, m := range matches {
 		matchedCredentials[i] = MatchedCredential{
-			InputDescriptorID: m.InputDescriptorID,
 			CredentialQueryID: m.CredentialQueryID,
 			CredentialID:      m.CredentialID,
 			DisclosableClaims: m.AvailableClaims,
@@ -938,13 +799,6 @@ func (h *OID4VPHandler) submitDirectPost(ctx context.Context, endpoint string, a
 		data.Set("state", authReq.State)
 	}
 
-	// DCQL responses omit presentation_submission (OID4VP §7.3)
-	if !authReq.IsDCQL() {
-		submission := h.buildPresentationSubmission(authReq.PresentationDefinition)
-		submissionJSON, _ := json.Marshal(submission)
-		data.Set("presentation_submission", string(submissionJSON))
-	}
-
 	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", err
@@ -996,27 +850,6 @@ func (h *OID4VPHandler) buildQueryRedirect(endpoint string, authReq *Authorizati
 	}
 	u.RawQuery = q.Encode()
 	return u.String()
-}
-
-func (h *OID4VPHandler) buildPresentationSubmission(pd *PresentationDefinition) map[string]interface{} {
-	if pd == nil {
-		return nil
-	}
-
-	descriptorMap := make([]map[string]interface{}, len(pd.InputDescriptors))
-	for i, desc := range pd.InputDescriptors {
-		descriptorMap[i] = map[string]interface{}{
-			"id":     desc.ID,
-			"format": "jwt_vp",
-			"path":   "$",
-		}
-	}
-
-	return map[string]interface{}{
-		"id":             pd.ID + "_submission",
-		"definition_id":  pd.ID,
-		"descriptor_map": descriptorMap,
-	}
 }
 
 // inferClientIDScheme infers the client_id_scheme from the client_id format

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -65,11 +65,17 @@ type AuthorizationRequest struct {
 	Scope                     string                  `json:"scope,omitempty"`
 	PresentationDefinition    *PresentationDefinition `json:"presentation_definition,omitempty"`
 	PresentationDefinitionURI string                  `json:"presentation_definition_uri,omitempty"`
+	DCQLQuery                 json.RawMessage         `json:"dcql_query,omitempty"`
 	ClientMetadata            *ClientMetadata         `json:"client_metadata,omitempty"`
 	ClientMetadataURI         string                  `json:"client_metadata_uri,omitempty"`
 	// RequestJWT stores the raw request JWT (if the request was JWT-secured).
 	// Used to extract x5c/jwk key material from the JWT header for trust evaluation.
 	RequestJWT string `json:"-"`
+}
+
+// IsDCQL returns true if this request uses a DCQL query instead of a Presentation Definition.
+func (r *AuthorizationRequest) IsDCQL() bool {
+	return len(r.DCQLQuery) > 0
 }
 
 // PresentationDefinition represents a DIF Presentation Definition
@@ -167,15 +173,20 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 	}
 
 	// Step 3: Send parsed request info to client
-	requestedClaims := h.extractRequestedClaims(authReq.PresentationDefinition)
-	_ = h.Progress(StepRequestParsed, map[string]interface{}{
-		"verifier":                verifier,
-		"presentation_definition": authReq.PresentationDefinition,
-		"requested_claims":        requestedClaims,
-	})
+	progressPayload := map[string]interface{}{
+		"verifier": verifier,
+	}
+	if authReq.IsDCQL() {
+		progressPayload["dcql_query"] = authReq.DCQLQuery
+	} else {
+		requestedClaims := h.extractRequestedClaims(authReq.PresentationDefinition)
+		progressPayload["presentation_definition"] = authReq.PresentationDefinition
+		progressPayload["requested_claims"] = requestedClaims
+	}
+	_ = h.Progress(StepRequestParsed, progressPayload)
 
 	// Step 4: Request client-side credential matching (privacy-preserving)
-	matches, err := h.requestCredentialMatching(ctx, authReq.PresentationDefinition)
+	matches, err := h.requestCredentialMatching(ctx, authReq)
 	if err != nil {
 		return err
 	}
@@ -265,6 +276,14 @@ func (h *OID4VPHandler) parseRequestFromURL(u *url.URL) (*AuthorizationRequest, 
 		authReq.PresentationDefinition = &pd
 	}
 	authReq.PresentationDefinitionURI = q.Get("presentation_definition_uri")
+
+	// Parse dcql_query if inline (DCQL takes precedence over presentation_definition)
+	if dcqlStr := q.Get("dcql_query"); dcqlStr != "" {
+		if !json.Valid([]byte(dcqlStr)) {
+			return nil, fmt.Errorf("invalid dcql_query: not valid JSON")
+		}
+		authReq.DCQLQuery = json.RawMessage(dcqlStr)
+	}
 
 	// Parse client_metadata if inline
 	if cmStr := q.Get("client_metadata"); cmStr != "" {
@@ -360,8 +379,8 @@ func (h *OID4VPHandler) evaluateVerifierTrust(ctx context.Context, authReq *Auth
 		}
 	}
 
-	// Fetch presentation_definition if needed
-	if authReq.PresentationDefinition == nil && authReq.PresentationDefinitionURI != "" {
+	// Fetch presentation_definition if needed (not applicable for DCQL)
+	if !authReq.IsDCQL() && authReq.PresentationDefinition == nil && authReq.PresentationDefinitionURI != "" {
 		pd, err := h.fetchPresentationDefinition(ctx, authReq.PresentationDefinitionURI)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch presentation definition: %w", err)
@@ -777,10 +796,10 @@ func (h *OID4VPHandler) extractRequestedClaims(pd *PresentationDefinition) []Req
 	return claims
 }
 
-func (h *OID4VPHandler) requestCredentialMatching(ctx context.Context, pd *PresentationDefinition) ([]CredentialMatch, error) {
+func (h *OID4VPHandler) requestCredentialMatching(ctx context.Context, authReq *AuthorizationRequest) ([]CredentialMatch, error) {
 	// Send match_request to client for local matching (privacy-preserving)
 	// The client matches credentials locally and returns only the matching credential IDs/metadata
-	resp, err := h.RequestMatch(ctx, pd)
+	resp, err := h.RequestMatch(ctx, authReq.PresentationDefinition, authReq.DCQLQuery)
 	if err != nil {
 		if errors.Is(err, ErrMatchTimeout) {
 			h.Logger.Warn("Credential matching timed out")
@@ -805,6 +824,7 @@ func (h *OID4VPHandler) requestConsent(ctx context.Context, matches []Credential
 	for i, m := range matches {
 		matchedCredentials[i] = MatchedCredential{
 			InputDescriptorID: m.InputDescriptorID,
+			CredentialQueryID: m.CredentialQueryID,
 			CredentialID:      m.CredentialID,
 			DisclosableClaims: m.AvailableClaims,
 		}
@@ -905,10 +925,12 @@ func (h *OID4VPHandler) submitDirectPost(ctx context.Context, endpoint string, a
 		data.Set("state", authReq.State)
 	}
 
-	// Build presentation_submission
-	submission := h.buildPresentationSubmission(authReq.PresentationDefinition)
-	submissionJSON, _ := json.Marshal(submission)
-	data.Set("presentation_submission", string(submissionJSON))
+	// DCQL responses omit presentation_submission (OID4VP §7.3)
+	if !authReq.IsDCQL() {
+		submission := h.buildPresentationSubmission(authReq.PresentationDefinition)
+		submissionJSON, _ := json.Marshal(submission)
+		data.Set("presentation_submission", string(submissionJSON))
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(data.Encode()))
 	if err != nil {

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -249,9 +249,9 @@ func TestAuthorizationRequest_IsDCQL(t *testing.T) {
 		{
 			name: "dcql_query is null JSON",
 			req:  AuthorizationRequest{DCQLQuery: json.RawMessage(`null`)},
-			// json.RawMessage("null") has length > 0, but that's the Go convention;
-			// callers provide non-null queries. This tests the raw length check.
-			want: true,
+			// A null JSON value is not a valid DCQL query and should not cause
+			// the request to be classified as DCQL.
+			want: false,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -253,6 +253,11 @@ func TestAuthorizationRequest_IsDCQL(t *testing.T) {
 			// the request to be classified as DCQL.
 			want: false,
 		},
+		{
+			name: "dcql_query is whitespace only",
+			req:  AuthorizationRequest{DCQLQuery: json.RawMessage("  \t\n ")},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -306,6 +311,27 @@ func TestParseRequestFromURL_DCQLQuery(t *testing.T) {
 
 	assert.True(t, authReq.IsDCQL())
 	assert.Nil(t, authReq.PresentationDefinition)
+	assert.JSONEq(t, dcqlJSON, string(authReq.DCQLQuery))
+}
+
+func TestParseRequestFromURL_DCQLClearsPD(t *testing.T) {
+	// When both dcql_query and presentation_definition are present in the URL,
+	// DCQL takes precedence and PD fields must be cleared.
+	pdJSON := `{"id":"test-pd","input_descriptors":[{"id":"id_card"}]}`
+	dcqlJSON := `{"credentials":[{"id":"my_credential","format":"vc+sd-jwt"}]}`
+	u, err := url.Parse("openid4vp://?response_type=vp_token&client_id=https://verifier.example.com" +
+		"&presentation_definition=" + url.QueryEscape(pdJSON) +
+		"&presentation_definition_uri=" + url.QueryEscape("https://example.com/pd") +
+		"&dcql_query=" + url.QueryEscape(dcqlJSON))
+	require.NoError(t, err)
+
+	h := &OID4VPHandler{}
+	authReq, err := h.parseRequestFromURL(u)
+	require.NoError(t, err)
+
+	assert.True(t, authReq.IsDCQL())
+	assert.Nil(t, authReq.PresentationDefinition, "PD should be cleared when DCQL is present")
+	assert.Empty(t, authReq.PresentationDefinitionURI, "PD URI should be cleared when DCQL is present")
 	assert.JSONEq(t, dcqlJSON, string(authReq.DCQLQuery))
 }
 

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -221,50 +221,7 @@ func TestGetCanonicalVerifierURL(t *testing.T) {
 	}
 }
 
-// ===== DCQL support tests =====
-
-func TestAuthorizationRequest_IsDCQL(t *testing.T) {
-	tests := []struct {
-		name string
-		req  AuthorizationRequest
-		want bool
-	}{
-		{
-			name: "dcql_query set",
-			req:  AuthorizationRequest{DCQLQuery: json.RawMessage(`{"credentials":[]}`)},
-			want: true,
-		},
-		{
-			name: "presentation_definition set",
-			req: AuthorizationRequest{PresentationDefinition: &PresentationDefinition{
-				ID: "test", InputDescriptors: []InputDescriptor{{ID: "id_card"}},
-			}},
-			want: false,
-		},
-		{
-			name: "neither set",
-			req:  AuthorizationRequest{},
-			want: false,
-		},
-		{
-			name: "dcql_query is null JSON",
-			req:  AuthorizationRequest{DCQLQuery: json.RawMessage(`null`)},
-			// A null JSON value is not a valid DCQL query and should not cause
-			// the request to be classified as DCQL.
-			want: false,
-		},
-		{
-			name: "dcql_query is whitespace only",
-			req:  AuthorizationRequest{DCQLQuery: json.RawMessage("  \t\n ")},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.req.IsDCQL())
-		})
-	}
-}
+// ===== DCQL query tests =====
 
 func TestCredentialMatch_QueryID(t *testing.T) {
 	tests := []struct {
@@ -273,23 +230,13 @@ func TestCredentialMatch_QueryID(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "DCQL credential_query_id",
+			name:  "credential_query_id set",
 			match: CredentialMatch{CredentialQueryID: "my_credential", CredentialID: "cred-1"},
 			want:  "my_credential",
 		},
 		{
-			name:  "PD input_descriptor_id",
-			match: CredentialMatch{InputDescriptorID: "id_card_desc", CredentialID: "cred-2"},
-			want:  "id_card_desc",
-		},
-		{
-			name:  "DCQL takes precedence",
-			match: CredentialMatch{CredentialQueryID: "dcql_id", InputDescriptorID: "pd_id", CredentialID: "cred-3"},
-			want:  "dcql_id",
-		},
-		{
-			name:  "neither set",
-			match: CredentialMatch{CredentialID: "cred-4"},
+			name:  "not set",
+			match: CredentialMatch{CredentialID: "cred-2"},
 			want:  "",
 		},
 	}
@@ -309,29 +256,7 @@ func TestParseRequestFromURL_DCQLQuery(t *testing.T) {
 	authReq, err := h.parseRequestFromURL(u)
 	require.NoError(t, err)
 
-	assert.True(t, authReq.IsDCQL())
-	assert.Nil(t, authReq.PresentationDefinition)
-	assert.JSONEq(t, dcqlJSON, string(authReq.DCQLQuery))
-}
-
-func TestParseRequestFromURL_DCQLClearsPD(t *testing.T) {
-	// When both dcql_query and presentation_definition are present in the URL,
-	// DCQL takes precedence and PD fields must be cleared.
-	pdJSON := `{"id":"test-pd","input_descriptors":[{"id":"id_card"}]}`
-	dcqlJSON := `{"credentials":[{"id":"my_credential","format":"vc+sd-jwt"}]}`
-	u, err := url.Parse("openid4vp://?response_type=vp_token&client_id=https://verifier.example.com" +
-		"&presentation_definition=" + url.QueryEscape(pdJSON) +
-		"&presentation_definition_uri=" + url.QueryEscape("https://example.com/pd") +
-		"&dcql_query=" + url.QueryEscape(dcqlJSON))
-	require.NoError(t, err)
-
-	h := &OID4VPHandler{}
-	authReq, err := h.parseRequestFromURL(u)
-	require.NoError(t, err)
-
-	assert.True(t, authReq.IsDCQL())
-	assert.Nil(t, authReq.PresentationDefinition, "PD should be cleared when DCQL is present")
-	assert.Empty(t, authReq.PresentationDefinitionURI, "PD URI should be cleared when DCQL is present")
+	assert.NotNil(t, authReq.DCQLQuery)
 	assert.JSONEq(t, dcqlJSON, string(authReq.DCQLQuery))
 }
 
@@ -373,12 +298,12 @@ func TestParseRequestJWT_DCQLQuery(t *testing.T) {
 	authReq, err := h.parseRequestJWT(jwtStr)
 	require.NoError(t, err)
 
-	assert.True(t, authReq.IsDCQL())
+	assert.True(t, len(authReq.DCQLQuery) > 0)
 	assert.JSONEq(t, dcqlJSON, string(authReq.DCQLQuery))
 	assert.Equal(t, "test-nonce", authReq.Nonce)
 }
 
-func TestSubmitDirectPost_DCQL_NoPresentationSubmission(t *testing.T) {
+func TestSubmitDirectPost_NoPresentationSubmission(t *testing.T) {
 	// Verify that DCQL requests don't send presentation_submission
 	var receivedForm url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -404,37 +329,7 @@ func TestSubmitDirectPost_DCQL_NoPresentationSubmission(t *testing.T) {
 
 	assert.Equal(t, "test-vp-token", receivedForm.Get("vp_token"))
 	assert.Equal(t, "test-state", receivedForm.Get("state"))
-	assert.Empty(t, receivedForm.Get("presentation_submission"), "DCQL should not send presentation_submission")
-}
-
-func TestSubmitDirectPost_PD_IncludesPresentationSubmission(t *testing.T) {
-	// Verify that PD requests still send presentation_submission
-	var receivedForm url.Values
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := r.ParseForm()
-		require.NoError(t, err)
-		receivedForm = r.PostForm
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{})
-	}))
-	defer server.Close()
-
-	h := &OID4VPHandler{
-		httpClient: server.Client(),
-	}
-
-	authReq := &AuthorizationRequest{
-		PresentationDefinition: &PresentationDefinition{
-			ID:               "test-pd",
-			InputDescriptors: []InputDescriptor{{ID: "id_card"}},
-		},
-		State: "test-state",
-	}
-
-	_, err := h.submitDirectPost(context.Background(), server.URL, authReq, "test-vp-token")
-	require.NoError(t, err)
-
-	assert.NotEmpty(t, receivedForm.Get("presentation_submission"), "PD should include presentation_submission")
+	assert.Empty(t, receivedForm.Get("presentation_submission"), "should not send presentation_submission")
 }
 
 func TestMatchRequestMessage_DCQLQuery_JSON(t *testing.T) {
@@ -453,32 +348,5 @@ func TestMatchRequestMessage_DCQLQuery_JSON(t *testing.T) {
 	var parsed map[string]interface{}
 	require.NoError(t, json.Unmarshal(data, &parsed))
 
-	// dcql_query should be present
 	assert.NotNil(t, parsed["dcql_query"])
-	// presentation_definition should be absent (omitempty)
-	_, hasPD := parsed["presentation_definition"]
-	assert.False(t, hasPD, "presentation_definition should be omitted for DCQL")
-}
-
-func TestMatchRequestMessage_PD_JSON(t *testing.T) {
-	msg := MatchRequestMessage{
-		Message: Message{
-			Type:   TypeMatchRequest,
-			FlowID: "test-flow",
-		},
-		PresentationDefinition: &PresentationDefinition{
-			ID:               "test-pd",
-			InputDescriptors: []InputDescriptor{{ID: "id_card"}},
-		},
-	}
-
-	data, err := json.Marshal(msg)
-	require.NoError(t, err)
-
-	var parsed map[string]interface{}
-	require.NoError(t, json.Unmarshal(data, &parsed))
-
-	assert.NotNil(t, parsed["presentation_definition"])
-	_, hasDCQL := parsed["dcql_query"]
-	assert.False(t, hasDCQL, "dcql_query should be omitted for PD")
 }

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -1,11 +1,15 @@
 package engine
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -215,4 +219,240 @@ func TestGetCanonicalVerifierURL(t *testing.T) {
 			assert.Equal(t, tt.want, got, tt.description)
 		})
 	}
+}
+
+// ===== DCQL support tests =====
+
+func TestAuthorizationRequest_IsDCQL(t *testing.T) {
+	tests := []struct {
+		name string
+		req  AuthorizationRequest
+		want bool
+	}{
+		{
+			name: "dcql_query set",
+			req:  AuthorizationRequest{DCQLQuery: json.RawMessage(`{"credentials":[]}`)},
+			want: true,
+		},
+		{
+			name: "presentation_definition set",
+			req: AuthorizationRequest{PresentationDefinition: &PresentationDefinition{
+				ID: "test", InputDescriptors: []InputDescriptor{{ID: "id_card"}},
+			}},
+			want: false,
+		},
+		{
+			name: "neither set",
+			req:  AuthorizationRequest{},
+			want: false,
+		},
+		{
+			name: "dcql_query is null JSON",
+			req:  AuthorizationRequest{DCQLQuery: json.RawMessage(`null`)},
+			// json.RawMessage("null") has length > 0, but that's the Go convention;
+			// callers provide non-null queries. This tests the raw length check.
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.req.IsDCQL())
+		})
+	}
+}
+
+func TestCredentialMatch_QueryID(t *testing.T) {
+	tests := []struct {
+		name  string
+		match CredentialMatch
+		want  string
+	}{
+		{
+			name:  "DCQL credential_query_id",
+			match: CredentialMatch{CredentialQueryID: "my_credential", CredentialID: "cred-1"},
+			want:  "my_credential",
+		},
+		{
+			name:  "PD input_descriptor_id",
+			match: CredentialMatch{InputDescriptorID: "id_card_desc", CredentialID: "cred-2"},
+			want:  "id_card_desc",
+		},
+		{
+			name:  "DCQL takes precedence",
+			match: CredentialMatch{CredentialQueryID: "dcql_id", InputDescriptorID: "pd_id", CredentialID: "cred-3"},
+			want:  "dcql_id",
+		},
+		{
+			name:  "neither set",
+			match: CredentialMatch{CredentialID: "cred-4"},
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.match.QueryID())
+		})
+	}
+}
+
+func TestParseRequestFromURL_DCQLQuery(t *testing.T) {
+	dcqlJSON := `{"credentials":[{"id":"my_credential","format":"vc+sd-jwt","meta":{"vct_values":["https://credentials.example.com/identity_credential"]},"claims":[{"path":["$.first_name"]},{"path":["$.last_name"]}]}]}`
+	u, err := url.Parse("openid4vp://?response_type=vp_token&client_id=https://verifier.example.com&dcql_query=" + url.QueryEscape(dcqlJSON))
+	require.NoError(t, err)
+
+	h := &OID4VPHandler{}
+	authReq, err := h.parseRequestFromURL(u)
+	require.NoError(t, err)
+
+	assert.True(t, authReq.IsDCQL())
+	assert.Nil(t, authReq.PresentationDefinition)
+	assert.JSONEq(t, dcqlJSON, string(authReq.DCQLQuery))
+}
+
+func TestParseRequestFromURL_InvalidDCQLQuery(t *testing.T) {
+	u, err := url.Parse("openid4vp://?dcql_query=not-valid-json")
+	require.NoError(t, err)
+
+	h := &OID4VPHandler{}
+	_, err = h.parseRequestFromURL(u)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid dcql_query")
+}
+
+func TestParseRequestJWT_DCQLQuery(t *testing.T) {
+	dcqlJSON := `{"credentials":[{"id":"my_credential","format":"vc+sd-jwt"}]}`
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	headerMap := map[string]any{"alg": "ES256"}
+	headerBytes, _ := json.Marshal(headerMap)
+	header := base64.RawURLEncoding.EncodeToString(headerBytes)
+
+	claims := map[string]any{
+		"client_id":  "https://verifier.example.com",
+		"dcql_query": json.RawMessage(dcqlJSON),
+		"nonce":      "test-nonce",
+	}
+	payloadBytes, _ := json.Marshal(claims)
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+
+	signingInput := header + "." + payload
+	sigBytes, err := jwt.SigningMethodES256.Sign(signingInput, privKey)
+	require.NoError(t, err)
+
+	jwtStr := signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes)
+
+	h := &OID4VPHandler{}
+	authReq, err := h.parseRequestJWT(jwtStr)
+	require.NoError(t, err)
+
+	assert.True(t, authReq.IsDCQL())
+	assert.JSONEq(t, dcqlJSON, string(authReq.DCQLQuery))
+	assert.Equal(t, "test-nonce", authReq.Nonce)
+}
+
+func TestSubmitDirectPost_DCQL_NoPresentationSubmission(t *testing.T) {
+	// Verify that DCQL requests don't send presentation_submission
+	var receivedForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+		require.NoError(t, err)
+		receivedForm = r.PostForm
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{})
+	}))
+	defer server.Close()
+
+	h := &OID4VPHandler{
+		httpClient: server.Client(),
+	}
+
+	authReq := &AuthorizationRequest{
+		DCQLQuery: json.RawMessage(`{"credentials":[{"id":"my_credential"}]}`),
+		State:     "test-state",
+	}
+
+	_, err := h.submitDirectPost(context.Background(), server.URL, authReq, "test-vp-token")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-vp-token", receivedForm.Get("vp_token"))
+	assert.Equal(t, "test-state", receivedForm.Get("state"))
+	assert.Empty(t, receivedForm.Get("presentation_submission"), "DCQL should not send presentation_submission")
+}
+
+func TestSubmitDirectPost_PD_IncludesPresentationSubmission(t *testing.T) {
+	// Verify that PD requests still send presentation_submission
+	var receivedForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+		require.NoError(t, err)
+		receivedForm = r.PostForm
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{})
+	}))
+	defer server.Close()
+
+	h := &OID4VPHandler{
+		httpClient: server.Client(),
+	}
+
+	authReq := &AuthorizationRequest{
+		PresentationDefinition: &PresentationDefinition{
+			ID:               "test-pd",
+			InputDescriptors: []InputDescriptor{{ID: "id_card"}},
+		},
+		State: "test-state",
+	}
+
+	_, err := h.submitDirectPost(context.Background(), server.URL, authReq, "test-vp-token")
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, receivedForm.Get("presentation_submission"), "PD should include presentation_submission")
+}
+
+func TestMatchRequestMessage_DCQLQuery_JSON(t *testing.T) {
+	dcqlJSON := json.RawMessage(`{"credentials":[{"id":"my_credential","format":"vc+sd-jwt"}]}`)
+	msg := MatchRequestMessage{
+		Message: Message{
+			Type:   TypeMatchRequest,
+			FlowID: "test-flow",
+		},
+		DCQLQuery: dcqlJSON,
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	// dcql_query should be present
+	assert.NotNil(t, parsed["dcql_query"])
+	// presentation_definition should be absent (omitempty)
+	_, hasPD := parsed["presentation_definition"]
+	assert.False(t, hasPD, "presentation_definition should be omitted for DCQL")
+}
+
+func TestMatchRequestMessage_PD_JSON(t *testing.T) {
+	msg := MatchRequestMessage{
+		Message: Message{
+			Type:   TypeMatchRequest,
+			FlowID: "test-flow",
+		},
+		PresentationDefinition: &PresentationDefinition{
+			ID:               "test-pd",
+			InputDescriptors: []InputDescriptor{{ID: "id_card"}},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	assert.NotNil(t, parsed["presentation_definition"])
+	_, hasDCQL := parsed["dcql_query"]
+	assert.False(t, hasDCQL, "dcql_query should be omitted for PD")
 }

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -695,7 +695,7 @@ var ErrMatchTimeout = errors.New("credential matching timed out")
 
 // RequestMatch sends a credential matching request and waits for response.
 // This is the privacy-preserving credential matching protocol where the client
-// matches credentials locally against the presentation definition.
+// matches credentials locally against a presentation definition or DCQL query.
 func (s *Session) RequestMatch(ctx context.Context, flowID string, pd *PresentationDefinition, dcql json.RawMessage) (*MatchResponseMessage, error) {
 	messageID := uuid.New().String()
 

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -696,7 +696,7 @@ var ErrMatchTimeout = errors.New("credential matching timed out")
 // RequestMatch sends a credential matching request and waits for response.
 // This is the privacy-preserving credential matching protocol where the client
 // matches credentials locally against the presentation definition.
-func (s *Session) RequestMatch(ctx context.Context, flowID string, pd *PresentationDefinition) (*MatchResponseMessage, error) {
+func (s *Session) RequestMatch(ctx context.Context, flowID string, pd *PresentationDefinition, dcql json.RawMessage) (*MatchResponseMessage, error) {
 	messageID := uuid.New().String()
 
 	msg := MatchRequestMessage{
@@ -707,6 +707,7 @@ func (s *Session) RequestMatch(ctx context.Context, flowID string, pd *Presentat
 			Timestamp: Now(),
 		},
 		PresentationDefinition: pd,
+		DCQLQuery:              dcql,
 	}
 
 	if err := s.Send(&msg); err != nil {

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -695,8 +695,8 @@ var ErrMatchTimeout = errors.New("credential matching timed out")
 
 // RequestMatch sends a credential matching request and waits for response.
 // This is the privacy-preserving credential matching protocol where the client
-// matches credentials locally against a presentation definition or DCQL query.
-func (s *Session) RequestMatch(ctx context.Context, flowID string, pd *PresentationDefinition, dcql json.RawMessage) (*MatchResponseMessage, error) {
+// matches credentials locally against the DCQL query.
+func (s *Session) RequestMatch(ctx context.Context, flowID string, dcql json.RawMessage) (*MatchResponseMessage, error) {
 	messageID := uuid.New().String()
 
 	msg := MatchRequestMessage{
@@ -706,8 +706,7 @@ func (s *Session) RequestMatch(ctx context.Context, flowID string, pd *Presentat
 			MessageID: messageID,
 			Timestamp: Now(),
 		},
-		PresentationDefinition: pd,
-		DCQLQuery:              dcql,
+		DCQLQuery: dcql,
 	}
 
 	if err := s.Send(&msg); err != nil {


### PR DESCRIPTION
## Summary
Add support for DCQL (Digital Credentials Query Language) as an alternative to Presentation Definition in the OID4VP engine flow. All verifiers in the ecosystem use `dcql_query`, but the engine only supported `presentation_definition`, causing the flow to fail.

## Type of change
- [x] Feature

## Changes
1. **`DCQLQuery` on `AuthorizationRequest`** — `json.RawMessage` field, auto-populated from JWT payloads and URL params
2. **`IsDCQL()` helper** — distinguishes DCQL vs PD requests throughout the flow
3. **`MatchRequestMessage`** — now carries either `presentation_definition` or `dcql_query` (mutually exclusive, both `omitempty`)
4. **`CredentialMatch` / `MatchedCredential`** — new `credential_query_id` field alongside existing `input_descriptor_id`; `QueryID()` helper for format-agnostic access
5. **`RequestMatch` signature** — updated to accept both PD and DCQL (`BaseHandler` + `Session`)
6. **`parseRequestFromURL`** — parses `dcql_query` param with JSON validation
7. **`evaluateVerifierTrust`** — skips PD URI fetch when DCQL is present
8. **`submitDirectPost`** — omits `presentation_submission` for DCQL responses (per OID4VP §7.3)
9. **Progress payload** — sends `dcql_query` instead of `presentation_definition`/`requested_claims` for DCQL flows

## Note on vp_token format
For DCQL, the `vp_token` is a JSON object keyed by credential query ID (not a single JWT string). This is handled by the frontend's `sign_presentation` handler, which receives the match results with the correct `credential_query_id` values and constructs the appropriate format.

## Testing
- 11 new tests covering IsDCQL, QueryID, URL/JWT parsing, direct_post behavior, and message serialization
- All existing tests pass (match_test.go updated for new RequestMatch signature)

Closes #127