### PR TITLE
feat: support multiple WebAuthn RP origins (rp_origins)

### DIFF
--- a/configs/config.production.yaml
+++ b/configs/config.production.yaml
@@ -12,6 +12,12 @@ server:
   registry_port: 8097
   rp_id: "wallet.example.com"
   rp_origin: "https://wallet.example.com"
+  # rp_origins allows multiple WebAuthn RP origins (e.g. for Android/iOS native app wrappers).
+  # When set, these are combined with rp_origin (if present) and deduplicated.
+  # Use rp_origins alone or alongside rp_origin for a gradual migration; at least one must be set.
+  # rp_origins:
+  #   - "https://wallet.example.com"
+  #   - "android:apk-key-hash:YOUR_APK_KEY_HASH_HERE"
   rp_name: "Example Wallet"
   base_url: "https://wallet.example.com"
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -10,6 +10,12 @@ server:
   registry_port: 8097
   rp_id: "localhost"
   rp_origin: "http://localhost:8080"
+  # rp_origins allows multiple WebAuthn RP origins (e.g. for native app wrappers).
+  # When set, these are combined with rp_origin (if present) and deduplicated.
+  # Use rp_origins alone or together with rp_origin; at least one must be set.
+  # rp_origins:
+  #   - "http://localhost:8080"
+  #   - "android:apk-key-hash:abc123def456"
   rp_name: "Wallet Backend"
   base_url: "http://localhost:8080"
 

