### PR TITLE
feat(vp): consolidate credential matching+consent into single credential_selection round-trip

### DIFF
--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -66,6 +66,7 @@ const (
 	StepEvaluatingVerifierTrust FlowStep = "evaluating_verifier_trust"
 	StepMatchCredentials        FlowStep = "match_credentials"
 	StepAwaitingConsent         FlowStep = "awaiting_consent"
+	StepCredentialSelection     FlowStep = "credential_selection"
 	StepSubmittingResponse      FlowStep = "submitting_response"
 )
 

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -134,7 +134,7 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 		return err
 	}
 
-	// Step 6: Request VP signing from client (use configured ClientID for audience if set)
+	// Step 4: Request VP signing from client (use configured ClientID for audience if set)
 	vpToken, err := h.requestVPSignature(ctx, authReq, selectedCredentials, verifier.ClientID)
 	if err != nil {
 		h.Logger.Debug("VP signature failed", zap.Error(err))
@@ -142,7 +142,7 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 		return err
 	}
 
-	// Step 7: Submit VP response to verifier
+	// Step 5: Submit VP response to verifier
 	redirectURI, err := h.submitResponse(ctx, authReq, vpToken)
 	if err != nil {
 		h.Logger.Debug("VP submission failed", zap.Error(err))
@@ -150,7 +150,7 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 		return err
 	}
 
-	// Step 8: Complete
+	// Step 6: Complete
 	return h.Complete(nil, redirectURI)
 }
 
@@ -716,6 +716,7 @@ func (h *OID4VPHandler) requestCredentialSelection(ctx context.Context, authReq 
 
 	var payload ConsentPayload
 	if err := json.Unmarshal(action.Payload, &payload); err != nil {
+		_ = h.Error(StepCredentialSelection, ErrCodeInvalidMessage, "Invalid consent payload")
 		return nil, fmt.Errorf("invalid consent payload: %w", err)
 	}
 

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -128,25 +128,8 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 		return err
 	}
 
-	// Step 3: Send parsed request info to client
-	_ = h.Progress(StepRequestParsed, map[string]interface{}{
-		"verifier":   verifier,
-		"dcql_query": authReq.DCQLQuery,
-	})
-
-	// Step 4: Request client-side credential matching (privacy-preserving)
-	matches, err := h.requestCredentialMatching(ctx, authReq)
-	if err != nil {
-		return err
-	}
-
-	if len(matches) == 0 {
-		_ = h.Error(StepMatchCredentials, ErrCodePresentationError, "No matching credentials found")
-		return errors.New("no matching credentials")
-	}
-
-	// Step 5: Request user consent
-	selectedCredentials, err := h.requestConsent(ctx, matches, verifier)
+	// Step 3: Send credential_selection with dcql_query + verifier; wait for consent or decline
+	selectedCredentials, err := h.requestCredentialSelection(ctx, authReq, verifier)
 	if err != nil {
 		return err
 	}
@@ -707,50 +690,15 @@ func (h *OID4VPHandler) fetchClientMetadata(ctx context.Context, uri string) (*C
 	return &cm, nil
 }
 
