### PR TITLE
fix: bump go-trust to v0.4.0 for URL subject type support in resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/redis/go-redis/v9 v9.19.0
 	github.com/sirosfoundation/go-cryptoutil v0.5.0
 	github.com/sirosfoundation/go-spocp v0.1.0
-	github.com/sirosfoundation/go-trust v0.3.1-0.20260504153707-11e4e9a51cb9 // pre-release: pending go-trust#43 merge + v0.4.0 tag
+	github.com/sirosfoundation/go-trust v0.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.mongodb.org/mongo-driver v1.17.9

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/sirosfoundation/go-cryptoutil v0.5.0 h1:ByKuNjHSdlvkOzGeElh0QAku36iuy
 github.com/sirosfoundation/go-cryptoutil v0.5.0/go.mod h1:OZi673Xmf5o2LzF/QMceptIpiB2GKYAYBfEa75ocBss=
 github.com/sirosfoundation/go-spocp v0.1.0 h1:fH/jrSHS8vc+KfAzJmq3fE9OH69ShRgL7G1ihb9FCPs=
 github.com/sirosfoundation/go-spocp v0.1.0/go.mod h1:a6WtxG5hnsUzcqUt5iHmSMvyX4PLUPMDFK7FLoDMSMs=
-github.com/sirosfoundation/go-trust v0.3.1-0.20260504153707-11e4e9a51cb9 h1:OSzG+FhEJCS3JXr8jL4CFqfM4WdUeE5xXHmakmw47+I=
-github.com/sirosfoundation/go-trust v0.3.1-0.20260504153707-11e4e9a51cb9/go.mod h1:jpZy/QnoVB+Ke7Aqq0utz+fOHQh/wKpzD5c11jT95I8=
+github.com/sirosfoundation/go-trust v0.4.0 h1:zbZWgG5uqQPx99d67FIJMjESy9RB3rytSzidpUYQuXU=
+github.com/sirosfoundation/go-trust v0.4.0/go.mod h1:jpZy/QnoVB+Ke7Aqq0utz+fOHQh/wKpzD5c11jT95I8=
 github.com/sirosfoundation/virtualwebauthn v0.0.0-20260114072326-01133d1ade61 h1:1XMBGQ57pLEZRkazk8AN7mhNu63czErGg9+I3stWSS0=
 github.com/sirosfoundation/virtualwebauthn v0.0.0-20260114072326-01133d1ade61/go.mod h1:gAxbvM0HnnY4c3aNYo6Za97nPpGSbqLfjUtxJ8qNGjs=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=


### PR DESCRIPTION
## Problem

`POST /v1/resolve` with `subject_type="url"` returns:
```json
{"decision": false, "context": {"reason": {"error": "invalid request: subject.type must be 'key', got 'url'"}}}
```

The pinned pre-release (`v0.3.1-0.20260504153707-11e4e9a51cb9`) predates go-trust PR #37 which added `subject_type="url"` support. The comment in `go.mod` noted this was pending the v0.4.0 tag — that tag was released on 2026-05-06.

## Change

Bumps `github.com/sirosfoundation/go-trust` from `v0.3.1-0.20260504153707-11e4e9a51cb9` to `v0.4.0`.

v0.4.0 includes:
- **go-trust#37**: URL-based issuer metadata resolution (`subject_type="url"`) — fixes this bug
- **go-trust#43**: Content-Type based metadata format detection with trust evaluation
- **go-trust#46**: x509_san_dns/uri subject ID normalization fix

## Testing

`go build ./...` passes cleanly. The `POST /v1/resolve` endpoint should now correctly resolve OpenID4VCI issuer metadata when called with `subject_type="url"`.