--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -61,7 +61,7 @@ func NewWebAuthnServiceWithValidator(store storage.Store, cfg *config.Config, lo
 	wconfig := &webauthn.Config{
 		RPDisplayName: cfg.Server.RPName,
 		RPID:          cfg.Server.RPID,
-		RPOrigins:     []string{cfg.Server.RPOrigin},
+		RPOrigins:     cfg.Server.GetRPOrigins(),
 	}
 
 	wa, err := webauthn.New(wconfig)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,13 +82,13 @@ type ServerConfig struct {
 	RegistryPort   int    `yaml:"registry_port" envconfig:"REGISTRY_PORT"`       // VCTM registry port (defaults to 8097)
 	AdminToken     string `yaml:"admin_token" envconfig:"ADMIN_TOKEN"`           // Bearer token for admin API (auto-generated if empty)
 	AdminTokenPath string `yaml:"admin_token_path" envconfig:"ADMIN_TOKEN_PATH"` // Path to file containing admin token
-	RPID      string `yaml:"rp_id" envconfig:"RP_ID"`
+	RPID           string `yaml:"rp_id" envconfig:"RP_ID"`
 	// RPOrigin is the legacy single-origin setting. Kept for backward compatibility.
 	// New deployments should use RPOrigins. When both are set, RPOrigin is prepended.
 	RPOrigin  string   `yaml:"rp_origin" envconfig:"RP_ORIGIN"`
 	RPOrigins []string `yaml:"rp_origins" envconfig:"RP_ORIGINS"`
 	RPName    string   `yaml:"rp_name" envconfig:"RP_NAME"`
-	BaseURL        string `yaml:"base_url" envconfig:"BASE_URL"`
+	BaseURL   string   `yaml:"base_url" envconfig:"BASE_URL"`
 
 	// CORS configuration
 	CORS CORSConfig `yaml:"cors" envconfig:"CORS"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,9 +82,12 @@ type ServerConfig struct {
 	RegistryPort   int    `yaml:"registry_port" envconfig:"REGISTRY_PORT"`       // VCTM registry port (defaults to 8097)
 	AdminToken     string `yaml:"admin_token" envconfig:"ADMIN_TOKEN"`           // Bearer token for admin API (auto-generated if empty)
 	AdminTokenPath string `yaml:"admin_token_path" envconfig:"ADMIN_TOKEN_PATH"` // Path to file containing admin token
-	RPID           string `yaml:"rp_id" envconfig:"RP_ID"`
-	RPOrigin       string `yaml:"rp_origin" envconfig:"RP_ORIGIN"`
-	RPName         string `yaml:"rp_name" envconfig:"RP_NAME"`
+	RPID      string `yaml:"rp_id" envconfig:"RP_ID"`
+	// RPOrigin is the legacy single-origin setting. Kept for backward compatibility.
+	// New deployments should use RPOrigins. When both are set, RPOrigin is prepended.
+	RPOrigin  string   `yaml:"rp_origin" envconfig:"RP_ORIGIN"`
+	RPOrigins []string `yaml:"rp_origins" envconfig:"RP_ORIGINS"`
+	RPName    string   `yaml:"rp_name" envconfig:"RP_NAME"`
 	BaseURL        string `yaml:"base_url" envconfig:"BASE_URL"`
 
 	// CORS configuration
@@ -163,6 +166,25 @@ type CORSConfig struct {
 
 	// MaxAge indicates how long (in seconds) the results of a preflight request can be cached.
 	MaxAge int `yaml:"max_age" envconfig:"MAX_AGE"`
+}
+
+// GetRPOrigins returns the deduplicated list of WebAuthn RP origins.
+// RPOrigin (legacy single-value field) is prepended when non-empty,
+// so existing deployments continue to work without any config change.
+func (c *ServerConfig) GetRPOrigins() []string {
+	seen := make(map[string]struct{})
+	var result []string
+	for _, o := range append([]string{c.RPOrigin}, c.RPOrigins...) {
+		if o == "" {
+			continue
+		}
+		if _, dup := seen[o]; dup {
+			continue
+		}
+		seen[o] = struct{}{}
+		result = append(result, o)
+	}
+	return result
 }
 
 // SetDefaults sets default values for CORS configuration
@@ -705,6 +727,7 @@ func defaultConfig() *Config {
 			RegistryPort: 8097, // VCTM registry port
 			RPID:         "localhost",
 			RPOrigin:     "http://localhost:8080",
+			RPOrigins:    nil,
 			RPName:       "Wallet Backend",
 			CORS:         corsConfig,
 		},
@@ -786,8 +809,8 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("rp_id is required")
 	}
 
-	if c.Server.RPOrigin == "" {
-		return fmt.Errorf("rp_origin is required")
+	if c.Server.RPOrigin == "" && len(c.Server.RPOrigins) == 0 {
+		return fmt.Errorf("rp_origin or rp_origins is required")
 	}
 
 	// Validate TLS configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -809,7 +809,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("rp_id is required")
 	}
 
-	if c.Server.RPOrigin == "" && len(c.Server.RPOrigins) == 0 {
+	if len(c.Server.GetRPOrigins()) == 0 {
 		return fmt.Errorf("rp_origin or rp_origins is required")
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -148,11 +148,22 @@ func TestServerConfig_GetRPOrigins(t *testing.T) {
 			cfg:       ServerConfig{},
 			wantOrder: nil,
 		},
+		{
+			name:      "list of only empty strings is treated as empty",
+			cfg:       ServerConfig{RPOrigins: []string{"", ""}},
+			wantOrder: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.cfg.GetRPOrigins()
+			if tt.wantOrder == nil {
+				if got != nil {
+					t.Fatalf("GetRPOrigins() = %v, want nil", got)
+				}
+				return
+			}
 			if len(got) != len(tt.wantOrder) {
 				t.Fatalf("GetRPOrigins() = %v, want %v", got, tt.wantOrder)
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -81,6 +81,7 @@ func TestConfig_Validate_MissingRPOrigin(t *testing.T) {
 			Port:     8080,
 			RPID:     "localhost",
 			RPOrigin: "",
+			// RPOrigins also empty
 		},
 		Storage: StorageConfig{Type: "memory"},
 		JWT:     JWTConfig{Secret: "test"},
@@ -88,7 +89,79 @@ func TestConfig_Validate_MissingRPOrigin(t *testing.T) {
 
 	err := cfg.Validate()
 	if err == nil {
-		t.Error("Expected validation error for missing RPOrigin")
+		t.Error("Expected validation error when both rp_origin and rp_origins are empty")
+	}
+}
+
+func TestConfig_Validate_RPOriginsAlone(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{
+			Host:      "localhost",
+			Port:      8080,
+			RPID:      "localhost",
+			RPOrigin:  "",
+			RPOrigins: []string{"https://id.example.com", "android:apk-key-hash:abc123"},
+		},
+		Storage: StorageConfig{Type: "memory"},
+		JWT:     JWTConfig{Secret: "test"},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Expected no validation error with rp_origins set, got: %v", err)
+	}
+}
+
+func TestServerConfig_GetRPOrigins(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       ServerConfig
+		wantOrder []string
+	}{
+		{
+			name:      "legacy single origin only",
+			cfg:       ServerConfig{RPOrigin: "https://id.example.com"},
+			wantOrder: []string{"https://id.example.com"},
+		},
+		{
+			name:      "new list only",
+			cfg:       ServerConfig{RPOrigins: []string{"https://a.example.com", "https://b.example.com"}},
+			wantOrder: []string{"https://a.example.com", "https://b.example.com"},
+		},
+		{
+			name: "legacy prepended to list",
+			cfg: ServerConfig{
+				RPOrigin:  "https://id.example.com",
+				RPOrigins: []string{"android:apk-key-hash:abc123"},
+			},
+			wantOrder: []string{"https://id.example.com", "android:apk-key-hash:abc123"},
+		},
+		{
+			name: "duplicate between legacy and list is deduplicated",
+			cfg: ServerConfig{
+				RPOrigin:  "https://id.example.com",
+				RPOrigins: []string{"https://id.example.com", "android:apk-key-hash:abc123"},
+			},
+			wantOrder: []string{"https://id.example.com", "android:apk-key-hash:abc123"},
+		},
+		{
+			name:      "both empty returns nil",
+			cfg:       ServerConfig{},
+			wantOrder: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.GetRPOrigins()
+			if len(got) != len(tt.wantOrder) {
+				t.Fatalf("GetRPOrigins() = %v, want %v", got, tt.wantOrder)
+			}
+			for i, o := range got {
+				if o != tt.wantOrder[i] {
+					t.Errorf("GetRPOrigins()[%d] = %q, want %q", i, o, tt.wantOrder[i])
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a `rp_origins` list field to `ServerConfig` alongside the existing `rp_origin` string field, enabling native app wrappers (Android, iOS) to register and authenticate against a wallet backend that also serves a web frontend.

Closes #143

## Changes

### `pkg/config/config.go`
- New `RPOrigins []string` field (`yaml:"rp_origins"`, `envconfig:"RP_ORIGINS"`)
- New `GetRPOrigins() []string` helper on `*ServerConfig`:
  - Prepends `RPOrigin` (legacy field) if non-empty
  - Deduplicates the combined list
  - Returns `nil` when both are empty
- `Validate()`: accepts either `rp_origin` or `rp_origins` being non-empty; both empty is still an error
- `defaultConfig()`: explicit `RPOrigins: nil` (no behaviour change)

### `internal/service/webauthn.go`
- `NewWebAuthnServiceWithValidator`: replace `[]string{cfg.Server.RPOrigin}` with `cfg.Server.GetRPOrigins()`

### `pkg/config/config_test.go`
- Updated `TestConfig_Validate_MissingRPOrigin` to cover both fields empty
- Added `TestConfig_Validate_RPOriginsAlone`: validate passes with only `rp_origins` set
- Added `TestServerConfig_GetRPOrigins` (5 table-driven cases): single legacy, list only, legacy prepended, deduplication, both empty

## Backward compatibility

Existing deployments using `rp_origin` require no config change. `GetRPOrigins()` returns `[rp_origin]` exactly as before.

## Example config (new style)

```yaml
server:
  rp_id: id.example.com
  rp_origins:
    - https://id.example.com
    - android:apk-key-hash:abc123def456
```

Or mixed (for gradual migration):

```yaml
server:
  rp_origin: https://id.example.com   # legacy — still works
  rp_origins:
    - android:apk-key-hash:abc123def456
```