-func (h *OID4VPHandler) requestCredentialMatching(ctx context.Context, authReq *AuthorizationRequest) ([]CredentialMatch, error) {
-	// Send match_request to client for local matching (privacy-preserving)
-	// The client matches credentials locally and returns only the matching credential IDs/metadata.
-	resp, err := h.RequestMatch(ctx, authReq.DCQLQuery)
-	if err != nil {
-		if errors.Is(err, ErrMatchTimeout) {
-			h.Logger.Warn("Credential matching timed out")
-			// Notify client that matching timed out so UI can show appropriate message
-			_ = h.Error(StepMatchCredentials, ErrCodeMatchTimeout, "Credential matching timed out")
-			return nil, err
-		}
-		h.Logger.Debug("Credential matching failed", zap.Error(err))
-		return nil, err
-	}
-
-	if resp.NoMatchReason != "" {
-		h.Logger.Info("No credentials matched", zap.String("reason", resp.NoMatchReason))
-	}
-
-	return resp.Matches, nil
-}
-
-func (h *OID4VPHandler) requestConsent(ctx context.Context, matches []CredentialMatch, verifier *VerifierInfo) ([]ConsentSelection, error) {
-	// Build matched credentials display
-	matchedCredentials := make([]MatchedCredential, len(matches))
-	for i, m := range matches {
-		matchedCredentials[i] = MatchedCredential{
-			CredentialQueryID: m.CredentialQueryID,
-			CredentialID:      m.CredentialID,
-			DisclosableClaims: m.AvailableClaims,
-		}
-
-		// Fetch credential display from VCTM if available
-		if m.VCT != "" && h.Registry != nil {
-			matchedCredentials[i].CredentialDisplay = h.Registry.FetchTypeMetadataJSON(ctx, m.VCT)
-		}
-	}
-
-	_ = h.Progress(StepAwaitingConsent, map[string]interface{}{
-		"matched_credentials": matchedCredentials,
-		"verifier":            verifier,
+// requestCredentialSelection sends dcql_query + verifier to the client in a single
+// credential_selection progress message and waits for the user to consent or decline.
+// The frontend is responsible for local credential matching and the consent UI.
+func (h *OID4VPHandler) requestCredentialSelection(ctx context.Context, authReq *AuthorizationRequest, verifier *VerifierInfo) ([]ConsentSelection, error) {
+	_ = h.Progress(StepCredentialSelection, map[string]interface{}{
+		"dcql_query": authReq.DCQLQuery,
+		"verifier":   verifier,
 	})
 
-	// Wait for consent or decline
 	action, err := h.WaitForAction(ctx, ActionConsent, ActionDecline)
 	if err != nil {
 		return nil, err
@@ -762,13 +710,18 @@ func (h *OID4VPHandler) requestConsent(ctx context.Context, matches []Credential
 		}
 		_ = json.Unmarshal(action.Payload, &decline)
 		h.Logger.Info("user declined presentation", zap.String("reason", decline.Reason))
-		_ = h.Error(StepAwaitingConsent, ErrCodePresentationError, "User declined the request")
+		_ = h.Error(StepCredentialSelection, ErrCodePresentationError, "User declined the request")
 		return nil, errors.New("user declined presentation")
 	}
 
 	var payload ConsentPayload
 	if err := json.Unmarshal(action.Payload, &payload); err != nil {
 		return nil, fmt.Errorf("invalid consent payload: %w", err)
+	}
+
+	if len(payload.SelectedCredentials) == 0 {
+		_ = h.Error(StepCredentialSelection, ErrCodePresentationError, "No credentials selected")
+		return nil, errors.New("no credentials selected")
 	}
 
 	return payload.SelectedCredentials, nil


### PR DESCRIPTION
## Summary

Implements #135 — consolidates the two-step VP credential matching + consent flow into a single `credential_selection` round-trip.

## Before

The OID4VP flow had two separate message exchanges:
1. **Step 4** — Server sends `match_request` with DCQL query; client responds with `match_response` (matched credential IDs)
2. **Step 5** — Server sends `awaiting_consent` progress with matched credentials + verifier info; client responds with `consent` or `decline` action

This required the client to do local matching, report back to the server, and then receive a second progress message before showing the consent UI.

## After

A single **`credential_selection`** `flow_progress` message carries both `dcql_query` and `verifier` info. The client:
1. Receives `credential_selection` with query + verifier in one message
2. Does local credential matching entirely client-side
3. Presents the consent UI
4. Sends `consent` (with selected credentials) or `decline` directly

## Changes

- **`internal/engine/messages.go`**: Add `StepCredentialSelection FlowStep = "credential_selection"`
- **`internal/engine/oid4vp.go`**:
  - Replace `requestCredentialMatching` + `requestConsent` with a single `requestCredentialSelection` method
  - Remove redundant `StepRequestParsed` progress (same data is now in `credential_selection`)
  - Validate non-empty `SelectedCredentials` before proceeding to VP signing
  - Remove dead `match_request`/`match_response` round-trip code

## Testing

All 178 engine tests pass. `go build ./...` and `go vet ./...` clean.