### PR TITLE
fix: replace VerifierStore trust cache with in-memory TTL cache

### DIFF
--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -19,17 +19,18 @@ type FlowHandler interface {
 }
 
 // FlowHandlerFactory creates a flow handler for a flow
-type FlowHandlerFactory func(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore) (FlowHandler, error)
+type FlowHandlerFactory func(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore, trustCache *TrustCache) (FlowHandler, error)
 
 // BaseHandler provides common functionality for flow handlers
 type BaseHandler struct {
-	Flow      *Flow
-	Config    *config.Config
-	Logger    *zap.Logger
-	TrustSvc  *TrustService
-	Registry  *RegistryClient
-	Verifiers storage.VerifierStore
-	cancel    context.CancelFunc
+	Flow       *Flow
+	Config     *config.Config
+	Logger     *zap.Logger
+	TrustSvc   *TrustService
+	Registry   *RegistryClient
+	Verifiers  storage.VerifierStore
+	TrustCache *TrustCache
+	cancel     context.CancelFunc
 }
 
 // Cancel cancels the flow

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -37,7 +37,7 @@ type OID4VCIHandler struct {
 }
 
 // NewOID4VCIHandler creates a new OID4VCI flow handler
-func NewOID4VCIHandler(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore) (FlowHandler, error) {
+func NewOID4VCIHandler(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore, trustCache *TrustCache) (FlowHandler, error) {
 	return &OID4VCIHandler{
 		BaseHandler: BaseHandler{
 			Flow:     flow,

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -27,15 +26,16 @@ type OID4VPHandler struct {
 }
 
 // NewOID4VPHandler creates a new OID4VP flow handler
-func NewOID4VPHandler(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore) (FlowHandler, error) {
+func NewOID4VPHandler(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore, trustCache *TrustCache) (FlowHandler, error) {
 	return &OID4VPHandler{
 		BaseHandler: BaseHandler{
-			Flow:      flow,
-			Config:    cfg,
-			Logger:    logger,
-			TrustSvc:  trustSvc,
-			Registry:  registry,
-			Verifiers: verifiers,
+			Flow:       flow,
+			Config:     cfg,
+			Logger:     logger,
+			TrustSvc:   trustSvc,
+			Registry:   registry,
+			Verifiers:  verifiers,
+			TrustCache: trustCache,
 		},
 		httpClient: cfg.HTTPClient.NewHTTPClient(0),
 	}, nil
@@ -519,13 +519,13 @@ func (h *OID4VPHandler) evaluateVerifierTrust(ctx context.Context, authReq *Auth
 		verifier.Logo = &LogoInfo{URI: trustResult.Logo}
 	}
 
-	// Cache trust evaluation result (best-effort, don't block the flow)
-	h.cacheVerifierTrust(ctx, authReq, verifier)
+	// Cache trust evaluation result in memory (does not write to VerifierStore)
+	h.cacheVerifierTrust(authReq, verifier)
 
-	// Look up stored verifier to get configured ClientID for VP audience
+	// Look up admin-configured ClientID for VP audience (read-only)
 	canonicalURL := getCanonicalVerifierURL(authReq)
-	if stored := h.getCachedVerifierTrust(ctx, canonicalURL); stored != nil && stored.ClientID != "" {
-		verifier.ClientID = stored.ClientID
+	if clientID := h.getAdminClientID(ctx, canonicalURL); clientID != "" {
+		verifier.ClientID = clientID
 	}
 
 	// Enforce trust decision: block untrusted verifiers
@@ -585,9 +585,9 @@ func getCanonicalVerifierURL(authReq *AuthorizationRequest) string {
 }
 
 // getCachedVerifierTrust checks if a cached trust evaluation exists for the given verifier URL.
-// Returns nil if no cache is available or lookup fails.
-func (h *OID4VPHandler) getCachedVerifierTrust(ctx context.Context, verifierURL string) *domain.Verifier {
-	if h.Verifiers == nil {
+// Returns nil if no cache is available or the entry has expired.
+func (h *OID4VPHandler) getCachedVerifierTrust(verifierURL string) *TrustCacheRecord {
+	if h.TrustCache == nil {
 		return nil
 	}
 
@@ -596,18 +596,33 @@ func (h *OID4VPHandler) getCachedVerifierTrust(ctx context.Context, verifierURL 
 		tenantID = domain.TenantID(h.Flow.Session.TenantID)
 	}
 
-	cached, err := h.Verifiers.GetByURL(ctx, tenantID, verifierURL)
-	if err != nil {
-		return nil // Not found or error — proceed with fresh evaluation
-	}
-	return cached
+	return h.TrustCache.Get(tenantID, verifierURL)
 }
 
-// cacheVerifierTrust persists verifier trust evaluation results for future lookups.
-// This is best-effort — failures are logged but don't affect the flow.
-func (h *OID4VPHandler) cacheVerifierTrust(ctx context.Context, authReq *AuthorizationRequest, verifier *VerifierInfo) {
+// getAdminClientID looks up the admin-configured ClientID for a verifier URL.
+// This is a read-only lookup against the admin VerifierStore.
+func (h *OID4VPHandler) getAdminClientID(ctx context.Context, verifierURL string) string {
 	if h.Verifiers == nil {
-		return // No store available (standalone engine mode)
+		return ""
+	}
+
+	tenantID := domain.TenantID("default")
+	if h.Flow != nil && h.Flow.Session != nil && h.Flow.Session.TenantID != "" {
+		tenantID = domain.TenantID(h.Flow.Session.TenantID)
+	}
+
+	stored, err := h.Verifiers.GetByURL(ctx, tenantID, verifierURL)
+	if err != nil || stored == nil {
+		return ""
+	}
+	return stored.ClientID
+}
+
+// cacheVerifierTrust stores verifier trust evaluation results in the in-memory cache.
+// This avoids writing to VerifierStore, which would pollute the admin registry.
+func (h *OID4VPHandler) cacheVerifierTrust(authReq *AuthorizationRequest, verifier *VerifierInfo) {
+	if h.TrustCache == nil {
+		return
 	}
 
 	tenantID := domain.TenantID("default")
@@ -622,25 +637,14 @@ func (h *OID4VPHandler) cacheVerifierTrust(ctx context.Context, authReq *Authori
 		trustStatus = domain.TrustStatusUntrusted
 	}
 
-	now := time.Now()
-	v := &domain.Verifier{
-		TenantID:         tenantID,
-		Name:             verifier.Name,
-		URL:              getCanonicalVerifierURL(authReq),
-		ClientIDScheme:   authReq.ClientIDScheme,
-		TrustStatus:      trustStatus,
-		TrustFramework:   verifier.Framework,
-		TrustEvaluatedAt: &now,
-	}
-	// Note: ClientID is intentionally NOT set here.
-	// If admin has configured a custom ClientID via the admin API,
-	// the Upsert will preserve it from the existing record.
-
-	if err := h.Verifiers.Upsert(ctx, v); err != nil {
-		h.Logger.Warn("Failed to cache verifier trust result",
-			zap.String("client_id", authReq.ClientID),
-			zap.Error(err))
-	}
+	h.TrustCache.Set(tenantID, getCanonicalVerifierURL(authReq), &TrustCacheRecord{
+		Name:           verifier.Name,
+		URL:            getCanonicalVerifierURL(authReq),
+		ClientIDScheme: authReq.ClientIDScheme,
+		TrustStatus:    trustStatus,
+		TrustFramework: verifier.Framework,
+		Trusted:        verifier.Trusted,
+	})
 }
 
 // extractDomain extracts a domain name from a client_id (URL or DID).

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -347,6 +347,30 @@ func (h *OID4VPHandler) fetchRequestFromURI(ctx context.Context, uri string) (*A
 func (h *OID4VPHandler) evaluateVerifierTrust(ctx context.Context, authReq *AuthorizationRequest) (*VerifierInfo, error) {
 	_ = h.ProgressMessage(StepEvaluatingVerifierTrust, "Evaluating verifier trust")
 
+	// Check in-memory trust cache before triggering frontend evaluation
+	canonicalURL := getCanonicalVerifierURL(authReq)
+	if cached := h.getCachedVerifierTrust(canonicalURL); cached != nil {
+		verifier := &VerifierInfo{
+			Name:           cached.Name,
+			ClientIDScheme: cached.ClientIDScheme,
+			Trusted:        cached.Trusted,
+			Framework:      cached.TrustFramework,
+			TrustedStatus:  string(cached.TrustStatus),
+			Domain:         extractDomain(authReq.ClientID),
+		}
+		// Look up admin-configured ClientID (read-only)
+		if clientID := h.getAdminClientID(ctx, canonicalURL); clientID != "" {
+			verifier.ClientID = clientID
+		}
+		if !verifier.Trusted {
+			return nil, fmt.Errorf("untrusted verifier %s (cached)", authReq.ClientID)
+		}
+		h.Logger.Debug("Using cached trust result",
+			zap.String("verifier", authReq.ClientID),
+			zap.Bool("trusted", cached.Trusted))
+		return verifier, nil
+	}
+
 	// Fetch client metadata if needed
 	var clientMeta *ClientMetadata
 	if authReq.ClientMetadata != nil {
@@ -523,7 +547,6 @@ func (h *OID4VPHandler) evaluateVerifierTrust(ctx context.Context, authReq *Auth
 	h.cacheVerifierTrust(authReq, verifier)
 
 	// Look up admin-configured ClientID for VP audience (read-only)
-	canonicalURL := getCanonicalVerifierURL(authReq)
 	if clientID := h.getAdminClientID(ctx, canonicalURL); clientID != "" {
 		verifier.ClientID = clientID
 	}
@@ -591,7 +614,7 @@ func (h *OID4VPHandler) getCachedVerifierTrust(verifierURL string) *TrustCacheRe
 		return nil
 	}
 
-	tenantID := domain.TenantID("default")
+	tenantID := domain.DefaultTenantID
 	if h.Flow != nil && h.Flow.Session != nil && h.Flow.Session.TenantID != "" {
 		tenantID = domain.TenantID(h.Flow.Session.TenantID)
 	}
@@ -606,7 +629,7 @@ func (h *OID4VPHandler) getAdminClientID(ctx context.Context, verifierURL string
 		return ""
 	}
 
-	tenantID := domain.TenantID("default")
+	tenantID := domain.DefaultTenantID
 	if h.Flow != nil && h.Flow.Session != nil && h.Flow.Session.TenantID != "" {
 		tenantID = domain.TenantID(h.Flow.Session.TenantID)
 	}
@@ -625,7 +648,7 @@ func (h *OID4VPHandler) cacheVerifierTrust(authReq *AuthorizationRequest, verifi
 		return
 	}
 
-	tenantID := domain.TenantID("default")
+	tenantID := domain.DefaultTenantID
 	if h.Flow != nil && h.Flow.Session != nil && h.Flow.Session.TenantID != "" {
 		tenantID = domain.TenantID(h.Flow.Session.TenantID)
 	}

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -78,6 +78,7 @@ type Manager struct {
 	trustService   *TrustService
 	registryClient *RegistryClient
 	verifierStore  storage.VerifierStore
+	trustCache     *TrustCache
 
 	// Persistent session store (optional, for horizontal scaling)
 	sessionStore SessionStore
@@ -101,6 +102,7 @@ func NewManager(cfg *config.Config, logger *zap.Logger) *Manager {
 		flowHandlers:   make(map[Protocol]FlowHandlerFactory),
 		trustService:   NewTrustService(cfg, logger),
 		registryClient: NewRegistryClient(cfg, logger),
+		trustCache:     NewTrustCache(1 * time.Hour),
 		sessionStore:   NewMemorySessionStore(logger), // Default to memory
 	}
 	return m
@@ -375,7 +377,7 @@ func (m *Manager) handleFlowStart(session *Session, msg *FlowStartMessage) {
 	session.flowsMu.Unlock()
 
 	// Create handler (after releasing lock to avoid holding it during potentially slow operations)
-	handler, err := factory(flow, m.cfg, logger, m.trustService, m.registryClient, m.verifierStore)
+	handler, err := factory(flow, m.cfg, logger, m.trustService, m.registryClient, m.verifierStore, m.trustCache)
 	if err != nil {
 		// Remove the reserved flow slot on error
 		session.flowsMu.Lock()

--- a/internal/engine/trust_cache.go
+++ b/internal/engine/trust_cache.go
@@ -1,0 +1,85 @@
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
+)
+
+// TrustCacheEntry holds a cached trust evaluation result with expiry.
+type TrustCacheEntry struct {
+	Verifier  *TrustCacheRecord
+	ExpiresAt time.Time
+}
+
+// TrustCacheRecord stores the trust evaluation fields that are cached in memory.
+type TrustCacheRecord struct {
+	Name           string
+	URL            string
+	ClientIDScheme string
+	TrustStatus    domain.TrustStatus
+	TrustFramework string
+	Trusted        bool
+}
+
+// TrustCache is a tenant-aware, in-memory TTL cache for verifier trust evaluations.
+// It replaces the previous approach of writing to VerifierStore (which polluted the admin registry).
+type TrustCache struct {
+	mu      sync.RWMutex
+	entries map[string]*TrustCacheEntry // key: tenantID + "|" + verifierURL
+	ttl     time.Duration
+}
+
+// NewTrustCache creates a new in-memory trust cache with the given TTL.
+func NewTrustCache(ttl time.Duration) *TrustCache {
+	return &TrustCache{
+		entries: make(map[string]*TrustCacheEntry),
+		ttl:     ttl,
+	}
+}
+
+func trustCacheKey(tenantID domain.TenantID, verifierURL string) string {
+	return string(tenantID) + "|" + verifierURL
+}
+
+// Get retrieves a cached trust record for the given tenant and verifier URL.
+// Returns nil if not found or expired.
+func (c *TrustCache) Get(tenantID domain.TenantID, verifierURL string) *TrustCacheRecord {
+	key := trustCacheKey(tenantID, verifierURL)
+
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+
+	if !ok {
+		return nil
+	}
+	if time.Now().After(entry.ExpiresAt) {
+		// Expired — remove lazily
+		c.mu.Lock()
+		delete(c.entries, key)
+		c.mu.Unlock()
+		return nil
+	}
+	return entry.Verifier
+}
+
+// Set stores a trust evaluation result in the cache.
+func (c *TrustCache) Set(tenantID domain.TenantID, verifierURL string, record *TrustCacheRecord) {
+	key := trustCacheKey(tenantID, verifierURL)
+
+	c.mu.Lock()
+	c.entries[key] = &TrustCacheEntry{
+		Verifier:  record,
+		ExpiresAt: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+}
+
+// Len returns the number of entries (including potentially expired ones).
+func (c *TrustCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}

--- a/internal/engine/trust_cache.go
+++ b/internal/engine/trust_cache.go
@@ -29,6 +29,7 @@ type TrustCache struct {
 	mu      sync.RWMutex
 	entries map[string]*TrustCacheEntry // key: tenantID + "|" + verifierURL
 	ttl     time.Duration
+	now     func() time.Time // injectable clock for testing
 }
 
 // NewTrustCache creates a new in-memory trust cache with the given TTL.
@@ -36,6 +37,7 @@ func NewTrustCache(ttl time.Duration) *TrustCache {
 	return &TrustCache{
 		entries: make(map[string]*TrustCacheEntry),
 		ttl:     ttl,
+		now:     time.Now,
 	}
 }
 
@@ -55,7 +57,7 @@ func (c *TrustCache) Get(tenantID domain.TenantID, verifierURL string) *TrustCac
 	if !ok {
 		return nil
 	}
-	if time.Now().After(entry.ExpiresAt) {
+	if c.now().After(entry.ExpiresAt) {
 		// Expired — remove lazily
 		c.mu.Lock()
 		delete(c.entries, key)
@@ -66,13 +68,21 @@ func (c *TrustCache) Get(tenantID domain.TenantID, verifierURL string) *TrustCac
 }
 
 // Set stores a trust evaluation result in the cache.
+// Also sweeps expired entries to prevent unbounded growth.
 func (c *TrustCache) Set(tenantID domain.TenantID, verifierURL string, record *TrustCacheRecord) {
 	key := trustCacheKey(tenantID, verifierURL)
+	now := c.now()
 
 	c.mu.Lock()
 	c.entries[key] = &TrustCacheEntry{
 		Verifier:  record,
-		ExpiresAt: time.Now().Add(c.ttl),
+		ExpiresAt: now.Add(c.ttl),
+	}
+	// Sweep expired entries opportunistically on each Set to prevent unbounded growth
+	for k, e := range c.entries {
+		if now.After(e.ExpiresAt) {
+			delete(c.entries, k)
+		}
 	}
 	c.mu.Unlock()
 }

--- a/internal/engine/trust_cache_test.go
+++ b/internal/engine/trust_cache_test.go
@@ -1,0 +1,144 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
+)
+
+func TestTrustCache_SetAndGet(t *testing.T) {
+	cache := NewTrustCache(1 * time.Hour)
+	tenant := domain.TenantID("test-tenant")
+
+	record := &TrustCacheRecord{
+		Name:           "Test Verifier",
+		URL:            "https://verifier.example.com/response",
+		ClientIDScheme: "redirect_uri",
+		TrustStatus:    domain.TrustStatusTrusted,
+		TrustFramework: "eidas",
+		Trusted:        true,
+	}
+
+	cache.Set(tenant, "https://verifier.example.com/response", record)
+
+	got := cache.Get(tenant, "https://verifier.example.com/response")
+	if got == nil {
+		t.Fatal("expected cached record, got nil")
+	}
+	if got.Name != "Test Verifier" {
+		t.Errorf("Name = %q, want %q", got.Name, "Test Verifier")
+	}
+	if got.TrustStatus != domain.TrustStatusTrusted {
+		t.Errorf("TrustStatus = %q, want %q", got.TrustStatus, domain.TrustStatusTrusted)
+	}
+	if !got.Trusted {
+		t.Error("Trusted = false, want true")
+	}
+}
+
+func TestTrustCache_GetMiss(t *testing.T) {
+	cache := NewTrustCache(1 * time.Hour)
+	tenant := domain.TenantID("test-tenant")
+
+	got := cache.Get(tenant, "https://unknown.example.com")
+	if got != nil {
+		t.Errorf("expected nil for unknown key, got %+v", got)
+	}
+}
+
+func TestTrustCache_TenantIsolation(t *testing.T) {
+	cache := NewTrustCache(1 * time.Hour)
+	url := "https://verifier.example.com"
+
+	cache.Set("tenant-a", url, &TrustCacheRecord{
+		Name:    "Verifier A",
+		Trusted: true,
+	})
+	cache.Set("tenant-b", url, &TrustCacheRecord{
+		Name:    "Verifier B",
+		Trusted: false,
+	})
+
+	a := cache.Get("tenant-a", url)
+	b := cache.Get("tenant-b", url)
+
+	if a == nil || a.Name != "Verifier A" || !a.Trusted {
+		t.Errorf("tenant-a record wrong: %+v", a)
+	}
+	if b == nil || b.Name != "Verifier B" || b.Trusted {
+		t.Errorf("tenant-b record wrong: %+v", b)
+	}
+}
+
+func TestTrustCache_Expiry(t *testing.T) {
+	cache := NewTrustCache(1 * time.Millisecond) // Very short TTL
+	tenant := domain.TenantID("test")
+
+	cache.Set(tenant, "https://verifier.example.com", &TrustCacheRecord{
+		Name:    "Expiring",
+		Trusted: true,
+	})
+
+	// Should be present immediately
+	if got := cache.Get(tenant, "https://verifier.example.com"); got == nil {
+		t.Fatal("expected record immediately after set")
+	}
+
+	// Wait for expiry
+	time.Sleep(5 * time.Millisecond)
+
+	got := cache.Get(tenant, "https://verifier.example.com")
+	if got != nil {
+		t.Errorf("expected nil after expiry, got %+v", got)
+	}
+
+	// Verify entry was cleaned up
+	if cache.Len() != 0 {
+		t.Errorf("expected 0 entries after expired get, got %d", cache.Len())
+	}
+}
+
+func TestTrustCache_Overwrite(t *testing.T) {
+	cache := NewTrustCache(1 * time.Hour)
+	tenant := domain.TenantID("test")
+	url := "https://verifier.example.com"
+
+	cache.Set(tenant, url, &TrustCacheRecord{
+		Name:        "Old",
+		TrustStatus: domain.TrustStatusUntrusted,
+		Trusted:     false,
+	})
+	cache.Set(tenant, url, &TrustCacheRecord{
+		Name:        "New",
+		TrustStatus: domain.TrustStatusTrusted,
+		Trusted:     true,
+	})
+
+	got := cache.Get(tenant, url)
+	if got == nil {
+		t.Fatal("expected record after overwrite")
+	}
+	if got.Name != "New" {
+		t.Errorf("Name = %q, want %q", got.Name, "New")
+	}
+	if !got.Trusted {
+		t.Error("Trusted = false, want true after overwrite")
+	}
+}
+
+func TestTrustCache_Len(t *testing.T) {
+	cache := NewTrustCache(1 * time.Hour)
+
+	if cache.Len() != 0 {
+		t.Errorf("Len() = %d, want 0 for empty cache", cache.Len())
+	}
+
+	cache.Set("t1", "url1", &TrustCacheRecord{Name: "a"})
+	cache.Set("t1", "url2", &TrustCacheRecord{Name: "b"})
+	cache.Set("t2", "url1", &TrustCacheRecord{Name: "c"})
+
+	if cache.Len() != 3 {
+		t.Errorf("Len() = %d, want 3", cache.Len())
+	}
+}

--- a/internal/engine/trust_cache_test.go
+++ b/internal/engine/trust_cache_test.go
@@ -72,8 +72,12 @@ func TestTrustCache_TenantIsolation(t *testing.T) {
 }
 
 func TestTrustCache_Expiry(t *testing.T) {
-	cache := NewTrustCache(1 * time.Millisecond) // Very short TTL
+	cache := NewTrustCache(1 * time.Hour)
 	tenant := domain.TenantID("test")
+
+	// Use injectable clock to avoid flaky time.Sleep-based tests
+	fakeNow := time.Now()
+	cache.now = func() time.Time { return fakeNow }
 
 	cache.Set(tenant, "https://verifier.example.com", &TrustCacheRecord{
 		Name:    "Expiring",
@@ -85,8 +89,8 @@ func TestTrustCache_Expiry(t *testing.T) {
 		t.Fatal("expected record immediately after set")
 	}
 
-	// Wait for expiry
-	time.Sleep(5 * time.Millisecond)
+	// Advance clock past TTL
+	fakeNow = fakeNow.Add(2 * time.Hour)
 
 	got := cache.Get(tenant, "https://verifier.example.com")
 	if got != nil {
@@ -140,5 +144,35 @@ func TestTrustCache_Len(t *testing.T) {
 
 	if cache.Len() != 3 {
 		t.Errorf("Len() = %d, want 3", cache.Len())
+	}
+}
+
+func TestTrustCache_SweepOnSet(t *testing.T) {
+	cache := NewTrustCache(1 * time.Hour)
+
+	fakeNow := time.Now()
+	cache.now = func() time.Time { return fakeNow }
+
+	// Add some entries
+	cache.Set("t1", "url1", &TrustCacheRecord{Name: "a"})
+	cache.Set("t1", "url2", &TrustCacheRecord{Name: "b"})
+	cache.Set("t2", "url1", &TrustCacheRecord{Name: "c"})
+
+	if cache.Len() != 3 {
+		t.Fatalf("Len() = %d, want 3 before sweep", cache.Len())
+	}
+
+	// Advance clock past TTL so all existing entries are expired
+	fakeNow = fakeNow.Add(2 * time.Hour)
+
+	// Set a new entry — this should sweep the 3 expired entries
+	cache.Set("t3", "url3", &TrustCacheRecord{Name: "d"})
+
+	// Only the new entry should remain
+	if cache.Len() != 1 {
+		t.Errorf("Len() = %d, want 1 after sweep-on-set", cache.Len())
+	}
+	if got := cache.Get("t3", "url3"); got == nil || got.Name != "d" {
+		t.Errorf("new entry missing after sweep, got %+v", got)
 	}
 }

--- a/internal/engine/vctm.go
+++ b/internal/engine/vctm.go
@@ -23,7 +23,7 @@ type VCTMHandler struct {
 }
 
 // NewVCTMHandler creates a new VCTM flow handler
-func NewVCTMHandler(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore) (FlowHandler, error) {
+func NewVCTMHandler(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore, trustCache *TrustCache) (FlowHandler, error) {
 	// Get registry URL from config, or use default
 	registryURL := cfg.Trust.RegistryURL
 	if registryURL == "" {


### PR DESCRIPTION
## Summary

The OID4VP engine was writing trust evaluation results to `VerifierStore` via `Upsert()`, polluting the admin verifier registry. `GET /verifier/all` returned auto-cached entries alongside admin-registered verifiers.

## Changes

- **New `TrustCache`** — in-memory, tenant-aware, TTL-based (1h) cache in `internal/engine/trust_cache.go`
- **`cacheVerifierTrust()`** — now writes to `TrustCache` instead of `VerifierStore` (no DB writes)
- **`getCachedVerifierTrust()`** — reads from in-memory cache
- **New `getAdminClientID()`** — read-only lookup against admin `VerifierStore` for configured ClientID
- **`FlowHandlerFactory`** signature updated to pass `*TrustCache` alongside `VerifierStore`
- **6 new tests** covering TTL expiry, tenant isolation, overwrite, etc.

## Result

- `VerifierStore` is now read-only from the engine — only used for admin ClientID lookups
- `GET /verifier/all` returns only admin-registered verifiers (no ephemeral trust entries)
- All 169 engine tests pass; all 21 packages pass

Closes #129