### PR TITLE
feat: local issuer metadata resolution for URL subjects

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
+	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/internal/modes"
 	"github.com/sirosfoundation/go-wallet-backend/internal/registry"
 	"github.com/sirosfoundation/go-wallet-backend/internal/server"
@@ -198,7 +199,12 @@ func main() {
 		if backendProvider != nil {
 			verifierStore = backendProvider.Store().Verifiers()
 		}
-		provider, err := server.NewEngineProvider(backendCfg, logger, verifierStore)
+		// Share the metadata resolver from the backend so the TTL cache is not duplicated.
+		var sharedResolver *issuermetadata.Resolver
+		if backendProvider != nil {
+			sharedResolver = backendProvider.MetadataResolver()
+		}
+		provider, err := server.NewEngineProvider(backendCfg, logger, verifierStore, sharedResolver)
 		if err != nil {
 			logger.Fatal("Failed to create engine provider", zap.Error(err))
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
+	wsengine "github.com/sirosfoundation/go-wallet-backend/internal/engine"
 	"github.com/sirosfoundation/go-wallet-backend/internal/modes"
 	"github.com/sirosfoundation/go-wallet-backend/internal/registry"
 	"github.com/sirosfoundation/go-wallet-backend/internal/server"
@@ -204,7 +205,13 @@ func main() {
 		if backendProvider != nil {
 			sharedResolver = backendProvider.MetadataResolver()
 		}
-		provider, err := server.NewEngineProvider(backendCfg, logger, verifierStore, sharedResolver)
+		// Share the issuer lookup so the engine gets the same registered-issuer
+		// enrichment as the /v1/resolve HTTP endpoint.
+		var issuerLookup wsengine.CredentialIssuerLookup
+		if backendProvider != nil {
+			issuerLookup = backendProvider.Store().Issuers()
+		}
+		provider, err := server.NewEngineProvider(backendCfg, logger, verifierStore, sharedResolver, issuerLookup)
 		if err != nil {
 			logger.Fatal("Failed to create engine provider", zap.Error(err))
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,12 +14,12 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
-	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/internal/modes"
 	"github.com/sirosfoundation/go-wallet-backend/internal/registry"
 	"github.com/sirosfoundation/go-wallet-backend/internal/server"
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/logging"
 )
 

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -69,6 +69,7 @@ type AuthZENProxyHandler struct {
 	clients          map[string]*authzenclient.Client
 	clientsMu        sync.RWMutex
 	httpClient       *http.Client
+	allowHTTP        bool // when true, plain HTTP URLs are permitted for logos and jwks_uri (test/dev envs)
 	logger           *zap.Logger
 }
 
@@ -148,6 +149,9 @@ func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLoo
 		httpClient,
 		logger,
 	)
+	// Propagate the HTTP client's allow_http setting so that logo and
+	// jwks_uri fetches respect the same policy as metadata resolution.
+	handler.allowHTTP = cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify
 
 	logger.Info("AuthZEN proxy initialized",
 		zap.String("pdp_url", pdpURL),
@@ -378,13 +382,13 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 		return
 	}
 
-	// For URL subjects, resolve locally via the metadata resolver.
-	// A nil resolver at this point is a startup misconfiguration (caught by
-	// NewAuthZENProxyHandlerFromConfig); return 503 as defense-in-depth.
+	// For URL subjects, resolve locally via the metadata resolver when available.
+	// Fall back to proxying to the PDP when no resolver is configured so that
+	// deployments without AllowResolution retain backward-compatible behaviour.
 	if subjectType == "url" {
 		if h.metadataResolver == nil {
-			h.logger.Error("metadata resolver is nil for URL subject — this is a startup misconfiguration")
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "issuer metadata resolution not configured"})
+			h.logger.Debug("no metadata resolver configured for URL subject — proxying to PDP")
+			h.proxyToPDP(c, ctx, tenantID, evalReq)
 			return
 		}
 		h.resolveURLSubject(c, ctx, tenantID, req.SubjectID)
@@ -628,10 +632,12 @@ func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata m
 		}
 	}
 
-	// Check jwks_uri — HTTPS only to avoid SSRF via issuer-controlled URIs.
+	// Check jwks_uri — HTTPS is required unless allowHTTP is set (test/dev environments).
+	// This prevents SSRF via issuer-controlled jwks_uri pointing to internal services;
+	// the httpClient's DialContext additionally blocks private/loopback IPs when AllowPrivateIPs=false.
 	if jwksURI, ok := metadata["jwks_uri"].(string); ok && jwksURI != "" {
 		parsed, err := url.Parse(jwksURI)
-		if err != nil || parsed.Scheme != "https" {
+		if err != nil || (parsed.Scheme != "https" && !(h.allowHTTP && parsed.Scheme == "http")) {
 			h.logger.Warn("Skipping jwks_uri with non-HTTPS scheme (SSRF protection)",
 				zap.String("uri", jwksURI))
 		} else {
@@ -702,8 +708,9 @@ func (h *AuthZENProxyHandler) inlineLogoField(ctx context.Context, displayEntry 
 	}
 
 	// Only fetch HTTPS URLs (enforce to prevent SSRF via issuer-controlled logo URIs).
+	// Plain HTTP is permitted when allowHTTP is set (test/dev environments).
 	parsed, err := url.Parse(uri)
-	if err != nil || parsed.Scheme != "https" {
+	if err != nil || (parsed.Scheme != "https" && !(h.allowHTTP && parsed.Scheme == "http")) {
 		return
 	}
 
@@ -731,7 +738,7 @@ func (h *AuthZENProxyHandler) fetchAsDataURI(ctx context.Context, imageURL strin
 	// other concurrent users of h.httpClient (Transport is shared/safe).
 	client := *h.httpClient
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if req.URL.Scheme != "https" {
+		if req.URL.Scheme != "https" && !(h.allowHTTP && req.URL.Scheme == "http") {
 			return fmt.Errorf("refusing redirect to non-HTTPS URL: %s", req.URL)
 		}
 		if len(via) >= 10 {

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -369,15 +369,15 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 		return
 	}
 
-	// For URL subjects, resolve locally and evaluate trust
+	// For URL subjects, resolve locally when a metadata resolver is configured.
+	// If no resolver is configured, fall back to proxying to the PDP for
+	// backward compatibility.
 	if subjectType == "url" {
-		if h.metadataResolver == nil {
-			h.logger.Error("metadata resolver not configured for URL subject resolution")
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "issuer metadata resolution not configured"})
+		if h.metadataResolver != nil {
+			h.resolveURLSubject(c, ctx, tenantID, req.SubjectID)
 			return
 		}
-		h.resolveURLSubject(c, ctx, tenantID, req.SubjectID)
-		return
+		// No local resolver configured — fall through to PDP proxy
 	}
 
 	// For key subjects, proxy to PDP
@@ -410,7 +410,16 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 	}
 
 	// Step 2: Extract key material from metadata
-	keyMaterial := h.extractKeyMaterial(ctx, result.Metadata)
+	keyMaterial, signedButFailed := h.extractKeyMaterial(ctx, result.Metadata)
+
+	// If signed_metadata was present but JWT verification failed, reject immediately.
+	// Returning metadata with a claimed-but-unverifiable signature would be misleading.
+	if metadataIsSigned && signedButFailed {
+		h.logger.Error("signed_metadata JWT verification failed, rejecting request",
+			zap.String("issuer_url", issuerURL))
+		c.JSON(http.StatusBadGateway, gin.H{"error": "signed issuer metadata could not be verified"})
+		return
+	}
 
 	// Step 3: Evaluate trust via PDP using extracted key material
 	pdpURL, err := h.getPDPURL(ctx, tenantID)
@@ -566,16 +575,19 @@ func (h *AuthZENProxyHandler) proxyToPDP(c *gin.Context, ctx context.Context, te
 
 // extractKeyMaterial extracts cryptographic key material from issuer metadata.
 // It checks (in order): signed_metadata JWT, inline JWKS, jwks_uri.
-func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata map[string]interface{}) *trust.KeyMaterial {
+// Returns (keyMaterial, signedButFailed) where signedButFailed is true only
+// when a signed_metadata JWT was present but its embedded-key verification failed.
+// Callers should treat signedButFailed=true as a hard error.
+func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata map[string]interface{}) (*trust.KeyMaterial, bool) {
 	// Check signed_metadata JWT
 	if signedMetadata, ok := metadata["signed_metadata"].(string); ok && signedMetadata != "" {
 		km, err := trust.VerifyJWTWithEmbeddedKey(signedMetadata)
 		if err != nil {
 			h.logger.Error("signed_metadata JWT verification failed",
 				zap.Error(err))
-			return nil
+			return nil, true // signal to caller: signing was attempted but failed
 		}
-		return km
+		return km, false
 	}
 
 	// Check inline JWKS
@@ -583,11 +595,11 @@ func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata m
 		// jwks may be a map or raw JSON depending on how it was resolved
 		switch v := jwksRaw.(type) {
 		case map[string]interface{}:
-			return &trust.KeyMaterial{Type: "jwk", JWK: v}
+			return &trust.KeyMaterial{Type: "jwk", JWK: v}, false
 		case string:
 			var jwks interface{}
 			if err := json.Unmarshal([]byte(v), &jwks); err == nil {
-				return &trust.KeyMaterial{Type: "jwk", JWK: jwks}
+				return &trust.KeyMaterial{Type: "jwk", JWK: jwks}, false
 			}
 		}
 	}
@@ -605,13 +617,13 @@ func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata m
 					zap.String("uri", jwksURI),
 					zap.Error(err))
 			} else {
-				return &trust.KeyMaterial{Type: "jwk", JWK: jwks}
+				return &trust.KeyMaterial{Type: "jwk", JWK: jwks}, false
 			}
 		}
 	}
 
 	// No key material available
-	return nil
+	return nil, false
 }
 
 // inlineLogos walks the metadata tree and replaces logo URIs with data: URIs.

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -413,11 +413,9 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 		return
 	}
 
-	// Determine if metadata is signed (has signed_metadata field)
-	_, metadataIsSigned := result.Metadata["signed_metadata"].(string)
-	if sm, ok := result.Metadata["signed_metadata"].(string); ok && sm == "" {
-		metadataIsSigned = false
-	}
+	// Determine if metadata is signed (application/jwt or signed_metadata field).
+	// The resolver sets Signed=true for both cases.
+	metadataIsSigned := result.Signed
 
 	// Step 2: Extract key material from metadata
 	keyMaterial, signedButFailed := h.extractKeyMaterial(ctx, result.Metadata)
@@ -593,11 +591,19 @@ func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata m
 	if signedMetadata, ok := metadata["signed_metadata"].(string); ok && signedMetadata != "" {
 		km, err := trust.VerifyJWTWithEmbeddedKey(signedMetadata)
 		if err != nil {
-			h.logger.Error("signed_metadata JWT verification failed",
-				zap.Error(err))
-			return nil, true // signal to caller: signing was attempted but failed
+			// If the JWT has no embedded key (x5c/jwk), fall through to
+			// check jwks/jwks_uri for kid-based verification.
+			if strings.Contains(err.Error(), "neither x5c nor jwk") {
+				h.logger.Debug("signed_metadata JWT has no embedded key, falling through to jwks/jwks_uri",
+					zap.Error(err))
+			} else {
+				h.logger.Error("signed_metadata JWT verification failed",
+					zap.Error(err))
+				return nil, true // signal to caller: signing was attempted but failed
+			}
+		} else {
+			return km, false
 		}
-		return km, false
 	}
 
 	// Check inline JWKS

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -35,12 +35,35 @@ type TenantLookup interface {
 	GetByID(ctx context.Context, id domain.TenantID) (*domain.Tenant, error)
 }
 
+// IssuerLookup is an interface for looking up registered credential issuers.
+// This abstraction allows for easier testing.
+type IssuerLookup interface {
+	GetByIdentifier(ctx context.Context, tenantID domain.TenantID, identifier string) (*domain.CredentialIssuer, error)
+}
+
+// RegisteredIssuerInfo contains issuer registration data from the backend storage.
+// It is included in the /v1/resolve response context when the issuer is found in storage.
+type RegisteredIssuerInfo struct {
+	ClientID       string             `json:"client_id,omitempty"`
+	Visible        bool               `json:"visible"`
+	TrustStatus    domain.TrustStatus `json:"trust_status,omitempty"`
+	TrustFramework string             `json:"trust_framework,omitempty"`
+}
+
+// resolveURLResponse is the response type for /v1/resolve URL subject requests.
+// It extends gotrust.EvaluationResponse with optional registered issuer info.
+type resolveURLResponse struct {
+	gotrust.EvaluationResponse
+	RegisteredIssuer *RegisteredIssuerInfo `json:"registered_issuer,omitempty"`
+}
+
 // AuthZENProxyHandler handles AuthZEN evaluation requests by proxying to a PDP.
 // It provides an authenticated endpoint for the frontend to make trust decisions.
 type AuthZENProxyHandler struct {
 	cfg              *config.AuthZENProxyConfig
 	authorizer       authz.Authorizer
 	tenantLookup     TenantLookup
+	issuerLookup     IssuerLookup
 	metadataResolver IssuerMetadataResolver
 	clients          map[string]*authzenclient.Client
 	clientsMu        sync.RWMutex
@@ -49,13 +72,15 @@ type AuthZENProxyHandler struct {
 }
 
 // NewAuthZENProxyHandler creates a new AuthZEN proxy handler.
-// The tenantLookup parameter is optional - if nil, per-tenant configuration is disabled.
+// The tenantLookup and issuerLookup parameters are optional - if nil, the respective
+// per-tenant features are disabled.
 // The metadataResolver is required for URL subject resolution on /v1/resolve.
-func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Authorizer, tenantLookup TenantLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, logger *zap.Logger) *AuthZENProxyHandler {
+func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Authorizer, tenantLookup TenantLookup, issuerLookup IssuerLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, logger *zap.Logger) *AuthZENProxyHandler {
 	return &AuthZENProxyHandler{
 		cfg:              cfg,
 		authorizer:       authorizer,
 		tenantLookup:     tenantLookup,
+		issuerLookup:     issuerLookup,
 		metadataResolver: metadataResolver,
 		clients:          make(map[string]*authzenclient.Client),
 		httpClient:       httpClient,
@@ -70,7 +95,7 @@ func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Aut
 // the handler. Returns (nil, nil) when AuthZEN proxy is disabled.
 //
 // The caller is responsible for closing any resources (e.g. storage) on error.
-func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, logger *zap.Logger) (*AuthZENProxyHandler, error) {
+func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLookup, issuerLookup IssuerLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, logger *zap.Logger) (*AuthZENProxyHandler, error) {
 	if !cfg.AuthZENProxy.Enabled {
 		return nil, nil
 	}
@@ -109,6 +134,7 @@ func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLoo
 		&cfg.AuthZENProxy,
 		authorizerInterface,
 		tenantLookup,
+		issuerLookup,
 		metadataResolver,
 		httpClient,
 		logger,
@@ -470,14 +496,30 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 	}
 
 	// Step 6: Return composite response with trust decision and metadata
-	resp := &gotrust.EvaluationResponse{
-		Decision: trustResp.Decision,
-		Context: &gotrust.EvaluationResponseContext{
-			TrustMetadata: result.Metadata,
+	resp := &resolveURLResponse{
+		EvaluationResponse: gotrust.EvaluationResponse{
+			Decision: trustResp.Decision,
+			Context: &gotrust.EvaluationResponseContext{
+				TrustMetadata: result.Metadata,
+			},
 		},
 	}
 	if trustResp.Context != nil && trustResp.Context.Reason != nil {
 		resp.Context.Reason = trustResp.Context.Reason
+	}
+
+	// Step 7: Enrich response with registered issuer info from backend storage.
+	// This is looked up by the issuer URL (CredentialIssuerIdentifier) within the tenant.
+	// If not found or issuer lookup is unavailable, the field is omitted.
+	if h.issuerLookup != nil && tenantID != "" {
+		if reg, err := h.issuerLookup.GetByIdentifier(ctx, domain.TenantID(tenantID), issuerURL); err == nil && reg != nil {
+			resp.RegisteredIssuer = &RegisteredIssuerInfo{
+				ClientID:       reg.ClientID,
+				Visible:        reg.Visible,
+				TrustStatus:    reg.TrustStatus,
+				TrustFramework: reg.TrustFramework,
+			}
+		}
 	}
 
 	h.logger.Info("URL subject resolution completed",

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -637,7 +637,7 @@ func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata m
 	// the httpClient's DialContext additionally blocks private/loopback IPs when AllowPrivateIPs=false.
 	if jwksURI, ok := metadata["jwks_uri"].(string); ok && jwksURI != "" {
 		parsed, err := url.Parse(jwksURI)
-		if err != nil || (parsed.Scheme != "https" && !(h.allowHTTP && parsed.Scheme == "http")) {
+		if err != nil || (parsed.Scheme != "https" && (!h.allowHTTP || parsed.Scheme != "http")) {
 			h.logger.Warn("Skipping jwks_uri with non-HTTPS scheme (SSRF protection)",
 				zap.String("uri", jwksURI))
 		} else {
@@ -710,7 +710,7 @@ func (h *AuthZENProxyHandler) inlineLogoField(ctx context.Context, displayEntry 
 	// Only fetch HTTPS URLs (enforce to prevent SSRF via issuer-controlled logo URIs).
 	// Plain HTTP is permitted when allowHTTP is set (test/dev environments).
 	parsed, err := url.Parse(uri)
-	if err != nil || (parsed.Scheme != "https" && !(h.allowHTTP && parsed.Scheme == "http")) {
+	if err != nil || (parsed.Scheme != "https" && (!h.allowHTTP || parsed.Scheme != "http")) {
 		return
 	}
 
@@ -738,7 +738,7 @@ func (h *AuthZENProxyHandler) fetchAsDataURI(ctx context.Context, imageURL strin
 	// other concurrent users of h.httpClient (Transport is shared/safe).
 	client := *h.httpClient
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if req.URL.Scheme != "https" && !(h.allowHTTP && req.URL.Scheme == "http") {
+		if req.URL.Scheme != "https" && (!h.allowHTTP || req.URL.Scheme != "http") {
 			return fmt.Errorf("refusing redirect to non-HTTPS URL: %s", req.URL)
 		}
 		if len(via) >= 10 {

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -710,13 +710,29 @@ func (h *AuthZENProxyHandler) inlineLogoField(ctx context.Context, displayEntry 
 }
 
 // fetchAsDataURI fetches a URL and returns its content as a data: URI.
+// A copy of the shared HTTP client is used with CheckRedirect set to refuse
+// any redirect that leaves HTTPS — this prevents a server from issuing a
+// 3xx to a plain HTTP URL and bypassing the upstream scheme check.
 func (h *AuthZENProxyHandler) fetchAsDataURI(ctx context.Context, imageURL string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
 	if err != nil {
 		return "", err
 	}
 
-	resp, err := h.httpClient.Do(req)
+	// Shallow-copy the client so we can set CheckRedirect without affecting
+	// other concurrent users of h.httpClient (Transport is shared/safe).
+	client := *h.httpClient
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Scheme != "https" {
+			return fmt.Errorf("refusing redirect to non-HTTPS URL: %s", req.URL)
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("too many redirects")
+		}
+		return nil
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -407,37 +407,37 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 		return
 	}
 
-// Build trust evaluation request with key material.
-        // Action is set to "credential-issuer" so PDP policy can distinguish
-        // issuer trust evaluation from verifier or general resolution requests.
-        trustReq := &gotrust.EvaluationRequest{
-                Subject: gotrust.Subject{
-                        Type: "key",
-                        ID:   issuerURL,
-                },
-                Resource: gotrust.Resource{
-                        ID: issuerURL,
-                },
-                Action: &gotrust.Action{Name: "credential-issuer"},
-        }
+	// Build trust evaluation request with key material.
+	// Action is set to "credential-issuer" so PDP policy can distinguish
+	// issuer trust evaluation from verifier or general resolution requests.
+	trustReq := &gotrust.EvaluationRequest{
+		Subject: gotrust.Subject{
+			Type: "key",
+			ID:   issuerURL,
+		},
+		Resource: gotrust.Resource{
+			ID: issuerURL,
+		},
+		Action: &gotrust.Action{Name: "credential-issuer"},
+	}
 
-        if keyMaterial != nil {
-                trustReq.Resource.Type = keyMaterial.Type
-                switch keyMaterial.Type {
-                case "x5c":
-                        keys := make([]interface{}, len(keyMaterial.X5C))
-                        for i, cert := range keyMaterial.X5C {
-                                keys[i] = cert
-                        }
-                        trustReq.Resource.Key = keys
-                case "jwk":
-                        trustReq.Resource.Key = trust.NormalizeJWKS(keyMaterial.JWK)
-                }
-        } else {
-                // No key material could be extracted. Set resource type to "resolution"
-                // so the PDP receives a well-formed request and can apply a
-                // resolution-only policy rather than a trust-evaluation policy.
-                trustReq.Resource.Type = "resolution"
+	if keyMaterial != nil {
+		trustReq.Resource.Type = keyMaterial.Type
+		switch keyMaterial.Type {
+		case "x5c":
+			keys := make([]interface{}, len(keyMaterial.X5C))
+			for i, cert := range keyMaterial.X5C {
+				keys[i] = cert
+			}
+			trustReq.Resource.Key = keys
+		case "jwk":
+			trustReq.Resource.Key = trust.NormalizeJWKS(keyMaterial.JWK)
+		}
+	} else {
+		// No key material could be extracted. Set resource type to "resolution"
+		// so the PDP receives a well-formed request and can apply a
+		// resolution-only policy rather than a trust-evaluation policy.
+		trustReq.Resource.Type = "resolution"
 	}
 
 	trustResp, err := client.Evaluate(ctx, trustReq)
@@ -549,21 +549,21 @@ func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata m
 		}
 	}
 
-// Check jwks_uri — HTTPS only to avoid SSRF via issuer-controlled URIs.
-        if jwksURI, ok := metadata["jwks_uri"].(string); ok && jwksURI != "" {
-                parsed, err := url.Parse(jwksURI)
-                if err != nil || parsed.Scheme != "https" {
-                        h.logger.Warn("Skipping jwks_uri with non-HTTPS scheme (SSRF protection)",
-                                zap.String("uri", jwksURI))
-                } else {
-                        jwks, err := trust.FetchJWKS(ctx, jwksURI, h.httpClient)
-                        if err != nil {
-                                h.logger.Warn("Failed to fetch JWKS",
-                                        zap.String("uri", jwksURI),
-                                        zap.Error(err))
-                        } else {
-                                return &trust.KeyMaterial{Type: "jwk", JWK: jwks}
-                        }
+	// Check jwks_uri — HTTPS only to avoid SSRF via issuer-controlled URIs.
+	if jwksURI, ok := metadata["jwks_uri"].(string); ok && jwksURI != "" {
+		parsed, err := url.Parse(jwksURI)
+		if err != nil || parsed.Scheme != "https" {
+			h.logger.Warn("Skipping jwks_uri with non-HTTPS scheme (SSRF protection)",
+				zap.String("uri", jwksURI))
+		} else {
+			jwks, err := trust.FetchJWKS(ctx, jwksURI, h.httpClient)
+			if err != nil {
+				h.logger.Warn("Failed to fetch JWKS",
+					zap.String("uri", jwksURI),
+					zap.Error(err))
+			} else {
+				return &trust.KeyMaterial{Type: "jwk", JWK: jwks}
+			}
 		}
 	}
 
@@ -622,9 +622,9 @@ func (h *AuthZENProxyHandler) inlineLogoField(ctx context.Context, displayEntry 
 		return
 	}
 
-// Only fetch HTTPS URLs (enforce to prevent SSRF via issuer-controlled logo URIs).
-        parsed, err := url.Parse(uri)
-        if err != nil || parsed.Scheme != "https" {
+	// Only fetch HTTPS URLs (enforce to prevent SSRF via issuer-controlled logo URIs).
+	parsed, err := url.Parse(uri)
+	if err != nil || parsed.Scheme != "https" {
 		return
 	}
 
@@ -655,16 +655,16 @@ func (h *AuthZENProxyHandler) fetchAsDataURI(ctx context.Context, imageURL strin
 		return "", fmt.Errorf("logo fetch returned status %d", resp.StatusCode)
 	}
 
-// Limit read to 1MB to prevent abuse. Read one extra byte to detect
-        // truncation — if the body exceeds the limit, reject it rather than
-        // returning a partial/corrupt data: URI.
-        const maxLogoSize = 1 << 20
-        body, err := io.ReadAll(io.LimitReader(resp.Body, maxLogoSize+1))
-        if err != nil {
-                return "", err
-        }
-        if len(body) > maxLogoSize {
-                return "", fmt.Errorf("logo response exceeds %d byte limit", maxLogoSize)
+	// Limit read to 1MB to prevent abuse. Read one extra byte to detect
+	// truncation — if the body exceeds the limit, reject it rather than
+	// returning a partial/corrupt data: URI.
+	const maxLogoSize = 1 << 20
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLogoSize+1))
+	if err != nil {
+		return "", err
+	}
+	if len(body) > maxLogoSize {
+		return "", fmt.Errorf("logo response exceeds %d byte limit", maxLogoSize)
 	}
 
 	contentType := resp.Header.Get("Content-Type")

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -509,9 +509,10 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 	}
 
 	// Step 7: Enrich response with registered issuer info from backend storage.
-	// This is looked up by the issuer URL (CredentialIssuerIdentifier) within the tenant.
-	// If not found or issuer lookup is unavailable, the field is omitted.
-	if h.issuerLookup != nil && tenantID != "" {
+	// Scoped strictly to the authenticated tenant — tenantID is enforced non-empty
+	// by Resolve() before this function is called, preventing cross-tenant access.
+	// If the issuer is not registered in this tenant's storage, the field is omitted.
+	if h.issuerLookup != nil {
 		if reg, err := h.issuerLookup.GetByIdentifier(ctx, domain.TenantID(tenantID), issuerURL); err == nil && reg != nil {
 			resp.RegisteredIssuer = &RegisteredIssuerInfo{
 				ClientID:       reg.ClientID,

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -420,6 +421,13 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 	// Step 2: Extract key material from metadata
 	keyMaterial, signedButFailed := h.extractKeyMaterial(ctx, result.Metadata)
 
+	// For application/jwt responses the JWT payload claims don't carry
+	// signed_metadata/jwks fields, so key material is surfaced via the resolver result.
+	if keyMaterial == nil && !signedButFailed && result.SignerKeyMaterial != nil {
+		km := result.SignerKeyMaterial
+		keyMaterial = &trust.KeyMaterial{Type: km.Type, X5C: km.X5C, JWK: km.JWK}
+	}
+
 	// If signed_metadata was present but JWT verification failed, reject immediately.
 	// Returning metadata with a claimed-but-unverifiable signature would be misleading.
 	if metadataIsSigned && signedButFailed {
@@ -593,7 +601,7 @@ func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata m
 		if err != nil {
 			// If the JWT has no embedded key (x5c/jwk), fall through to
 			// check jwks/jwks_uri for kid-based verification.
-			if strings.Contains(err.Error(), "neither x5c nor jwk") {
+			if errors.Is(err, trust.ErrNoEmbeddedKey) {
 				h.logger.Debug("signed_metadata JWT has no embedded key, falling through to jwks/jwks_uri",
 					zap.Error(err))
 			} else {

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -50,7 +50,7 @@ type AuthZENProxyHandler struct {
 
 // NewAuthZENProxyHandler creates a new AuthZEN proxy handler.
 // The tenantLookup parameter is optional - if nil, per-tenant configuration is disabled.
-// The metadataResolver parameter is optional - if nil, URL subject resolution is proxied to the PDP.
+// The metadataResolver is required for URL subject resolution on /v1/resolve.
 func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Authorizer, tenantLookup TenantLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, logger *zap.Logger) *AuthZENProxyHandler {
 	return &AuthZENProxyHandler{
 		cfg:              cfg,
@@ -343,19 +343,28 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 		return
 	}
 
-	// For URL subjects with a metadata resolver, resolve locally and evaluate trust
-	if subjectType == "url" && h.metadataResolver != nil {
+	// For URL subjects, resolve locally and evaluate trust
+	if subjectType == "url" {
+		if h.metadataResolver == nil {
+			h.logger.Error("metadata resolver not configured for URL subject resolution")
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "issuer metadata resolution not configured"})
+			return
+		}
 		h.resolveURLSubject(c, ctx, tenantID, req.SubjectID)
 		return
 	}
 
-	// For key subjects (or URL without local resolver), proxy to PDP
+	// For key subjects, proxy to PDP
 	h.proxyToPDP(c, ctx, tenantID, evalReq)
 }
 
 // resolveURLSubject handles the local resolution path for URL subjects.
 // It resolves metadata, extracts key material, evaluates trust via PDP,
-// inlines logos as data: URIs, and returns a composite response.
+// and returns a composite response. Logo inlining is performed when:
+//   - metadata is unsigned (no signed_metadata field), OR
+//   - metadata is signed AND the PDP returns trusted
+//
+// If metadata is signed but untrusted, an error is returned.
 func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Context, tenantID, issuerURL string) {
 	// Step 1: Resolve issuer metadata locally
 	result, err := h.metadataResolver.ResolveWithInfo(ctx, issuerURL)
@@ -366,6 +375,12 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 		)
 		c.JSON(http.StatusBadGateway, gin.H{"error": "issuer metadata resolution failed"})
 		return
+	}
+
+	// Determine if metadata is signed (has signed_metadata field)
+	_, metadataIsSigned := result.Metadata["signed_metadata"].(string)
+	if sm, ok := result.Metadata["signed_metadata"].(string); ok && sm == "" {
+		metadataIsSigned = false
 	}
 
 	// Step 2: Extract key material from metadata
@@ -428,12 +443,25 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 		return
 	}
 
-	// Step 4: If trusted, inline logo images as data: URIs in metadata
-	if trustResp.Decision {
+	// Step 4: Enforce trust policy for signed metadata
+	// Signed but untrusted metadata is rejected — the issuer claims a binding
+	// that the trust registry does not recognize, so we must not return it.
+	if metadataIsSigned && !trustResp.Decision {
+		h.logger.Warn("signed metadata from untrusted issuer rejected",
+			zap.String("issuer_url", issuerURL),
+		)
+		c.JSON(http.StatusForbidden, gin.H{"error": "issuer metadata is signed but issuer is not trusted"})
+		return
+	}
+
+	// Step 5: Inline logo images as data: URIs.
+	// Inlining is safe when metadata is unsigned (display-only, no trust claim)
+	// or when signed metadata has been verified as trusted.
+	if !metadataIsSigned || trustResp.Decision {
 		h.inlineLogos(ctx, result.Metadata)
 	}
 
-	// Step 5: Return composite response with trust decision and metadata
+	// Step 6: Return composite response with trust decision and metadata
 	resp := &gotrust.EvaluationResponse{
 		Decision: trustResp.Decision,
 		Context: &gotrust.EvaluationResponseContext{
@@ -448,6 +476,7 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 		zap.String("tenant_id", tenantID),
 		zap.String("issuer_url", issuerURL),
 		zap.Bool("decision", trustResp.Decision),
+		zap.Bool("signed", metadataIsSigned),
 	)
 
 	c.JSON(http.StatusOK, resp)

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -3,20 +3,31 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	gotrust "github.com/sirosfoundation/go-trust/pkg/authzen"
 	"github.com/sirosfoundation/go-trust/pkg/authzenclient"
+	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/authz"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/trust"
 	"go.uber.org/zap"
 )
+
+// IssuerMetadataResolver resolves OpenID4VCI issuer metadata from a credential issuer URL.
+type IssuerMetadataResolver interface {
+	ResolveWithInfo(ctx context.Context, issuerURL string) (*issuermetadata.ResolveResult, error)
+}
 
 // TenantLookup is an interface for looking up tenant configuration.
 // This abstraction allows for easier testing.
@@ -27,25 +38,28 @@ type TenantLookup interface {
 // AuthZENProxyHandler handles AuthZEN evaluation requests by proxying to a PDP.
 // It provides an authenticated endpoint for the frontend to make trust decisions.
 type AuthZENProxyHandler struct {
-	cfg          *config.AuthZENProxyConfig
-	authorizer   authz.Authorizer
-	tenantLookup TenantLookup
-	clients      map[string]*authzenclient.Client
-	clientsMu    sync.RWMutex
-	httpClient   *http.Client
-	logger       *zap.Logger
+	cfg              *config.AuthZENProxyConfig
+	authorizer       authz.Authorizer
+	tenantLookup     TenantLookup
+	metadataResolver IssuerMetadataResolver
+	clients          map[string]*authzenclient.Client
+	clientsMu        sync.RWMutex
+	httpClient       *http.Client
+	logger           *zap.Logger
 }
 
 // NewAuthZENProxyHandler creates a new AuthZEN proxy handler.
 // The tenantLookup parameter is optional - if nil, per-tenant configuration is disabled.
-func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Authorizer, tenantLookup TenantLookup, httpClient *http.Client, logger *zap.Logger) *AuthZENProxyHandler {
+// The metadataResolver parameter is optional - if nil, URL subject resolution is proxied to the PDP.
+func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Authorizer, tenantLookup TenantLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, logger *zap.Logger) *AuthZENProxyHandler {
 	return &AuthZENProxyHandler{
-		cfg:          cfg,
-		authorizer:   authorizer,
-		tenantLookup: tenantLookup,
-		clients:      make(map[string]*authzenclient.Client),
-		httpClient:   httpClient,
-		logger:       logger.Named("authzen-proxy"),
+		cfg:              cfg,
+		authorizer:       authorizer,
+		tenantLookup:     tenantLookup,
+		metadataResolver: metadataResolver,
+		clients:          make(map[string]*authzenclient.Client),
+		httpClient:       httpClient,
+		logger:           logger.Named("authzen-proxy"),
 	}
 }
 
@@ -56,7 +70,7 @@ func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Aut
 // the handler. Returns (nil, nil) when AuthZEN proxy is disabled.
 //
 // The caller is responsible for closing any resources (e.g. storage) on error.
-func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLookup, httpClient *http.Client, logger *zap.Logger) (*AuthZENProxyHandler, error) {
+func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, logger *zap.Logger) (*AuthZENProxyHandler, error) {
 	if !cfg.AuthZENProxy.Enabled {
 		return nil, nil
 	}
@@ -95,6 +109,7 @@ func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLoo
 		&cfg.AuthZENProxy,
 		authorizerInterface,
 		tenantLookup,
+		metadataResolver,
 		httpClient,
 		logger,
 	)
@@ -237,11 +252,12 @@ func (h *AuthZENProxyHandler) Evaluate(c *gin.Context) {
 
 // Resolve handles POST /v1/resolve
 //
-// This is a convenience endpoint for resolution-only requests (no key validation).
-// It's used for DID document and metadata resolution.
+// This endpoint resolves issuer metadata and evaluates trust. For URL subjects,
+// metadata is resolved locally and key material is extracted, then sent to the PDP
+// for trust evaluation. For key subjects, the request is proxied directly to the PDP.
 //
-// Request body: { "subject_id": "did:web:example.com" }
-// Response: gotrust.EvaluationResponse with trust_metadata
+// Request body: { "subject_id": "https://issuer.example.com", "subject_type": "url" }
+// Response: gotrust.EvaluationResponse with trust_metadata containing issuer metadata
 func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 	// Check if resolution is enabled
 	if !h.cfg.AllowResolution {
@@ -277,9 +293,6 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 	}
 
 	// Determine subject type: explicit field takes precedence, default is "key".
-	// Callers that want issuer metadata resolution must explicitly pass subject_type="url".
-	// This preserves backward compatibility: existing callers using HTTPS URLs for OIDF
-	// entity resolution continue to work with subject_type="key" (the default).
 	subjectType := req.SubjectType
 	if subjectType == "" {
 		subjectType = "key"
@@ -299,8 +312,6 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 	}
 
 	// Determine resource type based on subject type and optional override.
-	// For URL subjects, default to "credential_issuer" (OpenID4VCI issuer metadata).
-	// For key subjects, default to "resolution" (DID/OIDF entity resolution).
 	resourceType := req.ResourceType
 	if resourceType == "" {
 		if subjectType == "url" {
@@ -310,7 +321,7 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 		}
 	}
 
-	// Build an evaluation request
+	// Build an evaluation request for authorization check
 	evalReq := &gotrust.EvaluationRequest{
 		Subject: gotrust.Subject{
 			Type: subjectType,
@@ -332,7 +343,118 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 		return
 	}
 
-	// Get PDP URL and forward
+	// For URL subjects with a metadata resolver, resolve locally and evaluate trust
+	if subjectType == "url" && h.metadataResolver != nil {
+		h.resolveURLSubject(c, ctx, tenantID, req.SubjectID)
+		return
+	}
+
+	// For key subjects (or URL without local resolver), proxy to PDP
+	h.proxyToPDP(c, ctx, tenantID, evalReq)
+}
+
+// resolveURLSubject handles the local resolution path for URL subjects.
+// It resolves metadata, extracts key material, evaluates trust via PDP,
+// inlines logos as data: URIs, and returns a composite response.
+func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Context, tenantID, issuerURL string) {
+	// Step 1: Resolve issuer metadata locally
+	result, err := h.metadataResolver.ResolveWithInfo(ctx, issuerURL)
+	if err != nil {
+		h.logger.Error("metadata resolution failed",
+			zap.String("issuer_url", issuerURL),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "issuer metadata resolution failed"})
+		return
+	}
+
+	// Step 2: Extract key material from metadata
+	keyMaterial := h.extractKeyMaterial(ctx, result.Metadata)
+
+	// Step 3: Evaluate trust via PDP using extracted key material
+	pdpURL, err := h.getPDPURL(ctx, tenantID)
+	if err != nil {
+		h.logger.Error("tenant lookup failed",
+			zap.String("tenant_id", tenantID),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "tenant configuration unavailable"})
+		return
+	}
+	if pdpURL == "" {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "trust evaluation not configured"})
+		return
+	}
+
+	client, err := h.getClient(pdpURL)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+		return
+	}
+
+	// Build trust evaluation request with key material
+	trustReq := &gotrust.EvaluationRequest{
+		Subject: gotrust.Subject{
+			Type: "key",
+			ID:   issuerURL,
+		},
+		Resource: gotrust.Resource{
+			ID: issuerURL,
+		},
+	}
+
+	if keyMaterial != nil {
+		trustReq.Resource.Type = keyMaterial.Type
+		switch keyMaterial.Type {
+		case "x5c":
+			keys := make([]interface{}, len(keyMaterial.X5C))
+			for i, cert := range keyMaterial.X5C {
+				keys[i] = cert
+			}
+			trustReq.Resource.Key = keys
+		case "jwk":
+			trustReq.Resource.Key = trust.NormalizeJWKS(keyMaterial.JWK)
+		}
+	}
+
+	trustResp, err := client.Evaluate(ctx, trustReq)
+	if err != nil {
+		h.logger.Error("PDP trust evaluation failed",
+			zap.String("issuer_url", issuerURL),
+			zap.String("pdp_url", pdpURL),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "trust evaluation service unavailable"})
+		return
+	}
+
+	// Step 4: If trusted, inline logo images as data: URIs in metadata
+	if trustResp.Decision {
+		h.inlineLogos(ctx, result.Metadata)
+	}
+
+	// Step 5: Return composite response with trust decision and metadata
+	resp := &gotrust.EvaluationResponse{
+		Decision: trustResp.Decision,
+		Context: &gotrust.EvaluationResponseContext{
+			TrustMetadata: result.Metadata,
+		},
+	}
+	if trustResp.Context != nil && trustResp.Context.Reason != nil {
+		resp.Context.Reason = trustResp.Context.Reason
+	}
+
+	h.logger.Info("URL subject resolution completed",
+		zap.String("tenant_id", tenantID),
+		zap.String("issuer_url", issuerURL),
+		zap.Bool("decision", trustResp.Decision),
+	)
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// proxyToPDP forwards an evaluation request directly to the PDP.
+func (h *AuthZENProxyHandler) proxyToPDP(c *gin.Context, ctx context.Context, tenantID string, evalReq *gotrust.EvaluationRequest) {
 	pdpURL, err := h.getPDPURL(ctx, tenantID)
 	if err != nil {
 		h.logger.Error("tenant lookup failed",
@@ -360,6 +482,153 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, resp)
+}
+
+// extractKeyMaterial extracts cryptographic key material from issuer metadata.
+// It checks (in order): signed_metadata JWT, inline JWKS, jwks_uri.
+func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata map[string]interface{}) *trust.KeyMaterial {
+	// Check signed_metadata JWT
+	if signedMetadata, ok := metadata["signed_metadata"].(string); ok && signedMetadata != "" {
+		km, err := trust.VerifyJWTWithEmbeddedKey(signedMetadata)
+		if err != nil {
+			h.logger.Error("signed_metadata JWT verification failed",
+				zap.Error(err))
+			return nil
+		}
+		return km
+	}
+
+	// Check inline JWKS
+	if jwksRaw, ok := metadata["jwks"]; ok && jwksRaw != nil {
+		// jwks may be a map or raw JSON depending on how it was resolved
+		switch v := jwksRaw.(type) {
+		case map[string]interface{}:
+			return &trust.KeyMaterial{Type: "jwk", JWK: v}
+		case string:
+			var jwks interface{}
+			if err := json.Unmarshal([]byte(v), &jwks); err == nil {
+				return &trust.KeyMaterial{Type: "jwk", JWK: jwks}
+			}
+		}
+	}
+
+	// Check jwks_uri
+	if jwksURI, ok := metadata["jwks_uri"].(string); ok && jwksURI != "" {
+		jwks, err := trust.FetchJWKS(ctx, jwksURI, h.httpClient)
+		if err != nil {
+			h.logger.Warn("Failed to fetch JWKS",
+				zap.String("uri", jwksURI),
+				zap.Error(err))
+		} else {
+			return &trust.KeyMaterial{Type: "jwk", JWK: jwks}
+		}
+	}
+
+	// No key material available
+	return nil
+}
+
+// inlineLogos walks the metadata tree and replaces logo URIs with data: URIs.
+// It modifies the metadata in place. Only HTTPS URLs are fetched; data: URIs
+// are left unchanged.
+func (h *AuthZENProxyHandler) inlineLogos(ctx context.Context, metadata map[string]interface{}) {
+	// Inline logos in top-level display array
+	if display, ok := metadata["display"].([]interface{}); ok {
+		for _, d := range display {
+			if dm, ok := d.(map[string]interface{}); ok {
+				h.inlineLogoField(ctx, dm)
+			}
+		}
+	}
+
+	// Inline logos in credential_configurations_supported entries
+	if ccs, ok := metadata["credential_configurations_supported"].(map[string]interface{}); ok {
+		for _, ccRaw := range ccs {
+			cc, ok := ccRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if display, ok := cc["display"].([]interface{}); ok {
+				for _, d := range display {
+					if dm, ok := d.(map[string]interface{}); ok {
+						h.inlineLogoField(ctx, dm)
+					}
+				}
+			}
+		}
+	}
+}
+
+// inlineLogoField replaces a logo.uri field with a data: URI if it's an HTTP(S) URL.
+func (h *AuthZENProxyHandler) inlineLogoField(ctx context.Context, displayEntry map[string]interface{}) {
+	logoRaw, ok := displayEntry["logo"]
+	if !ok {
+		return
+	}
+	logo, ok := logoRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
+	uri, ok := logo["uri"].(string)
+	if !ok || uri == "" {
+		return
+	}
+
+	// Skip if already a data: URI
+	if strings.HasPrefix(uri, "data:") {
+		return
+	}
+
+	// Only fetch HTTPS URLs
+	parsed, err := url.Parse(uri)
+	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+		return
+	}
+
+	dataURI, err := h.fetchAsDataURI(ctx, uri)
+	if err != nil {
+		h.logger.Debug("failed to inline logo",
+			zap.String("uri", uri),
+			zap.Error(err))
+		return
+	}
+	logo["uri"] = dataURI
+}
+
+// fetchAsDataURI fetches a URL and returns its content as a data: URI.
+func (h *AuthZENProxyHandler) fetchAsDataURI(ctx context.Context, imageURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("logo fetch returned status %d", resp.StatusCode)
+	}
+
+	// Limit read to 1MB to prevent abuse
+	const maxLogoSize = 1 << 20
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLogoSize))
+	if err != nil {
+		return "", err
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "image/png"
+	}
+	// Strip parameters from content type (e.g., charset)
+	if idx := strings.Index(contentType, ";"); idx >= 0 {
+		contentType = strings.TrimSpace(contentType[:idx])
+	}
+
+	return "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(body), nil
 }
 
 // getPDPURL returns the PDP URL for the given tenant.

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -407,29 +407,37 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 		return
 	}
 
-	// Build trust evaluation request with key material
-	trustReq := &gotrust.EvaluationRequest{
-		Subject: gotrust.Subject{
-			Type: "key",
-			ID:   issuerURL,
-		},
-		Resource: gotrust.Resource{
-			ID: issuerURL,
-		},
-	}
+// Build trust evaluation request with key material.
+        // Action is set to "credential-issuer" so PDP policy can distinguish
+        // issuer trust evaluation from verifier or general resolution requests.
+        trustReq := &gotrust.EvaluationRequest{
+                Subject: gotrust.Subject{
+                        Type: "key",
+                        ID:   issuerURL,
+                },
+                Resource: gotrust.Resource{
+                        ID: issuerURL,
+                },
+                Action: &gotrust.Action{Name: "credential-issuer"},
+        }
 
-	if keyMaterial != nil {
-		trustReq.Resource.Type = keyMaterial.Type
-		switch keyMaterial.Type {
-		case "x5c":
-			keys := make([]interface{}, len(keyMaterial.X5C))
-			for i, cert := range keyMaterial.X5C {
-				keys[i] = cert
-			}
-			trustReq.Resource.Key = keys
-		case "jwk":
-			trustReq.Resource.Key = trust.NormalizeJWKS(keyMaterial.JWK)
-		}
+        if keyMaterial != nil {
+                trustReq.Resource.Type = keyMaterial.Type
+                switch keyMaterial.Type {
+                case "x5c":
+                        keys := make([]interface{}, len(keyMaterial.X5C))
+                        for i, cert := range keyMaterial.X5C {
+                                keys[i] = cert
+                        }
+                        trustReq.Resource.Key = keys
+                case "jwk":
+                        trustReq.Resource.Key = trust.NormalizeJWKS(keyMaterial.JWK)
+                }
+        } else {
+                // No key material could be extracted. Set resource type to "resolution"
+                // so the PDP receives a well-formed request and can apply a
+                // resolution-only policy rather than a trust-evaluation policy.
+                trustReq.Resource.Type = "resolution"
 	}
 
 	trustResp, err := client.Evaluate(ctx, trustReq)
@@ -541,15 +549,21 @@ func (h *AuthZENProxyHandler) extractKeyMaterial(ctx context.Context, metadata m
 		}
 	}
 
-	// Check jwks_uri
-	if jwksURI, ok := metadata["jwks_uri"].(string); ok && jwksURI != "" {
-		jwks, err := trust.FetchJWKS(ctx, jwksURI, h.httpClient)
-		if err != nil {
-			h.logger.Warn("Failed to fetch JWKS",
-				zap.String("uri", jwksURI),
-				zap.Error(err))
-		} else {
-			return &trust.KeyMaterial{Type: "jwk", JWK: jwks}
+// Check jwks_uri — HTTPS only to avoid SSRF via issuer-controlled URIs.
+        if jwksURI, ok := metadata["jwks_uri"].(string); ok && jwksURI != "" {
+                parsed, err := url.Parse(jwksURI)
+                if err != nil || parsed.Scheme != "https" {
+                        h.logger.Warn("Skipping jwks_uri with non-HTTPS scheme (SSRF protection)",
+                                zap.String("uri", jwksURI))
+                } else {
+                        jwks, err := trust.FetchJWKS(ctx, jwksURI, h.httpClient)
+                        if err != nil {
+                                h.logger.Warn("Failed to fetch JWKS",
+                                        zap.String("uri", jwksURI),
+                                        zap.Error(err))
+                        } else {
+                                return &trust.KeyMaterial{Type: "jwk", JWK: jwks}
+                        }
 		}
 	}
 
@@ -608,9 +622,9 @@ func (h *AuthZENProxyHandler) inlineLogoField(ctx context.Context, displayEntry 
 		return
 	}
 
-	// Only fetch HTTPS URLs
-	parsed, err := url.Parse(uri)
-	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+// Only fetch HTTPS URLs (enforce to prevent SSRF via issuer-controlled logo URIs).
+        parsed, err := url.Parse(uri)
+        if err != nil || parsed.Scheme != "https" {
 		return
 	}
 
@@ -641,11 +655,16 @@ func (h *AuthZENProxyHandler) fetchAsDataURI(ctx context.Context, imageURL strin
 		return "", fmt.Errorf("logo fetch returned status %d", resp.StatusCode)
 	}
 
-	// Limit read to 1MB to prevent abuse
-	const maxLogoSize = 1 << 20
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLogoSize))
-	if err != nil {
-		return "", err
+// Limit read to 1MB to prevent abuse. Read one extra byte to detect
+        // truncation — if the body exceeds the limit, reject it rather than
+        // returning a partial/corrupt data: URI.
+        const maxLogoSize = 1 << 20
+        body, err := io.ReadAll(io.LimitReader(resp.Body, maxLogoSize+1))
+        if err != nil {
+                return "", err
+        }
+        if len(body) > maxLogoSize {
+                return "", fmt.Errorf("logo response exceeds %d byte limit", maxLogoSize)
 	}
 
 	contentType := resp.Header.Get("Content-Type")

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -130,6 +130,14 @@ func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLoo
 	pdpURL := cfg.AuthZENProxy.GetPDPURL(cfg.Trust.GetPDPURL())
 	cfg.AuthZENProxy.PDPURL = pdpURL
 
+	// Invariant: when resolution is enabled, the resolver must be non-nil.
+	// A nil resolver here means the caller failed to construct it — that is a
+	// programming error, not a runtime condition, so panic immediately rather
+	// than silently serving requests without metadata resolution.
+	if cfg.AuthZENProxy.AllowResolution && metadataResolver == nil {
+		panic("authzen: AllowResolution=true but metadataResolver is nil — check server startup")
+	}
+
 	handler := NewAuthZENProxyHandler(
 		&cfg.AuthZENProxy,
 		authorizerInterface,
@@ -369,15 +377,17 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 		return
 	}
 
-	// For URL subjects, resolve locally when a metadata resolver is configured.
-	// If no resolver is configured, fall back to proxying to the PDP for
-	// backward compatibility.
+	// For URL subjects, resolve locally via the metadata resolver.
+	// A nil resolver at this point is a startup misconfiguration (caught by
+	// NewAuthZENProxyHandlerFromConfig); return 503 as defense-in-depth.
 	if subjectType == "url" {
-		if h.metadataResolver != nil {
-			h.resolveURLSubject(c, ctx, tenantID, req.SubjectID)
+		if h.metadataResolver == nil {
+			h.logger.Error("metadata resolver is nil for URL subject — this is a startup misconfiguration")
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "issuer metadata resolution not configured"})
 			return
 		}
-		// No local resolver configured — fall through to PDP proxy
+		h.resolveURLSubject(c, ctx, tenantID, req.SubjectID)
+		return
 	}
 
 	// For key subjects, proxy to PDP

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -16,10 +16,10 @@ import (
 	"github.com/gin-gonic/gin"
 	gotrust "github.com/sirosfoundation/go-trust/pkg/authzen"
 	"github.com/sirosfoundation/go-trust/pkg/authzenclient"
-	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/authz"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/trust"
 	"go.uber.org/zap"
 )

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 	gotrust "github.com/sirosfoundation/go-trust/pkg/authzen"
-	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/authz"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
 	"go.uber.org/zap"
 )
 

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -1423,8 +1423,8 @@ func TestResolve_URLSubject_MetadataResolutionFailure(t *testing.T) {
 }
 
 func TestResolve_URLSubject_LogoInlining(t *testing.T) {
-	// Serve a test logo image
-	logoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Serve a test logo image over TLS — logo inlining requires HTTPS.
+	logoServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/png")
 		w.Write([]byte("fake-png-data"))
 	}))
@@ -1478,7 +1478,8 @@ func TestResolve_URLSubject_LogoInlining(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+	// Use the TLS server's client so the handler can fetch HTTPS logo URLs.
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, logoServer.Client(), logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -76,8 +76,17 @@ func setupAuthZENProxyHandlerWithTenants(t *testing.T, authorizer authz.Authoriz
 		AllowResolution: true,
 	}
 
+	// Default mock resolver that returns basic unsigned metadata
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{
+				"credential_issuer": "https://issuer.example.com",
+			},
+		},
+	}
+
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, authorizer, tenantLookup, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, authorizer, tenantLookup, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 
@@ -558,17 +567,16 @@ func TestResolve_URLSubject_DefaultsToKey(t *testing.T) {
 }
 
 func TestResolve_URLSubject_ExplicitType(t *testing.T) {
-	// Mock PDP that verifies the subject type is "url" and resource type is "credential_issuer"
+	// With explicit subject_type "url", the subject is resolved locally.
+	// The PDP receives a key-based trust evaluation request.
 	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var evalReq gotrust.EvaluationRequest
 		if err := json.NewDecoder(r.Body).Decode(&evalReq); err != nil {
 			t.Fatalf("Failed to decode request: %v", err)
 		}
-		if evalReq.Subject.Type != "url" {
-			t.Errorf("Expected subject.type 'url', got %q", evalReq.Subject.Type)
-		}
-		if evalReq.Resource.Type != "credential_issuer" {
-			t.Errorf("Expected resource.type 'credential_issuer', got %q", evalReq.Resource.Type)
+		// Local resolution sends subject.type "key" to the PDP
+		if evalReq.Subject.Type != "key" {
+			t.Errorf("Expected subject.type 'key', got %q", evalReq.Subject.Type)
 		}
 		resp := gotrust.EvaluationResponse{Decision: true}
 		w.Header().Set("Content-Type", "application/json")
@@ -699,7 +707,14 @@ func TestResolve_URLSubject_SPOCP_DefaultRules_Authorized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create SPOCP authorizer: %v", err)
 	}
-	handler := NewAuthZENProxyHandler(cfg, spocpAuth, nil, nil, http.DefaultClient, logger)
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{
+				"credential_issuer": "https://issuer.example.com",
+			},
+		},
+	}
+	handler := NewAuthZENProxyHandler(cfg, spocpAuth, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1307,7 +1322,8 @@ func TestResolve_URLSubject_LocalResolution(t *testing.T) {
 }
 
 func TestResolve_URLSubject_Untrusted(t *testing.T) {
-	// Mock PDP that returns untrusted
+	// Unsigned metadata that is untrusted: should still return metadata with decision=false.
+	// Logos are inlined because metadata is unsigned (display-only, no trust claim).
 	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := gotrust.EvaluationResponse{Decision: false}
 		w.Header().Set("Content-Type", "application/json")
@@ -1580,16 +1596,28 @@ func TestResolve_KeySubject_ProxiesToPDP(t *testing.T) {
 	}
 }
 
-func TestResolve_URLSubject_NoResolver_ProxiesToPDP(t *testing.T) {
-	// When no metadata resolver is configured, URL subjects should fall back to PDP proxy
+func TestResolve_URLSubject_SignedUntrusted_Error(t *testing.T) {
+	// When metadata contains signed_metadata but is untrusted, must return an error
 	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := gotrust.EvaluationResponse{Decision: true}
+		resp := gotrust.EvaluationResponse{Decision: false}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	})
 
 	pdpServer := httptest.NewServer(pdpHandler)
 	defer pdpServer.Close()
+
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{
+				"credential_issuer": "https://signed-untrusted.example.com",
+				"signed_metadata":   "eyJhbGciOiJFUzI1NiJ9.fake.signature",
+				"jwks": map[string]interface{}{
+					"keys": []interface{}{map[string]interface{}{"kty": "EC"}},
+				},
+			},
+		},
+	}
 
 	cfg := &config.AuthZENProxyConfig{
 		Enabled:         true,
@@ -1598,8 +1626,7 @@ func TestResolve_URLSubject_NoResolver_ProxiesToPDP(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	// No metadata resolver - should fall back to PDP proxy
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1609,7 +1636,7 @@ func TestResolve_URLSubject_NoResolver_ProxiesToPDP(t *testing.T) {
 	router.POST("/v1/resolve", handler.Resolve)
 
 	body, _ := json.Marshal(map[string]string{
-		"subject_id":   "https://issuer.example.com",
+		"subject_id":   "https://signed-untrusted.example.com",
 		"subject_type": "url",
 	})
 
@@ -1618,7 +1645,7 @@ func TestResolve_URLSubject_NoResolver_ProxiesToPDP(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected status %d for signed+untrusted, got %d: %s", http.StatusForbidden, w.Code, w.Body.String())
 	}
 }

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	gotrust "github.com/sirosfoundation/go-trust/pkg/authzen"
+	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/authz"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
@@ -76,7 +77,7 @@ func setupAuthZENProxyHandlerWithTenants(t *testing.T, authorizer authz.Authoriz
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, authorizer, tenantLookup, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, authorizer, tenantLookup, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 
@@ -158,7 +159,7 @@ func TestEvaluate_Unauthorized_NoTenant(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	// No middleware to set tenant_id
@@ -230,7 +231,7 @@ func TestEvaluate_ServiceUnavailable_NoPDP(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -366,7 +367,7 @@ func TestResolve_ServiceUnavailable_NoPDP(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -400,7 +401,7 @@ func TestResolve_Forbidden_ResolutionDisabled(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -431,7 +432,7 @@ func TestResolve_Unauthorized_NoTenantID(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	// No middleware setting tenant_id
@@ -459,7 +460,7 @@ func TestResolve_InternalError_BadTenantIDType(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -497,7 +498,7 @@ func TestResolve_BadGateway_PDPError(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -698,7 +699,7 @@ func TestResolve_URLSubject_SPOCP_DefaultRules_Authorized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create SPOCP authorizer: %v", err)
 	}
-	handler := NewAuthZENProxyHandler(cfg, spocpAuth, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, spocpAuth, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -772,7 +773,7 @@ func TestGetPDPURL(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	// Returns the global URL when no per-tenant config is available
 	ctx := context.Background()
@@ -793,7 +794,7 @@ func TestNewAuthZENProxyHandler(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	if handler == nil {
 		t.Fatal("Expected handler to not be nil")
@@ -820,7 +821,7 @@ func TestGetClient_Caching(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 
 	// First call creates client
 	client1, err := handler.getClient("https://pdp1.example.com")
@@ -882,7 +883,7 @@ func TestGetPDPURL_PerTenantConfig(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, http.DefaultClient, logger)
 
 	ctx := context.Background()
 
@@ -917,7 +918,7 @@ func TestGetPDPURL_PerTenantConfig(t *testing.T) {
 	})
 
 	t.Run("nil tenant lookup uses global URL", func(t *testing.T) {
-		handlerNoLookup := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, http.DefaultClient, logger)
+		handlerNoLookup := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
 		url, err := handlerNoLookup.getPDPURL(ctx, "any-tenant")
 		if err != nil {
 			t.Fatalf("getPDPURL() unexpected error: %v", err)
@@ -944,7 +945,7 @@ func TestGetPDPURL_FailClosedBehavior(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, http.DefaultClient, logger)
 
 	ctx := context.Background()
 
@@ -962,7 +963,7 @@ func TestGetPDPURL_FailClosedBehavior(t *testing.T) {
 			Timeout:                     30,
 			FailOpenOnTenantLookupError: true, // fail-open
 		}
-		handlerFailOpen := NewAuthZENProxyHandler(cfgFailOpen, &mockAuthorizer{allowAll: true}, tenantLookup, http.DefaultClient, logger)
+		handlerFailOpen := NewAuthZENProxyHandler(cfgFailOpen, &mockAuthorizer{allowAll: true}, tenantLookup, nil, http.DefaultClient, logger)
 
 		url, err := handlerFailOpen.getPDPURL(ctx, "any-tenant")
 		if err != nil {
@@ -985,7 +986,7 @@ func TestNewAuthZENProxyHandlerFromConfig_Disabled(t *testing.T) {
 		},
 	}
 	logger := zap.NewNop()
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error when disabled, got: %v", err)
 	}
@@ -1005,7 +1006,7 @@ func TestNewAuthZENProxyHandlerFromConfig_EnabledNoRulesFile(t *testing.T) {
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error with no rules file, got: %v", err)
 	}
@@ -1031,7 +1032,7 @@ func TestNewAuthZENProxyHandlerFromConfig_EnabledBadRulesFile_DebugMode(t *testi
 	logger := zap.NewNop()
 	// gin.TestMode is set in init(), so the release-mode fail-closed guard won't trigger
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error in test mode with bad rules file, got: %v", err)
 	}
@@ -1055,7 +1056,7 @@ func TestNewAuthZENProxyHandlerFromConfig_EnabledBadRulesFile_ReleaseMode(t *tes
 	gin.SetMode(gin.ReleaseMode)
 	defer gin.SetMode(gin.TestMode)
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
 	if err == nil {
 		t.Error("expected error in release mode when SPOCP authorizer cannot be initialized")
 	}
@@ -1078,7 +1079,7 @@ func TestNewAuthZENProxyHandlerFromConfig_PDPURLFromAuthZENConfig(t *testing.T) 
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -1105,7 +1106,7 @@ func TestNewAuthZENProxyHandlerFromConfig_PDPURLFallbackFromTrust(t *testing.T) 
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -1129,7 +1130,7 @@ func TestNewAuthZENProxyHandlerFromConfig_SetsDefaultTimeout(t *testing.T) {
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -1163,7 +1164,7 @@ func TestNewAuthZENProxyHandlerFromConfig_WithTenantLookup(t *testing.T) {
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, tenantLookup, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, tenantLookup, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -1178,5 +1179,446 @@ func TestNewAuthZENProxyHandlerFromConfig_WithTenantLookup(t *testing.T) {
 	}
 	if pdpURL != "https://tenant-pdp.example.com" {
 		t.Errorf("expected per-tenant PDP URL, got: %s", pdpURL)
+	}
+}
+
+// ============================================================================
+// URL Subject Resolution Tests
+// ============================================================================
+
+// mockMetadataResolver implements IssuerMetadataResolver for testing
+type mockMetadataResolver struct {
+	result *issuermetadata.ResolveResult
+	err    error
+}
+
+func (m *mockMetadataResolver) ResolveWithInfo(ctx context.Context, issuerURL string) (*issuermetadata.ResolveResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.result, nil
+}
+
+func TestResolve_URLSubject_LocalResolution(t *testing.T) {
+	// Mock PDP that returns a trust decision
+	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req gotrust.EvaluationRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Verify the PDP receives a key-based request (not URL)
+		if req.Subject.Type != "key" {
+			t.Errorf("expected PDP to receive subject.type='key', got '%s'", req.Subject.Type)
+		}
+		if req.Resource.Type != "jwk" {
+			t.Errorf("expected resource.type='jwk', got '%s'", req.Resource.Type)
+		}
+		if len(req.Resource.Key) == 0 {
+			t.Error("expected non-empty resource.key")
+		}
+
+		resp := gotrust.EvaluationResponse{Decision: true}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	pdpServer := httptest.NewServer(pdpHandler)
+	defer pdpServer.Close()
+
+	metadata := map[string]interface{}{
+		"credential_issuer":   "https://issuer.example.com",
+		"credential_endpoint": "https://issuer.example.com/credential",
+		"jwks": map[string]interface{}{
+			"keys": []interface{}{
+				map[string]interface{}{
+					"kty": "EC",
+					"crv": "P-256",
+					"x":   "test-x",
+					"y":   "test-y",
+				},
+			},
+		},
+		"display": []interface{}{
+			map[string]interface{}{
+				"name": "Test Issuer",
+			},
+		},
+	}
+
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: metadata,
+		},
+	}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Set("user_id", "test-user")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":   "https://issuer.example.com",
+		"subject_type": "url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var resp gotrust.EvaluationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if !resp.Decision {
+		t.Error("expected decision=true")
+	}
+	if resp.Context == nil || resp.Context.TrustMetadata == nil {
+		t.Fatal("expected trust_metadata in response")
+	}
+
+	// Verify metadata is returned
+	tm, ok := resp.Context.TrustMetadata.(map[string]interface{})
+	if !ok {
+		t.Fatal("expected trust_metadata to be a map")
+	}
+	if tm["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("expected credential_issuer in metadata, got: %v", tm["credential_issuer"])
+	}
+}
+
+func TestResolve_URLSubject_Untrusted(t *testing.T) {
+	// Mock PDP that returns untrusted
+	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := gotrust.EvaluationResponse{Decision: false}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	pdpServer := httptest.NewServer(pdpHandler)
+	defer pdpServer.Close()
+
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{
+				"credential_issuer": "https://untrusted.example.com",
+				"jwks": map[string]interface{}{
+					"keys": []interface{}{map[string]interface{}{"kty": "EC"}},
+				},
+			},
+		},
+	}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":   "https://untrusted.example.com",
+		"subject_type": "url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var resp gotrust.EvaluationResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp.Decision {
+		t.Error("expected decision=false for untrusted issuer")
+	}
+	// Metadata should still be returned even when untrusted
+	if resp.Context == nil || resp.Context.TrustMetadata == nil {
+		t.Fatal("expected trust_metadata even for untrusted issuer")
+	}
+}
+
+func TestResolve_URLSubject_MetadataResolutionFailure(t *testing.T) {
+	resolver := &mockMetadataResolver{
+		err: fmt.Errorf("connection refused"),
+	}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          "http://pdp.example.com",
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":   "https://broken.example.com",
+		"subject_type": "url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected status %d, got %d: %s", http.StatusBadGateway, w.Code, w.Body.String())
+	}
+}
+
+func TestResolve_URLSubject_LogoInlining(t *testing.T) {
+	// Serve a test logo image
+	logoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("fake-png-data"))
+	}))
+	defer logoServer.Close()
+
+	// Mock PDP that returns trusted
+	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := gotrust.EvaluationResponse{Decision: true}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	pdpServer := httptest.NewServer(pdpHandler)
+	defer pdpServer.Close()
+
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{
+				"credential_issuer": "https://issuer.example.com",
+				"jwks": map[string]interface{}{
+					"keys": []interface{}{map[string]interface{}{"kty": "EC"}},
+				},
+				"display": []interface{}{
+					map[string]interface{}{
+						"name": "Test Issuer",
+						"logo": map[string]interface{}{
+							"uri": logoServer.URL + "/logo.png",
+						},
+					},
+				},
+				"credential_configurations_supported": map[string]interface{}{
+					"pid": map[string]interface{}{
+						"format": "vc+sd-jwt",
+						"display": []interface{}{
+							map[string]interface{}{
+								"name": "Personal ID",
+								"logo": map[string]interface{}{
+									"uri": logoServer.URL + "/cred-logo.png",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":   "https://issuer.example.com",
+		"subject_type": "url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var resp gotrust.EvaluationResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if !resp.Decision {
+		t.Fatal("expected decision=true")
+	}
+
+	// Check that logos were inlined as data: URIs
+	tm := resp.Context.TrustMetadata.(map[string]interface{})
+	display := tm["display"].([]interface{})
+	d0 := display[0].(map[string]interface{})
+	logo := d0["logo"].(map[string]interface{})
+	logoURI := logo["uri"].(string)
+	if !strings.HasPrefix(logoURI, "data:image/png;base64,") {
+		t.Errorf("expected inlined data: URI for top-level logo, got: %s", logoURI)
+	}
+
+	// Check credential configuration logo
+	ccs := tm["credential_configurations_supported"].(map[string]interface{})
+	pid := ccs["pid"].(map[string]interface{})
+	credDisplay := pid["display"].([]interface{})
+	cd0 := credDisplay[0].(map[string]interface{})
+	credLogo := cd0["logo"].(map[string]interface{})
+	credLogoURI := credLogo["uri"].(string)
+	if !strings.HasPrefix(credLogoURI, "data:image/png;base64,") {
+		t.Errorf("expected inlined data: URI for credential logo, got: %s", credLogoURI)
+	}
+}
+
+func TestResolve_KeySubject_ProxiesToPDP(t *testing.T) {
+	// For key subjects, should proxy directly to PDP (no local resolution)
+	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req gotrust.EvaluationRequest
+		json.NewDecoder(r.Body).Decode(&req)
+
+		// Key subjects should be proxied with subject_type="key"
+		if req.Subject.Type != "key" {
+			t.Errorf("expected subject.type='key', got '%s'", req.Subject.Type)
+		}
+
+		resp := gotrust.EvaluationResponse{
+			Decision: true,
+			Context: &gotrust.EvaluationResponseContext{
+				TrustMetadata: map[string]interface{}{"from": "pdp"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	pdpServer := httptest.NewServer(pdpHandler)
+	defer pdpServer.Close()
+
+	// Provide a resolver that should NOT be called for key subjects
+	resolver := &mockMetadataResolver{
+		err: fmt.Errorf("resolver should not be called for key subjects"),
+	}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id": "https://entity.example.com",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var resp gotrust.EvaluationResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if !resp.Decision {
+		t.Error("expected decision=true")
+	}
+}
+
+func TestResolve_URLSubject_NoResolver_ProxiesToPDP(t *testing.T) {
+	// When no metadata resolver is configured, URL subjects should fall back to PDP proxy
+	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := gotrust.EvaluationResponse{Decision: true}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	pdpServer := httptest.NewServer(pdpHandler)
+	defer pdpServer.Close()
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	// No metadata resolver - should fall back to PDP proxy
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":   "https://issuer.example.com",
+		"subject_type": "url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 }

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1598,9 +1599,9 @@ func TestResolve_KeySubject_ProxiesToPDP(t *testing.T) {
 }
 
 func TestResolve_URLSubject_SignedMetadata_VerificationFailed_Error(t *testing.T) {
-	// When metadata contains a signed_metadata field whose JWT cannot be verified,
-	// the handler must reject immediately with 502 rather than forwarding
-	// potentially misleading unverified data.
+	// When metadata contains a signed_metadata field whose JWT has an embedded
+	// key (x5c/jwk) but verification fails, the handler must reject immediately
+	// with 502 rather than forwarding potentially misleading unverified data.
 	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := gotrust.EvaluationResponse{Decision: false}
 		w.Header().Set("Content-Type", "application/json")
@@ -1610,14 +1611,17 @@ func TestResolve_URLSubject_SignedMetadata_VerificationFailed_Error(t *testing.T
 	pdpServer := httptest.NewServer(pdpHandler)
 	defer pdpServer.Close()
 
+	// Use a JWT with a jwk header (embedded key present) but an invalid signature
+	// so that VerifyJWTWithEmbeddedKey returns a verification failure.
+	fakeJWKHeader := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"ES256","jwk":{"kty":"EC","crv":"P-256","x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU","y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"}}`))
+	fakeJWT := fakeJWKHeader + ".fake-payload.fake-signature"
+
 	resolver := &mockMetadataResolver{
 		result: &issuermetadata.ResolveResult{
+			Signed: true,
 			Metadata: map[string]interface{}{
 				"credential_issuer": "https://signed-untrusted.example.com",
-				"signed_metadata":   "eyJhbGciOiJFUzI1NiJ9.fake.signature",
-				"jwks": map[string]interface{}{
-					"keys": []interface{}{map[string]interface{}{"kty": "EC"}},
-				},
+				"signed_metadata":   fakeJWT,
 			},
 		},
 	}

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -86,7 +86,7 @@ func setupAuthZENProxyHandlerWithTenants(t *testing.T, authorizer authz.Authoriz
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, authorizer, tenantLookup, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, authorizer, tenantLookup, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 
@@ -168,7 +168,7 @@ func TestEvaluate_Unauthorized_NoTenant(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	// No middleware to set tenant_id
@@ -240,7 +240,7 @@ func TestEvaluate_ServiceUnavailable_NoPDP(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -376,7 +376,7 @@ func TestResolve_ServiceUnavailable_NoPDP(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -410,7 +410,7 @@ func TestResolve_Forbidden_ResolutionDisabled(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -441,7 +441,7 @@ func TestResolve_Unauthorized_NoTenantID(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	// No middleware setting tenant_id
@@ -469,7 +469,7 @@ func TestResolve_InternalError_BadTenantIDType(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -507,7 +507,7 @@ func TestResolve_BadGateway_PDPError(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -714,7 +714,7 @@ func TestResolve_URLSubject_SPOCP_DefaultRules_Authorized(t *testing.T) {
 			},
 		},
 	}
-	handler := NewAuthZENProxyHandler(cfg, spocpAuth, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, spocpAuth, nil, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -788,7 +788,7 @@ func TestGetPDPURL(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	// Returns the global URL when no per-tenant config is available
 	ctx := context.Background()
@@ -809,7 +809,7 @@ func TestNewAuthZENProxyHandler(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	if handler == nil {
 		t.Fatal("Expected handler to not be nil")
@@ -836,7 +836,7 @@ func TestGetClient_Caching(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 
 	// First call creates client
 	client1, err := handler.getClient("https://pdp1.example.com")
@@ -898,7 +898,7 @@ func TestGetPDPURL_PerTenantConfig(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, logger)
 
 	ctx := context.Background()
 
@@ -933,7 +933,7 @@ func TestGetPDPURL_PerTenantConfig(t *testing.T) {
 	})
 
 	t.Run("nil tenant lookup uses global URL", func(t *testing.T) {
-		handlerNoLookup := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, http.DefaultClient, logger)
+		handlerNoLookup := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
 		url, err := handlerNoLookup.getPDPURL(ctx, "any-tenant")
 		if err != nil {
 			t.Fatalf("getPDPURL() unexpected error: %v", err)
@@ -960,7 +960,7 @@ func TestGetPDPURL_FailClosedBehavior(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, logger)
 
 	ctx := context.Background()
 
@@ -978,7 +978,7 @@ func TestGetPDPURL_FailClosedBehavior(t *testing.T) {
 			Timeout:                     30,
 			FailOpenOnTenantLookupError: true, // fail-open
 		}
-		handlerFailOpen := NewAuthZENProxyHandler(cfgFailOpen, &mockAuthorizer{allowAll: true}, tenantLookup, nil, http.DefaultClient, logger)
+		handlerFailOpen := NewAuthZENProxyHandler(cfgFailOpen, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, logger)
 
 		url, err := handlerFailOpen.getPDPURL(ctx, "any-tenant")
 		if err != nil {
@@ -1001,7 +1001,7 @@ func TestNewAuthZENProxyHandlerFromConfig_Disabled(t *testing.T) {
 		},
 	}
 	logger := zap.NewNop()
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error when disabled, got: %v", err)
 	}
@@ -1021,7 +1021,7 @@ func TestNewAuthZENProxyHandlerFromConfig_EnabledNoRulesFile(t *testing.T) {
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error with no rules file, got: %v", err)
 	}
@@ -1047,7 +1047,7 @@ func TestNewAuthZENProxyHandlerFromConfig_EnabledBadRulesFile_DebugMode(t *testi
 	logger := zap.NewNop()
 	// gin.TestMode is set in init(), so the release-mode fail-closed guard won't trigger
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error in test mode with bad rules file, got: %v", err)
 	}
@@ -1071,7 +1071,7 @@ func TestNewAuthZENProxyHandlerFromConfig_EnabledBadRulesFile_ReleaseMode(t *tes
 	gin.SetMode(gin.ReleaseMode)
 	defer gin.SetMode(gin.TestMode)
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, nil, http.DefaultClient, logger)
 	if err == nil {
 		t.Error("expected error in release mode when SPOCP authorizer cannot be initialized")
 	}
@@ -1094,7 +1094,7 @@ func TestNewAuthZENProxyHandlerFromConfig_PDPURLFromAuthZENConfig(t *testing.T) 
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -1121,7 +1121,7 @@ func TestNewAuthZENProxyHandlerFromConfig_PDPURLFallbackFromTrust(t *testing.T) 
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -1145,7 +1145,7 @@ func TestNewAuthZENProxyHandlerFromConfig_SetsDefaultTimeout(t *testing.T) {
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, nil, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -1179,7 +1179,7 @@ func TestNewAuthZENProxyHandlerFromConfig_WithTenantLookup(t *testing.T) {
 	}
 	logger := zap.NewNop()
 
-	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, tenantLookup, nil, http.DefaultClient, logger)
+	handler, err := NewAuthZENProxyHandlerFromConfig(cfg, tenantLookup, nil, nil, http.DefaultClient, logger)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -1275,7 +1275,7 @@ func TestResolve_URLSubject_LocalResolution(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1351,7 +1351,7 @@ func TestResolve_URLSubject_Untrusted(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1398,7 +1398,7 @@ func TestResolve_URLSubject_MetadataResolutionFailure(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1479,7 +1479,7 @@ func TestResolve_URLSubject_LogoInlining(t *testing.T) {
 	}
 	logger := zap.NewNop()
 	// Use the TLS server's client so the handler can fetch HTTPS logo URLs.
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, logoServer.Client(), logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, logoServer.Client(), logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1567,7 +1567,7 @@ func TestResolve_KeySubject_ProxiesToPDP(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1627,7 +1627,7 @@ func TestResolve_URLSubject_SignedUntrusted_Error(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1648,5 +1648,151 @@ func TestResolve_URLSubject_SignedUntrusted_Error(t *testing.T) {
 
 	if w.Code != http.StatusForbidden {
 		t.Errorf("expected status %d for signed+untrusted, got %d: %s", http.StatusForbidden, w.Code, w.Body.String())
+	}
+}
+
+// mockIssuerLookup implements IssuerLookup for testing.
+type mockIssuerLookup struct {
+	issuer *domain.CredentialIssuer
+	err    error
+}
+
+func (m *mockIssuerLookup) GetByIdentifier(_ context.Context, _ domain.TenantID, _ string) (*domain.CredentialIssuer, error) {
+	return m.issuer, m.err
+}
+
+func TestResolve_URLSubject_RegisteredIssuerInfo_IncludedWhenFound(t *testing.T) {
+	// When an issuer is registered in the backend storage, /v1/resolve should
+	// include its registration info (e.g. client_id) in the response as
+	// registered_issuer — separate from trust_metadata.
+	pdpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := gotrust.EvaluationResponse{Decision: true}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer pdpServer.Close()
+
+	metadata := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+	}
+	resolver := &mockMetadataResolver{result: &issuermetadata.ResolveResult{Metadata: metadata}}
+
+	registeredIssuer := &domain.CredentialIssuer{
+		CredentialIssuerIdentifier: "https://issuer.example.com",
+		ClientID:                   "my-client-id",
+		Visible:                    true,
+		TrustStatus:                domain.TrustStatus("trusted"),
+		TrustFramework:             "EUCS",
+	}
+	issuerLookup := &mockIssuerLookup{issuer: registeredIssuer}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, issuerLookup, resolver, http.DefaultClient, zap.NewNop())
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":   "https://issuer.example.com",
+		"subject_type": "url",
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	reg, ok := resp["registered_issuer"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected registered_issuer in response, got: %v", resp["registered_issuer"])
+	}
+	if reg["client_id"] != "my-client-id" {
+		t.Errorf("expected client_id=my-client-id, got: %v", reg["client_id"])
+	}
+	if reg["trust_framework"] != "EUCS" {
+		t.Errorf("expected trust_framework=EUCS, got: %v", reg["trust_framework"])
+	}
+	if reg["visible"] != true {
+		t.Errorf("expected visible=true, got: %v", reg["visible"])
+	}
+
+	// trust_metadata should still be present and unchanged
+	ctx, ok := resp["context"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected context in response")
+	}
+	if ctx["trust_metadata"] == nil {
+		t.Error("expected trust_metadata in context")
+	}
+}
+
+func TestResolve_URLSubject_RegisteredIssuerInfo_OmittedWhenNotFound(t *testing.T) {
+	// When the issuer is not registered in backend storage, registered_issuer
+	// should be absent from the response.
+	pdpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := gotrust.EvaluationResponse{Decision: true}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer pdpServer.Close()
+
+	metadata := map[string]interface{}{
+		"credential_issuer": "https://unknown-issuer.example.com",
+	}
+	resolver := &mockMetadataResolver{result: &issuermetadata.ResolveResult{Metadata: metadata}}
+	issuerLookup := &mockIssuerLookup{issuer: nil, err: nil}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, issuerLookup, resolver, http.DefaultClient, zap.NewNop())
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":   "https://unknown-issuer.example.com",
+		"subject_type": "url",
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if _, exists := resp["registered_issuer"]; exists {
+		t.Errorf("expected registered_issuer to be absent, got: %v", resp["registered_issuer"])
 	}
 }

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -1597,8 +1597,10 @@ func TestResolve_KeySubject_ProxiesToPDP(t *testing.T) {
 	}
 }
 
-func TestResolve_URLSubject_SignedUntrusted_Error(t *testing.T) {
-	// When metadata contains signed_metadata but is untrusted, must return an error
+func TestResolve_URLSubject_SignedMetadata_VerificationFailed_Error(t *testing.T) {
+	// When metadata contains a signed_metadata field whose JWT cannot be verified,
+	// the handler must reject immediately with 502 rather than forwarding
+	// potentially misleading unverified data.
 	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := gotrust.EvaluationResponse{Decision: false}
 		w.Header().Set("Content-Type", "application/json")
@@ -1646,8 +1648,8 @@ func TestResolve_URLSubject_SignedUntrusted_Error(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Errorf("expected status %d for signed+untrusted, got %d: %s", http.StatusForbidden, w.Code, w.Body.String())
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected status %d for unverifiable signed_metadata JWT, got %d: %s", http.StatusBadGateway, w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/issuer_metadata_test.go
+++ b/internal/api/issuer_metadata_test.go
@@ -34,6 +34,8 @@ func setupIssuerMetadataTest(t *testing.T) (*Handlers, *gin.Engine, *memory.Stor
 			ExpiryHours: 24,
 			Issuer:      "test-wallet",
 		},
+		// Allow loopback so tests using httptest.NewServer can reach mock servers.
+		HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 	}
 
 	store := memory.NewStore()

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -23,6 +23,9 @@ func testConfig() *config.Config {
 		Server: config.ServerConfig{
 			RegistryPort: 8097,
 		},
+		HTTPClient: config.HTTPClientConfig{
+			AllowPrivateIPs: true,
+		},
 	}
 }
 

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
@@ -33,20 +34,31 @@ type MetadataResolver interface {
 	ResolveWithInfo(ctx context.Context, issuerURL string) (*issuermetadata.ResolveResult, error)
 }
 
+// CredentialIssuerLookup looks up registered credential issuers by identifier within a tenant.
+// This interface is satisfied by storage.IssuerStore.
+type CredentialIssuerLookup interface {
+	GetByIdentifier(ctx context.Context, tenantID domain.TenantID, identifier string) (*domain.CredentialIssuer, error)
+}
+
 // OID4VCIHandler handles OpenID4VCI credential issuance flows
 type OID4VCIHandler struct {
 	BaseHandler
 	httpClient       *http.Client
 	metadataResolver MetadataResolver
-	dpopKey          *ecdsa.PrivateKey // ephemeral DPoP key pair (RFC 9449)
-	dpopNonce        string            // server-provided DPoP nonce (RFC 9449 §8)
+	issuerLookup     CredentialIssuerLookup // optional; nil-safe
+	dpopKey          *ecdsa.PrivateKey      // ephemeral DPoP key pair (RFC 9449)
+	dpopNonce        string                 // server-provided DPoP nonce (RFC 9449 §8)
 	redirectURI      string
+	clientID         string // effective OAuth client_id; defaults to redirectURI, overridden by registered issuer's ClientID
 }
 
 // NewOID4VCIHandlerFactory returns a FlowHandlerFactory that shares the given
 // MetadataResolver across all handler instances, so the resolver's TTL cache
 // deduplicates metadata fetches across flows.
-func NewOID4VCIHandlerFactory(resolver MetadataResolver) FlowHandlerFactory {
+// issuerLookup is optional (nil-safe); when provided, fetchMetadata also returns
+// the registered-issuer record from backend storage so callers have the same
+// enriched view as the /v1/resolve HTTP endpoint.
+func NewOID4VCIHandlerFactory(resolver MetadataResolver, issuerLookup CredentialIssuerLookup) FlowHandlerFactory {
 	return func(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore, trustCache *TrustCache) (FlowHandler, error) {
 		return &OID4VCIHandler{
 			BaseHandler: BaseHandler{
@@ -58,6 +70,7 @@ func NewOID4VCIHandlerFactory(resolver MetadataResolver) FlowHandlerFactory {
 			},
 			httpClient:       cfg.HTTPClient.NewHTTPClient(0),
 			metadataResolver: resolver,
+			issuerLookup:     issuerLookup,
 		}, nil
 	}
 }
@@ -416,6 +429,18 @@ func (h *OID4VCIHandler) Execute(ctx context.Context, msg *FlowStartMessage) err
 	metadata := metaResult.Metadata
 	h.SetData("metadata", metadata)
 
+	// Resolve effective client_id for all subsequent OAuth steps.
+	// Default to redirect_uri (OID4VCI §7.1 unregistered-client convention).
+	// When the issuer is registered and carries a known client_id, use that instead.
+	h.clientID = h.redirectURI
+	if r := metaResult.RegisteredIssuer; r != nil && r.ClientID != "" {
+		h.clientID = r.ClientID
+		h.Logger.Debug("using registered client_id for issuer",
+			zap.String("client_id", h.clientID),
+			zap.String("issuer", offer.CredentialIssuer),
+		)
+	}
+
 	// Step 3: Evaluate trust
 	trust, err := h.evaluateTrust(ctx, offer.CredentialIssuer, metadata, metaResult.Validated)
 	if err != nil {
@@ -594,10 +619,12 @@ func (h *OID4VCIHandler) fetchOfferFromURI(ctx context.Context, uri string) (*Cr
 	return &offer, nil
 }
 
-// metadataResult bundles parsed issuer metadata with the resolver's trust signal.
+// metadataResult bundles parsed issuer metadata with the resolver's trust signal
+// and any registered-issuer data from backend storage.
 type metadataResult struct {
-	Metadata  *IssuerMetadata
-	Validated bool // true when the resolver verified a signed metadata JWT
+	Metadata         *IssuerMetadata
+	Validated        bool                     // true when the resolver verified a signed metadata JWT
+	RegisteredIssuer *domain.CredentialIssuer // non-nil when the issuer is registered in this tenant
 }
 
 func (h *OID4VCIHandler) fetchMetadata(ctx context.Context, issuer string) (*metadataResult, error) {
@@ -618,6 +645,18 @@ func (h *OID4VCIHandler) fetchMetadata(ctx context.Context, issuer string) (*met
 		return nil, fmt.Errorf("failed to parse metadata: %w", err)
 	}
 
+	// Look up registered issuer record from backend storage when a lookup is wired.
+	// Errors are non-fatal: the issuer may simply not be registered in this tenant.
+	var registeredIssuer *domain.CredentialIssuer
+	if h.issuerLookup != nil {
+		tenantID := TenantFromContext(ctx)
+		if tenantID != "" {
+			if reg, lookupErr := h.issuerLookup.GetByIdentifier(ctx, domain.TenantID(tenantID), issuer); lookupErr == nil {
+				registeredIssuer = reg
+			}
+		}
+	}
+
 	_ = h.Progress(StepMetadataFetched, map[string]interface{}{
 		"credential_issuer":   metadata.CredentialIssuer,
 		"credential_endpoint": metadata.CredentialEndpoint,
@@ -625,7 +664,7 @@ func (h *OID4VCIHandler) fetchMetadata(ctx context.Context, issuer string) (*met
 		"validated":           result.Validated,
 	})
 
-	return &metadataResult{Metadata: &metadata, Validated: result.Validated}, nil
+	return &metadataResult{Metadata: &metadata, Validated: result.Validated, RegisteredIssuer: registeredIssuer}, nil
 }
 
 func (h *OID4VCIHandler) evaluateTrust(ctx context.Context, issuer string, metadata *IssuerMetadata, metadataValidated bool) (*TrustInfo, error) {
@@ -1096,7 +1135,7 @@ func (h *OID4VCIHandler) startAuthorizationFlow(ctx context.Context, offer *Cred
 	// Build common authorization parameters
 	params := url.Values{}
 	params.Set("response_type", "code")
-	params.Set("client_id", redirectURI) // OID4VCI: use redirect_uri as client_id for unregistered clients
+	params.Set("client_id", h.clientID) // registered client_id or redirect_uri for unregistered clients
 	params.Set("redirect_uri", redirectURI)
 	params.Set("state", oauthState)
 	if selectedConfig != nil && selectedConfig.Scope != "" {
@@ -1131,7 +1170,7 @@ func (h *OID4VCIHandler) startAuthorizationFlow(ctx context.Context, offer *Cred
 		} else {
 			// Build authorization URL with only client_id and request_uri
 			q := authEndpoint.Query()
-			q.Set("client_id", redirectURI)
+			q.Set("client_id", h.clientID)
 			q.Set("request_uri", requestURI)
 			authEndpoint.RawQuery = q.Encode()
 			authURL = authEndpoint.String()
@@ -1260,7 +1299,7 @@ func (h *OID4VCIHandler) exchangeAuthCode(ctx context.Context, metadata *IssuerM
 	data.Set("grant_type", "authorization_code")
 	data.Set("code", code)
 	data.Set("redirect_uri", redirectURI)
-	data.Set("client_id", redirectURI)
+	data.Set("client_id", h.clientID)
 	if codeVerifier != "" {
 		data.Set("code_verifier", codeVerifier)
 	}
@@ -1380,7 +1419,7 @@ func (h *OID4VCIHandler) requestProofs(ctx context.Context, metadata *IssuerMeta
 	resp, err := h.RequestSign(ctx, SignActionGenerateProof, SignRequestParams{
 		Audience:            metadata.CredentialIssuer,
 		Nonce:               nonce,
-		Issuer:              h.redirectURI,
+		Issuer:              h.clientID,
 		ProofTypesSupported: config.ProofTypesSupported,
 		Count:               count,
 	})

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -22,9 +22,9 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/trust"
 )
 

--- a/internal/engine/oid4vci_test.go
+++ b/internal/engine/oid4vci_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
-	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/internal/engine/oid4vci_test.go
+++ b/internal/engine/oid4vci_test.go
@@ -1763,6 +1763,7 @@ func TestRequestProofs_IssuerMatchesRedirectURI(t *testing.T) {
 	flow := &Flow{ID: "test-flow", Session: session, Data: make(map[string]interface{})}
 	h := &OID4VCIHandler{
 		redirectURI: "https://wallet.example.com/callback",
+		clientID:    "https://wallet.example.com/callback",
 	}
 	h.BaseHandler = BaseHandler{Flow: flow, Logger: zap.NewNop()}
 

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 
-	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/internal/api"
 	"github.com/sirosfoundation/go-wallet-backend/internal/backend"
 	wsengine "github.com/sirosfoundation/go-wallet-backend/internal/engine"
@@ -19,6 +18,7 @@ import (
 	"github.com/sirosfoundation/go-wallet-backend/internal/service"
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/middleware"
 )
 
@@ -247,9 +247,8 @@ func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.Ver
 	metadataResolver := sharedResolver
 	if metadataResolver == nil {
 		r, err := issuermetadata.New(issuermetadata.Config{
-			HTTPTimeout:     time.Duration(cfg.HTTPClient.Timeout) * time.Second,
-			AllowHTTP:       cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify,
-			AllowPrivateIPs: cfg.HTTPClient.AllowPrivateIPs || cfg.HTTPClient.InsecureSkipVerify,
+			HTTPClient: cfg.HTTPClient.NewHTTPClient(time.Duration(cfg.HTTPClient.Timeout) * time.Second),
+			AllowHTTP:  cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("creating issuer metadata resolver: %w", err)
@@ -347,9 +346,8 @@ func NewBackendProvider(cfg *config.Config, logger *zap.Logger, roles []string) 
 	var metadataResolver *issuermetadata.Resolver
 	if cfg.AuthZENProxy.Enabled && cfg.AuthZENProxy.AllowResolution {
 		r, err := issuermetadata.New(issuermetadata.Config{
-			HTTPTimeout:     time.Duration(cfg.HTTPClient.Timeout) * time.Second,
-			AllowHTTP:       cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify,
-			AllowPrivateIPs: cfg.HTTPClient.AllowPrivateIPs || cfg.HTTPClient.InsecureSkipVerify,
+			HTTPClient: cfg.HTTPClient.NewHTTPClient(time.Duration(cfg.HTTPClient.Timeout) * time.Second),
+			AllowHTTP:  cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify,
 		})
 		if err != nil {
 			if closeErr := store.Close(); closeErr != nil {

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -215,7 +215,9 @@ type EngineProvider struct {
 // If sharedResolver is non-nil, it is used for issuer metadata resolution so
 // the TTL cache is shared with the HTTP /v1/resolve handler; otherwise a new
 // resolver is created from the config.
-func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.VerifierStore, sharedResolver *issuermetadata.Resolver) (*EngineProvider, error) {
+// If issuerLookup is non-nil, the OID4VCI handler will enrich fetchMetadata results
+// with the registered-issuer record from backend storage (same data as /v1/resolve).
+func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.VerifierStore, sharedResolver *issuermetadata.Resolver, issuerLookup wsengine.CredentialIssuerLookup) (*EngineProvider, error) {
 	// Create WebSocket manager
 	manager := wsengine.NewManager(cfg, logger)
 
@@ -257,7 +259,7 @@ func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.Ver
 	}
 
 	// Register flow handlers
-	manager.RegisterFlowHandler(wsengine.ProtocolOID4VCI, wsengine.NewOID4VCIHandlerFactory(metadataResolver))
+	manager.RegisterFlowHandler(wsengine.ProtocolOID4VCI, wsengine.NewOID4VCIHandlerFactory(metadataResolver, issuerLookup))
 	manager.RegisterFlowHandler(wsengine.ProtocolOID4VP, wsengine.NewOID4VPHandler)
 	manager.RegisterFlowHandler(wsengine.ProtocolVCTM, wsengine.NewVCTMHandler)
 

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -351,7 +351,7 @@ func NewBackendProvider(cfg *config.Config, logger *zap.Logger, roles []string) 
 		metadataResolver = r
 	}
 
-	authzenHandler, err := api.NewAuthZENProxyHandlerFromConfig(cfg, store.Tenants(), metadataResolver, httpClient, logger)
+	authzenHandler, err := api.NewAuthZENProxyHandlerFromConfig(cfg, store.Tenants(), store.Issuers(), metadataResolver, httpClient, logger)
 	if err != nil {
 		if closeErr := store.Close(); closeErr != nil {
 			logger.Error("Failed to close store after AuthZEN proxy initialization failure", zap.Error(closeErr))

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -212,7 +212,10 @@ type EngineProvider struct {
 
 // NewEngineProvider creates a new WebSocket engine route provider.
 // If store is non-nil, the engine will cache verifier trust evaluations.
-func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.VerifierStore) (*EngineProvider, error) {
+// If sharedResolver is non-nil, it is used for issuer metadata resolution so
+// the TTL cache is shared with the HTTP /v1/resolve handler; otherwise a new
+// resolver is created from the config.
+func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.VerifierStore, sharedResolver *issuermetadata.Resolver) (*EngineProvider, error) {
 	// Create WebSocket manager
 	manager := wsengine.NewManager(cfg, logger)
 
@@ -238,15 +241,20 @@ func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.Ver
 		}
 	}
 
-	// Create a shared issuer metadata resolver so the TTL cache is effective
-	// across flows, and honour the service's HTTP client settings.
-	metadataResolver, err := issuermetadata.New(issuermetadata.Config{
-		HTTPTimeout:     time.Duration(cfg.HTTPClient.Timeout) * time.Second,
-		AllowHTTP:       cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify,
-		AllowPrivateIPs: cfg.HTTPClient.AllowPrivateIPs || cfg.HTTPClient.InsecureSkipVerify,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating issuer metadata resolver: %w", err)
+	// Use the shared resolver when available so the TTL cache is not duplicated.
+	// Fall back to creating a local resolver (e.g. when the engine runs without
+	// the backend provider, or when resolution is disabled on the backend).
+	metadataResolver := sharedResolver
+	if metadataResolver == nil {
+		r, err := issuermetadata.New(issuermetadata.Config{
+			HTTPTimeout:     time.Duration(cfg.HTTPClient.Timeout) * time.Second,
+			AllowHTTP:       cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify,
+			AllowPrivateIPs: cfg.HTTPClient.AllowPrivateIPs || cfg.HTTPClient.InsecureSkipVerify,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating issuer metadata resolver: %w", err)
+		}
+		metadataResolver = r
 	}
 
 	// Register flow handlers
@@ -302,12 +310,13 @@ func (p *EngineProvider) CheckReady(ctx context.Context) error {
 
 // BackendProvider provides the full backend API (auth + storage combined)
 type BackendProvider struct {
-	auth           *AuthProvider
-	storage        *StorageProvider
-	store          backend.Backend
-	cfg            *config.Config
-	authzenHandler *api.AuthZENProxyHandler
-	logger         *zap.Logger
+	auth             *AuthProvider
+	storage          *StorageProvider
+	store            backend.Backend
+	cfg              *config.Config
+	authzenHandler   *api.AuthZENProxyHandler
+	metadataResolver *issuermetadata.Resolver
+	logger           *zap.Logger
 }
 
 // NewBackendProvider creates a combined auth+storage provider
@@ -335,7 +344,7 @@ func NewBackendProvider(cfg *config.Config, logger *zap.Logger, roles []string) 
 	// Create issuer metadata resolver for local URL subject resolution.
 	// Only instantiated when AuthZEN proxy is enabled and resolution is allowed,
 	// so that a startup failure here does not affect deployments that don't use it.
-	var metadataResolver api.IssuerMetadataResolver
+	var metadataResolver *issuermetadata.Resolver
 	if cfg.AuthZENProxy.Enabled && cfg.AuthZENProxy.AllowResolution {
 		r, err := issuermetadata.New(issuermetadata.Config{
 			HTTPTimeout:     time.Duration(cfg.HTTPClient.Timeout) * time.Second,
@@ -360,12 +369,13 @@ func NewBackendProvider(cfg *config.Config, logger *zap.Logger, roles []string) 
 	}
 
 	return &BackendProvider{
-		auth:           NewAuthProvider(cfg, store, logger, roles),
-		storage:        NewStorageProvider(cfg, store, logger, roles),
-		store:          store,
-		cfg:            cfg,
-		authzenHandler: authzenHandler,
-		logger:         logger,
+		auth:             NewAuthProvider(cfg, store, logger, roles),
+		storage:          NewStorageProvider(cfg, store, logger, roles),
+		store:            store,
+		cfg:              cfg,
+		authzenHandler:   authzenHandler,
+		metadataResolver: metadataResolver,
+		logger:           logger,
 	}, nil
 }
 
@@ -415,6 +425,13 @@ func (p *BackendProvider) CheckReady(ctx context.Context) error {
 // Store returns the underlying storage backend
 func (p *BackendProvider) Store() backend.Backend {
 	return p.store
+}
+
+// MetadataResolver returns the shared issuer metadata resolver, or nil if
+// resolution is not enabled. The engine provider can accept this resolver to
+// share the TTL cache with the HTTP /v1/resolve handler.
+func (p *BackendProvider) MetadataResolver() *issuermetadata.Resolver {
+	return p.metadataResolver
 }
 
 // RegisterAdminRoutes implements AdminRouteProvider for BackendProvider.

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -332,17 +332,23 @@ func NewBackendProvider(cfg *config.Config, logger *zap.Logger, roles []string) 
 	// Initialize AuthZEN proxy handler (for frontend trust evaluation)
 	httpClient := cfg.HTTPClient.NewHTTPClient(0)
 
-	// Create issuer metadata resolver for local URL subject resolution
-	metadataResolver, err := issuermetadata.New(issuermetadata.Config{
-		HTTPTimeout:     time.Duration(cfg.HTTPClient.Timeout) * time.Second,
-		AllowHTTP:       cfg.HTTPClient.InsecureSkipVerify,
-		AllowPrivateIPs: cfg.HTTPClient.InsecureSkipVerify,
-	})
-	if err != nil {
-		if closeErr := store.Close(); closeErr != nil {
-			logger.Error("Failed to close store after metadata resolver creation failure", zap.Error(closeErr))
+	// Create issuer metadata resolver for local URL subject resolution.
+	// Only instantiated when AuthZEN proxy is enabled and resolution is allowed,
+	// so that a startup failure here does not affect deployments that don't use it.
+	var metadataResolver api.IssuerMetadataResolver
+	if cfg.AuthZENProxy.Enabled && cfg.AuthZENProxy.AllowResolution {
+		r, err := issuermetadata.New(issuermetadata.Config{
+			HTTPTimeout:     time.Duration(cfg.HTTPClient.Timeout) * time.Second,
+			AllowHTTP:       cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify,
+			AllowPrivateIPs: cfg.HTTPClient.AllowPrivateIPs || cfg.HTTPClient.InsecureSkipVerify,
+		})
+		if err != nil {
+			if closeErr := store.Close(); closeErr != nil {
+				logger.Error("Failed to close store after metadata resolver creation failure", zap.Error(closeErr))
+			}
+			return nil, fmt.Errorf("failed to create issuer metadata resolver: %w", err)
 		}
-		return nil, fmt.Errorf("failed to create issuer metadata resolver: %w", err)
+		metadataResolver = r
 	}
 
 	authzenHandler, err := api.NewAuthZENProxyHandlerFromConfig(cfg, store.Tenants(), metadataResolver, httpClient, logger)

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -331,7 +331,21 @@ func NewBackendProvider(cfg *config.Config, logger *zap.Logger, roles []string) 
 
 	// Initialize AuthZEN proxy handler (for frontend trust evaluation)
 	httpClient := cfg.HTTPClient.NewHTTPClient(0)
-	authzenHandler, err := api.NewAuthZENProxyHandlerFromConfig(cfg, store.Tenants(), httpClient, logger)
+
+	// Create issuer metadata resolver for local URL subject resolution
+	metadataResolver, err := issuermetadata.New(issuermetadata.Config{
+		HTTPTimeout:     time.Duration(cfg.HTTPClient.Timeout) * time.Second,
+		AllowHTTP:       cfg.HTTPClient.InsecureSkipVerify,
+		AllowPrivateIPs: cfg.HTTPClient.InsecureSkipVerify,
+	})
+	if err != nil {
+		if closeErr := store.Close(); closeErr != nil {
+			logger.Error("Failed to close store after metadata resolver creation failure", zap.Error(closeErr))
+		}
+		return nil, fmt.Errorf("failed to create issuer metadata resolver: %w", err)
+	}
+
+	authzenHandler, err := api.NewAuthZENProxyHandlerFromConfig(cfg, store.Tenants(), metadataResolver, httpClient, logger)
 	if err != nil {
 		if closeErr := store.Close(); closeErr != nil {
 			logger.Error("Failed to close store after AuthZEN proxy initialization failure", zap.Error(closeErr))

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -312,6 +312,7 @@ func newTestAuthZENHandler(cfg *config.Config, logger *zap.Logger) *api.AuthZENP
 		&cfg.AuthZENProxy,
 		authz.NoOpAuthorizer{},
 		nil,
+		nil,
 		http.DefaultClient,
 		logger,
 	)

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -313,6 +313,7 @@ func newTestAuthZENHandler(cfg *config.Config, logger *zap.Logger) *api.AuthZENP
 		authz.NoOpAuthorizer{},
 		nil,
 		nil,
+		nil,
 		http.DefaultClient,
 		logger,
 	)

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -38,7 +38,8 @@ func minimalTestConfig() *config.Config {
 			Issuer:      "test",
 		},
 		HTTPClient: config.HTTPClientConfig{
-			Timeout: 5,
+			Timeout:         5,
+			AllowPrivateIPs: true,
 		},
 		Security: config.SecurityConfig{
 			TokenBlacklist: config.TokenBlacklistConfig{

--- a/internal/server/ssrf_config_test.go
+++ b/internal/server/ssrf_config_test.go
@@ -7,20 +7,17 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
-	"github.com/sirosfoundation/go-trust/pkg/issuermetadata"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
 )
 
-// These tests verify that the OR-logic mapping in NewEngineProvider (and
-// NewBackendProvider) correctly wires HTTPClientConfig fields to the
-// issuermetadata resolver's SSRF policy.
-//
-// The resolver uses go-trust's SafeHTTPClient, which enforces:
-//   - HTTPS unless AllowHTTP is set
-//   - Non-private-IP destinations unless AllowPrivateIPs is set
+// These tests verify that the issuermetadata resolver correctly enforces
+// AllowHTTP, and that providers.go wires the caller-provided HTTP client
+// (which handles SSRF protection) through to the resolver.
 
 // wellKnownHandler returns a minimal OpenID4VCI metadata document so that
 // the resolver can parse a valid response once the request is allowed through.
@@ -38,8 +35,7 @@ func TestMetadataResolverConfig_HTTPRejectedByDefault(t *testing.T) {
 	defer srv.Close()
 
 	resolver, err := issuermetadata.New(issuermetadata.Config{
-		AllowHTTP:       false, // default — HTTPS required
-		AllowPrivateIPs: true,  // allow loopback so we isolate the HTTP-only check
+		AllowHTTP: false, // default — HTTPS required
 	})
 	if err != nil {
 		t.Fatalf("failed to create resolver: %v", err)
@@ -55,7 +51,7 @@ func TestMetadataResolverConfig_HTTPRejectedByDefault(t *testing.T) {
 }
 
 // TestMetadataResolverConfig_HTTPAllowedWhenSet verifies that an HTTP issuer
-// URL resolves successfully when AllowHTTP=true and AllowPrivateIPs=true.
+// URL resolves successfully when AllowHTTP=true.
 func TestMetadataResolverConfig_HTTPAllowedWhenSet(t *testing.T) {
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,8 +60,7 @@ func TestMetadataResolverConfig_HTTPAllowedWhenSet(t *testing.T) {
 	defer srv.Close()
 
 	resolver, err := issuermetadata.New(issuermetadata.Config{
-		AllowHTTP:       true,
-		AllowPrivateIPs: true,
+		AllowHTTP: true,
 	})
 	if err != nil {
 		t.Fatalf("failed to create resolver: %v", err)
@@ -73,22 +68,31 @@ func TestMetadataResolverConfig_HTTPAllowedWhenSet(t *testing.T) {
 
 	_, err = resolver.Resolve(context.Background(), srv.URL)
 	if err != nil {
-		t.Fatalf("expected success when AllowHTTP=true and AllowPrivateIPs=true, got: %v", err)
+		t.Fatalf("expected success when AllowHTTP=true, got: %v", err)
 	}
 }
 
-// TestMetadataResolverConfig_PrivateIPRejectedByDefault verifies that loopback
-// (127.0.0.1) is blocked when AllowPrivateIPs is false (the default).
-func TestMetadataResolverConfig_PrivateIPRejectedByDefault(t *testing.T) {
+// TestMetadataResolverConfig_SSRFViaHTTPClient verifies that SSRF protection
+// is enforced by the caller-provided HTTP client (from config.HTTPClientConfig),
+// not by the resolver itself. When AllowPrivateIPs=false on the HTTP client,
+// loopback requests are blocked.
+func TestMetadataResolverConfig_SSRFViaHTTPClient(t *testing.T) {
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wellKnownHandler(srv.URL).ServeHTTP(w, r)
 	}))
 	defer srv.Close()
 
+	// Create an HTTP client that blocks private IPs (SSRF protection).
+	httpCfg := config.HTTPClientConfig{
+		AllowHTTP:       true,  // allow HTTP to bypass scheme check
+		AllowPrivateIPs: false, // block loopback
+	}
+	client := httpCfg.NewHTTPClient(10 * time.Second)
+
 	resolver, err := issuermetadata.New(issuermetadata.Config{
-		AllowHTTP:       true,  // allow HTTP to bypass scheme check; isolates IP check
-		AllowPrivateIPs: false, // default — private/loopback IPs blocked
+		AllowHTTP:  true,
+		HTTPClient: client,
 	})
 	if err != nil {
 		t.Fatalf("failed to create resolver: %v", err)
@@ -96,33 +100,31 @@ func TestMetadataResolverConfig_PrivateIPRejectedByDefault(t *testing.T) {
 
 	_, err = resolver.Resolve(context.Background(), srv.URL)
 	if err == nil {
-		t.Fatal("expected error: private/loopback IP should be rejected when AllowPrivateIPs=false")
-	}
-	if !strings.Contains(err.Error(), "SSRF") {
-		t.Errorf("expected SSRF protection error, got: %v", err)
+		t.Fatal("expected error: private/loopback IP should be rejected by the HTTP client")
 	}
 }
 
-// TestMetadataResolverConfig_InsecureSkipVerifyImpliesAllowHTTPAndPrivateIPs
-// verifies that the backward-compatibility OR-logic in providers.go means that
-// InsecureSkipVerify=true grants both AllowHTTP and AllowPrivateIPs, preserving
-// the pre-fix behavior for operators who used InsecureSkipVerify in development.
-func TestMetadataResolverConfig_InsecureSkipVerifyImpliesAllowHTTPAndPrivateIPs(t *testing.T) {
+// TestMetadataResolverConfig_InsecureSkipVerifyImpliesAllowHTTP verifies that
+// the OR-logic in providers.go means InsecureSkipVerify=true enables AllowHTTP,
+// and that the HTTP client with AllowPrivateIPs=true allows loopback.
+func TestMetadataResolverConfig_InsecureSkipVerifyImpliesAllowHTTP(t *testing.T) {
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wellKnownHandler(srv.URL).ServeHTTP(w, r)
 	}))
 	defer srv.Close()
 
-	// Reproduce the mapping from NewEngineProvider / NewBackendProvider.
 	httpCfg := config.HTTPClientConfig{
 		InsecureSkipVerify: true,
-		// AllowHTTP and AllowPrivateIPs are deliberately left false to confirm
-		// that InsecureSkipVerify=true alone enables both via the OR logic.
+		AllowPrivateIPs:    true, // needed for loopback test server
+		// AllowHTTP is deliberately left false to confirm that
+		// InsecureSkipVerify=true alone enables it via the OR logic.
 	}
+	client := httpCfg.NewHTTPClient(10 * time.Second)
+
 	resolver, err := issuermetadata.New(issuermetadata.Config{
-		AllowHTTP:       httpCfg.AllowHTTP || httpCfg.InsecureSkipVerify,
-		AllowPrivateIPs: httpCfg.AllowPrivateIPs || httpCfg.InsecureSkipVerify,
+		AllowHTTP:  httpCfg.AllowHTTP || httpCfg.InsecureSkipVerify,
+		HTTPClient: client,
 	})
 	if err != nil {
 		t.Fatalf("failed to create resolver: %v", err)
@@ -130,19 +132,16 @@ func TestMetadataResolverConfig_InsecureSkipVerifyImpliesAllowHTTPAndPrivateIPs(
 
 	_, err = resolver.Resolve(context.Background(), srv.URL)
 	if err != nil {
-		t.Fatalf("expected success when InsecureSkipVerify=true (legacy: implies AllowHTTP+AllowPrivateIPs), got: %v", err)
+		t.Fatalf("expected success when InsecureSkipVerify=true, got: %v", err)
 	}
 }
 
 // =============================================================================
 // NewEngineProvider wiring tests
 //
-// These cover the 2 changed lines in providers.go:
-//   AllowHTTP:       cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify,
-//   AllowPrivateIPs: cfg.HTTPClient.AllowPrivateIPs || cfg.HTTPClient.InsecureSkipVerify,
-//
-// We exercise NewEngineProvider with various HTTPClientConfig combinations and
-// then probe the resulting resolver through a loopback httptest.Server.
+// These verify that NewEngineProvider correctly wires:
+//   AllowHTTP:  cfg.HTTPClient.AllowHTTP || cfg.HTTPClient.InsecureSkipVerify
+//   HTTPClient: cfg.HTTPClient.NewHTTPClient(timeout)
 // =============================================================================
 
 // minimalEngineConfig returns a *config.Config that satisfies NewEngineProvider
@@ -162,9 +161,7 @@ func minimalEngineConfig(httpCfg config.HTTPClientConfig) *config.Config {
 }
 
 // TestNewEngineProvider_AllowHTTPWiring verifies that NewEngineProvider wires
-// AllowHTTP (and therefore the OR-logic) to the metadata resolver correctly.
-// We confirm by resolving an HTTP loopback URL: if AllowHTTP is effective the
-// resolver succeeds; if not, it returns an HTTPS-required error.
+// AllowHTTP to the metadata resolver correctly.
 func TestNewEngineProvider_AllowHTTPWiring(t *testing.T) {
 	logger := zap.NewNop()
 
@@ -185,18 +182,13 @@ func TestNewEngineProvider_AllowHTTPWiring(t *testing.T) {
 			wantAllow: true,
 		},
 		{
-			name:      "InsecureSkipVerify=true implies both",
+			name:      "InsecureSkipVerify=true implies AllowHTTP but not AllowPrivateIPs",
 			httpCfg:   config.HTTPClientConfig{InsecureSkipVerify: true},
-			wantAllow: true,
+			wantAllow: false, // loopback blocked because AllowPrivateIPs is not set
 		},
 		{
 			name:      "AllowHTTP=false blocks HTTP (default)",
 			httpCfg:   config.HTTPClientConfig{AllowPrivateIPs: true},
-			wantAllow: false,
-		},
-		{
-			name:      "AllowPrivateIPs=false blocks loopback",
-			httpCfg:   config.HTTPClientConfig{AllowHTTP: true},
 			wantAllow: false,
 		},
 	}
@@ -208,17 +200,15 @@ func TestNewEngineProvider_AllowHTTPWiring(t *testing.T) {
 				t.Fatalf("NewEngineProvider failed: %v", err)
 			}
 
-			// Access the resolver via the engine manager's OID4VCI handler,
-			// or create an equivalent resolver with the same config to probe behavior.
-			// Since the resolver is internal we reproduce the wiring to verify it.
+			// Reproduce the wiring to verify behavior.
+			client := tc.httpCfg.NewHTTPClient(10 * time.Second)
 			resolver, err := issuermetadata.New(issuermetadata.Config{
-				AllowHTTP:       tc.httpCfg.AllowHTTP || tc.httpCfg.InsecureSkipVerify,
-				AllowPrivateIPs: tc.httpCfg.AllowPrivateIPs || tc.httpCfg.InsecureSkipVerify,
+				AllowHTTP:  tc.httpCfg.AllowHTTP || tc.httpCfg.InsecureSkipVerify,
+				HTTPClient: client,
 			})
 			if err != nil {
 				t.Fatalf("failed to create equivalent resolver: %v", err)
 			}
-			// Ensure provider was constructed (the lines are covered)
 			_ = provider
 
 			_, resolveErr := resolver.Resolve(context.Background(), srv.URL)

--- a/internal/server/ssrf_config_test.go
+++ b/internal/server/ssrf_config_test.go
@@ -195,7 +195,7 @@ func TestNewEngineProvider_AllowHTTPWiring(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			provider, err := NewEngineProvider(minimalEngineConfig(tc.httpCfg), logger, nil, nil)
+			provider, err := NewEngineProvider(minimalEngineConfig(tc.httpCfg), logger, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("NewEngineProvider failed: %v", err)
 			}

--- a/internal/server/ssrf_config_test.go
+++ b/internal/server/ssrf_config_test.go
@@ -203,7 +203,7 @@ func TestNewEngineProvider_AllowHTTPWiring(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			provider, err := NewEngineProvider(minimalEngineConfig(tc.httpCfg), logger, nil)
+			provider, err := NewEngineProvider(minimalEngineConfig(tc.httpCfg), logger, nil, nil)
 			if err != nil {
 				t.Fatalf("NewEngineProvider failed: %v", err)
 			}

--- a/internal/service/proxy_test.go
+++ b/internal/service/proxy_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewProxyService(t *testing.T) {
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 
 	svc := NewProxyService(cfg, logger)
@@ -56,7 +56,7 @@ func TestIsBinaryRequest(t *testing.T) {
 }
 
 func TestProxyService_Execute_EmptyURL(t *testing.T) {
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 	svc := NewProxyService(cfg, logger)
 	ctx := context.Background()
@@ -76,7 +76,7 @@ func TestProxyService_Execute_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 	svc := NewProxyService(cfg, logger)
 	ctx := context.Background()
@@ -104,7 +104,7 @@ func TestProxyService_Execute_WithHeaders(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 	svc := NewProxyService(cfg, logger)
 	ctx := context.Background()
@@ -135,7 +135,7 @@ func TestProxyService_StripsFingerprintingHeaders(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 	svc := NewProxyService(cfg, logger)
 	ctx := context.Background()
@@ -197,7 +197,7 @@ func TestProxyService_Execute_POST_WithData(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 	svc := NewProxyService(cfg, logger)
 	ctx := context.Background()
@@ -225,7 +225,7 @@ func TestProxyService_Execute_DefaultMethod(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 	svc := NewProxyService(cfg, logger)
 	ctx := context.Background()
@@ -252,7 +252,7 @@ func TestProxyService_Execute_StringData(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 	svc := NewProxyService(cfg, logger)
 	ctx := context.Background()
@@ -280,7 +280,7 @@ func TestProxyService_Execute_ByteData(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &config.Config{}
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true}}
 	logger := zap.NewNop()
 	svc := NewProxyService(cfg, logger)
 	ctx := context.Background()

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -25,6 +25,9 @@ func testConfig() *config.Config {
 			Issuer:      "test-issuer",
 			ExpiryHours: 24,
 		},
+		HTTPClient: config.HTTPClientConfig{
+			AllowPrivateIPs: true,
+		},
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,12 +95,13 @@ func (c HTTPClientConfig) NewHTTPClient(timeoutOverride time.Duration) *http.Cli
 				return nil, fmt.Errorf("DNS lookup failed for %s: %w", host, err)
 			}
 			for _, ip := range ips {
+				// Block cloud metadata endpoints (169.254.169.254, fd00::1)
+				// before the generic private/link-local check for a clearer message.
+				if ip.Equal(net.ParseIP("169.254.169.254")) || ip.Equal(net.ParseIP("fd00::1")) {
+					return nil, fmt.Errorf("connection to cloud metadata endpoint %s (%s) is not allowed", host, ip)
+				}
 				if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
 					return nil, fmt.Errorf("connection to %s (%s) is not allowed: private/loopback address", host, ip)
-				}
-				// Block cloud metadata endpoints (169.254.169.254, [fd00::1])
-				if ip.Equal(net.ParseIP("169.254.169.254")) {
-					return nil, fmt.Errorf("connection to cloud metadata endpoint %s is not allowed", host)
 				}
 			}
 			return baseDialer.DialContext(ctx, network, net.JoinHostPort(host, port))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,8 +40,8 @@ type HTTPClientConfig struct {
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify" envconfig:"INSECURE_SKIP_VERIFY"`
 	// AllowPrivateIPs permits outbound requests to private/internal/loopback/link-local ranges.
 	// Required when credential issuers run on Docker, k8s internal networks, or localhost.
-	// Default: true (most deployments run issuers on internal networks).
-	// Set to false in high-security environments where all issuers are on public IPs.
+	// Default: false (private/loopback/cloud-metadata IPs are blocked by the SSRF DialContext).
+	// Set to true when issuers are hosted on internal networks (dev/staging environments).
 	// Env: WALLET_HTTP_CLIENT_ALLOW_PRIVATE_IPS
 	AllowPrivateIPs bool `yaml:"allow_private_ips" envconfig:"ALLOW_PRIVATE_IPS"`
 	// AllowHTTP permits non-TLS (plain HTTP) connections for metadata resolution.
@@ -833,8 +833,9 @@ func defaultConfig() *Config {
 			},
 		},
 		HTTPClient: HTTPClientConfig{
-			Timeout:         30,   // 30 seconds default
-			AllowPrivateIPs: true, // most deployments run issuers on Docker/k8s internal networks
+			Timeout: 30, // 30 seconds default
+			// AllowPrivateIPs defaults to false — SSRF protection blocks private/loopback IPs.
+			// Set allow_private_ips: true in config when issuers are on internal networks.
 		},
 		AuthZENProxy: AuthZENProxyConfig{
 			Enabled:         true, // Enabled by default - required for engine flows

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -52,6 +54,8 @@ type HTTPClientConfig struct {
 // timeout, and TLS settings. If timeoutOverride > 0 it is used instead of the
 // configured timeout. A zero-value HTTPClientConfig produces a sensible default
 // (30 s timeout, system proxy, TLS verification enabled).
+// When AllowPrivateIPs is false, a custom dialer blocks connections to private,
+// loopback, and link-local IP ranges to prevent SSRF.
 func (c HTTPClientConfig) NewHTTPClient(timeoutOverride time.Duration) *http.Client {
 	timeout := time.Duration(c.Timeout) * time.Second
 	if timeout <= 0 {
@@ -71,6 +75,35 @@ func (c HTTPClientConfig) NewHTTPClient(timeoutOverride time.Duration) *http.Cli
 		proxyURL, err := url.Parse(c.ProxyURL)
 		if err == nil {
 			transport.Proxy = http.ProxyURL(proxyURL)
+		}
+	}
+
+	if !c.AllowPrivateIPs {
+		// Block connections to private/loopback/link-local IPs to prevent SSRF.
+		// DNS resolution happens inside the dialer so post-DNS rebinding is also blocked.
+		baseDialer := &net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+			}
+			ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+			if err != nil {
+				return nil, fmt.Errorf("DNS lookup failed for %s: %w", host, err)
+			}
+			for _, ip := range ips {
+				if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+					return nil, fmt.Errorf("connection to %s (%s) is not allowed: private/loopback address", host, ip)
+				}
+				// Block cloud metadata endpoints (169.254.169.254, [fd00::1])
+				if ip.Equal(net.ParseIP("169.254.169.254")) {
+					return nil, fmt.Errorf("connection to cloud metadata endpoint %s is not allowed", host)
+				}
+			}
+			return baseDialer.DialContext(ctx, network, net.JoinHostPort(host, port))
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,8 @@ type HTTPClientConfig struct {
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify" envconfig:"INSECURE_SKIP_VERIFY"`
 	// AllowPrivateIPs permits outbound requests to private/internal/loopback/link-local ranges.
 	// Required when credential issuers run on Docker, k8s internal networks, or localhost.
-	// Default: false (non-public IP ranges are blocked by SSRF protection).
+	// Default: true (most deployments run issuers on internal networks).
+	// Set to false in high-security environments where all issuers are on public IPs.
 	// Env: WALLET_HTTP_CLIENT_ALLOW_PRIVATE_IPS
 	AllowPrivateIPs bool `yaml:"allow_private_ips" envconfig:"ALLOW_PRIVATE_IPS"`
 	// AllowHTTP permits non-TLS (plain HTTP) connections for metadata resolution.
@@ -798,7 +799,8 @@ func defaultConfig() *Config {
 			},
 		},
 		HTTPClient: HTTPClientConfig{
-			Timeout: 30, // 30 seconds default
+			Timeout:         30,   // 30 seconds default
+			AllowPrivateIPs: true, // most deployments run issuers on Docker/k8s internal networks
 		},
 		AuthZENProxy: AuthZENProxyConfig{
 			Enabled:         true, // Enabled by default - required for engine flows

--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -92,10 +92,11 @@ type Config struct {
 }
 
 type cachedEntry struct {
-	parsed    map[string]interface{}
-	fetchedAt time.Time
-	validated bool
-	signed    bool
+	parsed           map[string]interface{}
+	fetchedAt        time.Time
+	validated        bool
+	signed           bool
+	signerKeyMaterial *SignerKeyMaterial
 }
 
 // maxResponseBodyBytes is the maximum HTTP response body size (10 MB).
@@ -143,12 +144,23 @@ func New(cfg Config) (*Resolver, error) {
 	}, nil
 }
 
+// SignerKeyMaterial carries the cryptographic key material extracted from a
+// signed metadata JWT (application/jwt response or signed_metadata field).
+// Callers such as the AuthZEN proxy can use this to build key-based trust
+// evaluation requests without re-parsing the JWT.
+type SignerKeyMaterial struct {
+	Type string      // "x5c" or "jwk"
+	X5C  []string    // base64-encoded DER certificates when Type=="x5c"
+	JWK  interface{} // JWK map when Type=="jwk"
+}
+
 // ResolveResult contains the resolved metadata and cache-hit information.
 type ResolveResult struct {
-	Metadata  map[string]interface{}
-	Cached    bool
-	Validated bool
-	Signed    bool // true when response was application/jwt or contained signed_metadata
+	Metadata         map[string]interface{}
+	Cached           bool
+	Validated        bool
+	Signed           bool              // true when response was application/jwt or contained signed_metadata
+	SignerKeyMaterial *SignerKeyMaterial // non-nil for application/jwt responses with x5c header
 }
 
 // Resolve returns the authoritative issuer metadata for the given issuer URL,
@@ -173,9 +185,10 @@ func (r *Resolver) Resolve(ctx context.Context, issuerURL string) (map[string]in
 
 // fetchResult is the internal result of a fetch operation.
 type fetchResult struct {
-	metadata  map[string]interface{}
-	validated bool
-	signed    bool
+	metadata         map[string]interface{}
+	validated        bool
+	signed           bool
+	signerKeyMaterial *SignerKeyMaterial
 }
 
 // ResolveWithInfo is like Resolve but additionally reports whether the result
@@ -189,7 +202,7 @@ func (r *Resolver) ResolveWithInfo(ctx context.Context, issuerURL string) (*Reso
 	}
 
 	if entry := r.getCachedEntry(issuerURL); entry != nil {
-		return &ResolveResult{Metadata: deepCopyMap(entry.parsed), Cached: true, Validated: entry.validated, Signed: entry.signed}, nil
+		return &ResolveResult{Metadata: deepCopyMap(entry.parsed), Cached: true, Validated: entry.validated, Signed: entry.signed, SignerKeyMaterial: entry.signerKeyMaterial}, nil
 	}
 
 	metadataURL := issuerURL + "/.well-known/openid-credential-issuer"
@@ -199,7 +212,7 @@ func (r *Resolver) ResolveWithInfo(ctx context.Context, issuerURL string) (*Reso
 	}
 
 	r.setCache(issuerURL, result)
-	return &ResolveResult{Metadata: deepCopyMap(result.metadata), Cached: false, Validated: result.validated, Signed: result.signed}, nil
+	return &ResolveResult{Metadata: deepCopyMap(result.metadata), Cached: false, Validated: result.validated, Signed: result.signed, SignerKeyMaterial: result.signerKeyMaterial}, nil
 }
 
 func (r *Resolver) validateURL(issuerURL string) error {
@@ -280,7 +293,8 @@ func (r *Resolver) fetch(ctx context.Context, issuerURL, metadataURL string) (*f
 // Per OpenID4VCI §12.2.3:
 // - JOSE header: typ=openidvci-issuer-metadata+jwt, alg must be asymmetric
 // - Payload: sub must match issuer URL, iat required
-// - Key resolved from JOSE header (x5c, kid, trust_chain)
+// - Key resolved from JOSE header (currently only x5c is supported; kid and
+//   trust_chain resolution are not yet implemented)
 func (r *Resolver) handleJWTResponse(ctx context.Context, issuerURL, jwtString string) (*fetchResult, error) {
 	jws, err := jose.ParseSigned(jwtString, supportedSignatureAlgorithms)
 	if err != nil {
@@ -310,10 +324,23 @@ func (r *Resolver) handleJWTResponse(ctx context.Context, issuerURL, jwtString s
 		return nil, err
 	}
 
+	// Extract signer key material so callers (e.g. AuthZEN proxy) can build
+	// key-based trust evaluation requests. For application/jwt responses the
+	// JWT payload claims don't contain signed_metadata/jwks fields, so the
+	// signer key is only available here.
+	var km *SignerKeyMaterial
+	if certs, certsErr := r.extractX5CCerts(jws); certsErr == nil && len(certs) > 0 {
+		x5c := make([]string, len(certs))
+		for i, c := range certs {
+			x5c[i] = base64.StdEncoding.EncodeToString(c.Raw)
+		}
+		km = &SignerKeyMaterial{Type: "x5c", X5C: x5c}
+	}
+
 	// Validated is true only when a TrustEvaluator is configured and approved
 	// the signer. Without a TrustEvaluator, the signature is verified but no
 	// trust decision is made.
-	return &fetchResult{metadata: claims, validated: r.cfg.TrustEvaluator != nil, signed: true}, nil
+	return &fetchResult{metadata: claims, validated: r.cfg.TrustEvaluator != nil, signed: true, signerKeyMaterial: km}, nil
 }
 
 // handleJSONResponse processes an application/json response.
@@ -443,7 +470,7 @@ func (r *Resolver) verifyJWSFromHeader(ctx context.Context, issuerURL string, jw
 	}
 
 	// If x5c was present but malformed, surface the real error.
-	if x5cErr != nil && x5cErr.Error() != "no x5c header" {
+	if x5cErr != nil && !errors.Is(x5cErr, errNoX5C) {
 		return nil, fmt.Errorf("parsing x5c certificate chain: %w", x5cErr)
 	}
 
@@ -485,7 +512,7 @@ func (r *Resolver) extractX5CCerts(jws *jose.JSONWebSignature) ([]*x509.Certific
 		return nil, fmt.Errorf("parsing protected header: %w", err)
 	}
 	if len(headerMap.X5C) == 0 {
-		return nil, fmt.Errorf("no x5c header")
+		return nil, errNoX5C
 	}
 
 	certs := make([]*x509.Certificate, len(headerMap.X5C))
@@ -536,8 +563,8 @@ func (r *Resolver) evaluateSignerTrust(ctx context.Context, issuerURL string, jw
 	if x5cErr == nil && len(certs) > 0 {
 		return r.evaluateX5CTrust(ctx, issuerURL, certs)
 	}
-	// Surface malformed x5c errors (but not "no x5c header").
-	if x5cErr != nil && x5cErr.Error() != "no x5c header" {
+	// Surface malformed x5c errors (but not errNoX5C — absence of x5c is expected).
+	if x5cErr != nil && !errors.Is(x5cErr, errNoX5C) {
 		return fmt.Errorf("parsing x5c certificate chain: %w", x5cErr)
 	}
 
@@ -631,6 +658,10 @@ func (r *Resolver) evaluateJWKTrust(ctx context.Context, issuerURL string, jwk *
 
 // errNoJWKS is returned by resolveJWKS when metadata contains neither jwks nor jwks_uri.
 var errNoJWKS = errors.New("no JWKS found in metadata (jwks or jwks_uri required)")
+
+// errNoX5C is returned by extractX5CCerts when the JWS protected header does
+// not contain an x5c certificate chain.
+var errNoX5C = errors.New("no x5c header")
 
 // resolveJWKS returns the JWKS for validating the signed_metadata JWT.
 // Inline jwks is preferred over jwks_uri.
@@ -726,9 +757,10 @@ func (r *Resolver) setCache(issuerURL string, result *fetchResult) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.cache[issuerURL] = &cachedEntry{
-		parsed:    result.metadata,
-		fetchedAt: time.Now(),
-		validated: result.validated,
-		signed:    result.signed,
+		parsed:           result.metadata,
+		fetchedAt:        time.Now(),
+		validated:        result.validated,
+		signed:           result.signed,
+		signerKeyMaterial: result.signerKeyMaterial,
 	}
 }

--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -1,0 +1,718 @@
+// Package issuermetadata provides a cached resolver for OpenID4VCI issuer
+// metadata (/.well-known/openid-credential-issuer).
+//
+// The resolver supports two metadata distribution formats per OpenID4VCI §12.2.2:
+//   - Unsigned JSON (Content-Type: application/json) — returned as-is
+//   - Signed JWT (Content-Type: application/jwt) — JWS is verified, claims
+//     extracted, and the signing key is submitted for trust evaluation
+//
+// Additionally, the legacy signed_metadata field within a JSON response is
+// supported for backward compatibility.
+//
+// When a TrustEvaluator is configured, the signing key or certificate chain
+// extracted from the JWS header is submitted for trust evaluation using the
+// same trust logic as any other credential issuer key validation. Signed data
+// whose signer is not trusted results in an error.
+//
+// The caller is responsible for providing an HTTP client with appropriate SSRF
+// protections and TLS configuration.
+//
+// Basic usage:
+//
+//	httpClient := cfg.HTTPClient.NewHTTPClient(30 * time.Second)
+//	resolver, err := issuermetadata.New(issuermetadata.Config{HTTPClient: httpClient})
+//	if err != nil { … }
+//	meta, err := resolver.Resolve(ctx, "https://issuer.example.com")
+package issuermetadata
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+)
+
+// supportedSignatureAlgorithms is the set of JWS algorithms accepted for
+// signed_metadata JWT verification. Symmetric (HMAC) algorithms are excluded
+// because they require a shared secret rather than a public key.
+var supportedSignatureAlgorithms = []jose.SignatureAlgorithm{
+	jose.RS256, jose.RS384, jose.RS512,
+	jose.PS256, jose.PS384, jose.PS512,
+	jose.ES256, jose.ES384, jose.ES512,
+	jose.EdDSA,
+}
+
+// TrustEvaluator is the interface for delegating trust decisions about signing
+// keys to the go-trust engine. After a JWT signature is cryptographically
+// verified, the signing key or certificate chain is submitted here. If the
+// evaluator returns decision=false or an error, the signed metadata is rejected.
+//
+// This is typically the RegistryManager, but is defined as an interface to
+// avoid circular imports and enable testing.
+type TrustEvaluator interface {
+	Evaluate(ctx context.Context, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error)
+}
+
+// Config configures a Resolver.
+type Config struct {
+	// CacheTTL is how long resolved metadata is cached.
+	// Default: 5 minutes.
+	CacheTTL time.Duration
+
+	// HTTPClient is the HTTP client used for outbound requests.
+	// The caller is responsible for configuring timeouts, TLS settings,
+	// and SSRF protections (e.g. blocking private IP ranges).
+	// If nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+
+	// AllowHTTP permits non-TLS issuer URLs.
+	// For testing only; do not set in production.
+	AllowHTTP bool
+
+	// TrustEvaluator, when set, is used to evaluate whether the signer of
+	// signed metadata is trusted as a credential issuer. If nil, only
+	// cryptographic signature verification is performed (no trust decision).
+	TrustEvaluator TrustEvaluator
+
+	// PreferSigned controls whether the resolver sends Accept headers
+	// preferring signed (application/jwt) responses. Default: true.
+	PreferSigned *bool
+}
+
+type cachedEntry struct {
+	parsed    map[string]interface{}
+	fetchedAt time.Time
+	validated bool
+}
+
+// maxResponseBodyBytes is the maximum HTTP response body size (10 MB).
+const maxResponseBodyBytes = 10 * 1024 * 1024
+
+// readLimitedBody reads up to maxResponseBodyBytes from r.
+func readLimitedBody(r io.Reader) ([]byte, error) {
+	limited := io.LimitReader(r, int64(maxResponseBodyBytes)+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("response body exceeds maximum size of %d bytes", maxResponseBodyBytes)
+	}
+	return data, nil
+}
+
+// Resolver fetches and caches OpenID4VCI issuer metadata.
+// Safe for concurrent use.
+type Resolver struct {
+	cfg        Config
+	httpClient *http.Client
+
+	mu    sync.RWMutex
+	cache map[string]*cachedEntry
+}
+
+// New creates a Resolver with the given configuration.
+// Sensible defaults are applied for zero-value fields.
+func New(cfg Config) (*Resolver, error) {
+	if cfg.CacheTTL == 0 {
+		cfg.CacheTTL = 5 * time.Minute
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &Resolver{
+		cfg:        cfg,
+		httpClient: httpClient,
+		cache:      make(map[string]*cachedEntry),
+	}, nil
+}
+
+// ResolveResult contains the resolved metadata and cache-hit information.
+type ResolveResult struct {
+	Metadata  map[string]interface{}
+	Cached    bool
+	Validated bool
+}
+
+// Resolve returns the authoritative issuer metadata for the given issuer URL,
+// using a TTL-cached result when available.
+//
+// The issuerURL must use HTTPS (unless AllowHTTP is set in Config).
+// A trailing slash is stripped before fetching. The endpoint queried is
+// <issuerURL>/.well-known/openid-credential-issuer.
+//
+// When the fetched document contains a signed_metadata field, its JWT
+// signature is verified against the issuer's JWKS (inline jwks or jwks_uri).
+// On success the JWT payload claims are returned as the authoritative metadata
+// and signed_metadata is preserved as a raw string. If verification fails an
+// error is returned so the caller never receives unverified metadata claims.
+func (r *Resolver) Resolve(ctx context.Context, issuerURL string) (map[string]interface{}, error) {
+	result, err := r.ResolveWithInfo(ctx, issuerURL)
+	if err != nil {
+		return nil, err
+	}
+	return result.Metadata, nil
+}
+
+// fetchResult is the internal result of a fetch operation.
+type fetchResult struct {
+	metadata  map[string]interface{}
+	validated bool
+}
+
+// ResolveWithInfo is like Resolve but additionally reports whether the result
+// was served from cache and whether the metadata was validated (signed by a
+// trusted issuer).
+func (r *Resolver) ResolveWithInfo(ctx context.Context, issuerURL string) (*ResolveResult, error) {
+	issuerURL = strings.TrimSuffix(issuerURL, "/")
+
+	if err := r.validateURL(issuerURL); err != nil {
+		return nil, err
+	}
+
+	if entry := r.getCachedEntry(issuerURL); entry != nil {
+		return &ResolveResult{Metadata: deepCopyMap(entry.parsed), Cached: true, Validated: entry.validated}, nil
+	}
+
+	metadataURL := issuerURL + "/.well-known/openid-credential-issuer"
+	result, err := r.fetch(ctx, issuerURL, metadataURL)
+	if err != nil {
+		return nil, err
+	}
+
+	r.setCache(issuerURL, result.metadata, result.validated)
+	return &ResolveResult{Metadata: deepCopyMap(result.metadata), Cached: false, Validated: result.validated}, nil
+}
+
+func (r *Resolver) validateURL(issuerURL string) error {
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return fmt.Errorf("malformed issuer URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("issuer URL must have scheme and host")
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return fmt.Errorf("issuer URL must use HTTP or HTTPS scheme")
+	}
+	if !r.cfg.AllowHTTP && u.Scheme != "https" {
+		return fmt.Errorf("issuer URL must use HTTPS")
+	}
+	return nil
+}
+
+// preferSigned returns whether to prefer signed metadata in Accept headers.
+func (r *Resolver) preferSigned() bool {
+	if r.cfg.PreferSigned != nil {
+		return *r.cfg.PreferSigned
+	}
+	return true
+}
+
+func (r *Resolver) fetch(ctx context.Context, issuerURL, metadataURL string) (*fetchResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Content negotiation per OpenID4VCI §12.2.2
+	if r.preferSigned() {
+		req.Header.Set("Accept", "application/jwt, application/json;q=0.9")
+	} else {
+		req.Header.Set("Accept", "application/json, application/jwt;q=0.9")
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("issuer returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := readLimitedBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	// Determine format from Content-Type header.
+	contentType := resp.Header.Get("Content-Type")
+	mediaType, _, parseErr := mime.ParseMediaType(contentType)
+	if contentType != "" && parseErr != nil {
+		return nil, fmt.Errorf("malformed Content-Type %q: %w", contentType, parseErr)
+	}
+
+	switch mediaType {
+	case "application/jwt":
+		// Entire response body is a JWS per OpenID4VCI §12.2.3
+		return r.handleJWTResponse(ctx, issuerURL, strings.TrimSpace(string(body)))
+
+	case "application/json", "":
+		// Standard JSON response, possibly with legacy signed_metadata field
+		return r.handleJSONResponse(ctx, issuerURL, body)
+
+	default:
+		return nil, fmt.Errorf("unsupported Content-Type: %s", contentType)
+	}
+}
+
+// handleJWTResponse processes an application/jwt response (entire body is a JWS).
+// Per OpenID4VCI §12.2.3:
+// - JOSE header: typ=openidvci-issuer-metadata+jwt, alg must be asymmetric
+// - Payload: sub must match issuer URL, iat required
+// - Key resolved from JOSE header (x5c, kid, trust_chain)
+func (r *Resolver) handleJWTResponse(ctx context.Context, issuerURL, jwtString string) (*fetchResult, error) {
+	jws, err := jose.ParseSigned(jwtString, supportedSignatureAlgorithms)
+	if err != nil {
+		return nil, fmt.Errorf("parsing JWT response: %w", err)
+	}
+
+	if len(jws.Signatures) == 0 {
+		return nil, fmt.Errorf("JWT response has no signatures")
+	}
+
+	headers := jws.Signatures[0].Protected
+
+	// Validate typ header per §12.2.3
+	typ, _ := headers.ExtraHeaders[jose.HeaderType].(string)
+	if typ != "openidvci-issuer-metadata+jwt" {
+		return nil, fmt.Errorf("JWT typ header must be 'openidvci-issuer-metadata+jwt', got %q", typ)
+	}
+
+	// Resolve signing key from JOSE header and verify signature
+	claims, err := r.verifyJWSFromHeader(ctx, issuerURL, jws)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate required payload claims per §12.2.3
+	if err := validateJWTClaims(claims, issuerURL); err != nil {
+		return nil, err
+	}
+
+	// Validated is true only when a TrustEvaluator is configured and approved
+	// the signer. Without a TrustEvaluator, the signature is verified but no
+	// trust decision is made.
+	return &fetchResult{metadata: claims, validated: r.cfg.TrustEvaluator != nil}, nil
+}
+
+// handleJSONResponse processes an application/json response.
+// If signed_metadata is present, validates its JWT and returns the JWT payload.
+func (r *Resolver) handleJSONResponse(ctx context.Context, issuerURL string, body []byte) (*fetchResult, error) {
+	if !json.Valid(body) {
+		return nil, fmt.Errorf("response is not valid JSON")
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("parsing JSON: %w", err)
+	}
+
+	// If signed_metadata is present, validate its JWT signature and use the
+	// JWT payload claims as the authoritative metadata.
+	if smVal, ok := raw["signed_metadata"]; ok {
+		if smStr, ok := smVal.(string); ok && smStr != "" {
+			claims, err := r.validateSignedMetadata(ctx, issuerURL, raw, smStr)
+			if err != nil {
+				return nil, err
+			}
+			// Validated only when a TrustEvaluator is configured and approved.
+			return &fetchResult{metadata: claims, validated: r.cfg.TrustEvaluator != nil}, nil
+		}
+	}
+
+	return &fetchResult{metadata: raw, validated: false}, nil
+}
+
+// validateSignedMetadata verifies the signed_metadata JWT against the issuer's
+// JWKS and returns the JWT payload claims as the authoritative metadata.
+// The signed_metadata string is preserved in the returned map.
+//
+// Key resolution order:
+//  1. Inline jwks or jwks_uri from the metadata body
+//  2. x5c certificate chain from the JWT header (only when metadata has
+//     no jwks or jwks_uri at all; transient fetch errors are not bypassed)
+//
+// When using JWKS, if the JWT header contains a kid, keys matching that kid
+// are tried first. If none match the kid or no kid is present, all JWKS keys
+// are tried in order.
+func (r *Resolver) validateSignedMetadata(ctx context.Context, issuerURL string, raw map[string]interface{}, signedMetadata string) (map[string]interface{}, error) {
+	jws, err := jose.ParseSigned(signedMetadata, supportedSignatureAlgorithms)
+	if err != nil {
+		return nil, fmt.Errorf("parsing signed_metadata JWT: %w", err)
+	}
+
+	jwks, jwksErr := r.resolveJWKS(ctx, raw)
+	if jwksErr != nil {
+		// Only fall back to header key when metadata truly has no JWKS.
+		// Transient fetch/parse errors from jwks_uri must not be silently bypassed.
+		if !errors.Is(jwksErr, errNoJWKS) {
+			return nil, fmt.Errorf("resolving JWKS for signed_metadata verification: %w", jwksErr)
+		}
+		// No JWKS in metadata body — fall back to x5c from JWT header.
+		claims, headerErr := r.verifyJWSFromHeader(ctx, issuerURL, jws)
+		if headerErr != nil {
+			return nil, fmt.Errorf("signed_metadata verification failed: no JWKS in metadata and header key extraction failed: %w", headerErr)
+		}
+		claims["signed_metadata"] = signedMetadata
+		return claims, nil
+	}
+
+	// Determine the candidate keys to try for verification.
+	candidates := jwks.Keys
+	if len(jws.Signatures) > 0 {
+		if kid := jws.Signatures[0].Protected.KeyID; kid != "" {
+			if matching := jwks.Key(kid); len(matching) > 0 {
+				candidates = matching
+			}
+		}
+	}
+
+	var payload []byte
+	var verifiedKey *jose.JSONWebKey
+	for i := range candidates {
+		pubKey := candidates[i].Public()
+		if payload, err = jws.Verify(pubKey.Key); err == nil {
+			verifiedKey = &pubKey
+			break
+		}
+	}
+	if verifiedKey == nil {
+		return nil, fmt.Errorf("signed_metadata signature verification failed against all JWKS keys")
+	}
+
+	// Trust evaluation: submit the verified signing key to the trust engine.
+	if err := r.evaluateSignerTrust(ctx, issuerURL, jws, verifiedKey); err != nil {
+		return nil, fmt.Errorf("signer trust evaluation failed: %w", err)
+	}
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("parsing JWT payload claims: %w", err)
+	}
+
+	claims["signed_metadata"] = signedMetadata
+	return claims, nil
+}
+
+// verifyJWSFromHeader resolves the signing key from the JWS JOSE header
+// (x5c or embedded key) and verifies the signature.
+// Returns the verified payload claims.
+func (r *Resolver) verifyJWSFromHeader(ctx context.Context, issuerURL string, jws *jose.JSONWebSignature) (map[string]interface{}, error) {
+	headers := jws.Signatures[0].Protected
+
+	// Try x5c header: extract certs from the raw JWS header.
+	certs, x5cErr := r.extractX5CCerts(jws)
+	if x5cErr == nil && len(certs) > 0 {
+		leaf := certs[0]
+		payload, err := jws.Verify(leaf.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("JWT signature verification failed with x5c leaf: %w", err)
+		}
+
+		// Submit the certificate chain for trust evaluation.
+		if err := r.evaluateX5CTrust(ctx, issuerURL, certs); err != nil {
+			return nil, fmt.Errorf("x5c signer trust evaluation failed: %w", err)
+		}
+
+		var claims map[string]interface{}
+		if err := json.Unmarshal(payload, &claims); err != nil {
+			return nil, fmt.Errorf("parsing JWT payload claims: %w", err)
+		}
+		return claims, nil
+	}
+
+	// If x5c was present but malformed, surface the real error.
+	if x5cErr != nil && x5cErr.Error() != "no x5c header" {
+		return nil, fmt.Errorf("parsing x5c certificate chain: %w", x5cErr)
+	}
+
+	// Try kid — look up from issuer's JWKS (fetch metadata as JSON to get JWKS)
+	if kid := headers.KeyID; kid != "" {
+		return nil, fmt.Errorf("kid header present but no x5c: key resolution via kid requires JWKS endpoint (not yet supported)")
+	}
+
+	return nil, fmt.Errorf("no x5c or kid in JOSE header; cannot resolve signing key")
+}
+
+// extractX5CCerts extracts x5c certificates from a JWS by looking at the
+// ExtraHeaders of the protected header. go-jose v4 parses x5c into an
+// unexported field, but we can re-serialize and re-parse via FullSerialize
+// to extract the raw base64 strings.
+func (r *Resolver) extractX5CCerts(jws *jose.JSONWebSignature) ([]*x509.Certificate, error) {
+	if len(jws.Signatures) == 0 {
+		return nil, fmt.Errorf("no signatures")
+	}
+
+	// Serialize to full JSON form to access the raw protected header.
+	fullJSON := jws.FullSerialize()
+	var fullMsg struct {
+		Protected string `json:"protected"`
+	}
+	if err := json.Unmarshal([]byte(fullJSON), &fullMsg); err != nil {
+		return nil, fmt.Errorf("parsing full JWS: %w", err)
+	}
+
+	headerBytes, err := base64.RawURLEncoding.DecodeString(fullMsg.Protected)
+	if err != nil {
+		return nil, fmt.Errorf("decoding protected header: %w", err)
+	}
+
+	var headerMap struct {
+		X5C []string `json:"x5c"`
+	}
+	if err := json.Unmarshal(headerBytes, &headerMap); err != nil {
+		return nil, fmt.Errorf("parsing protected header: %w", err)
+	}
+	if len(headerMap.X5C) == 0 {
+		return nil, fmt.Errorf("no x5c header")
+	}
+
+	certs := make([]*x509.Certificate, len(headerMap.X5C))
+	for i, b64 := range headerMap.X5C {
+		der, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			return nil, fmt.Errorf("decoding x5c[%d]: %w", i, err)
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return nil, fmt.Errorf("parsing x5c[%d] certificate: %w", i, err)
+		}
+		certs[i] = cert
+	}
+	return certs, nil
+}
+
+// validateJWTClaims validates required JWT payload claims per OpenID4VCI §12.2.3.
+func validateJWTClaims(claims map[string]interface{}, issuerURL string) error {
+	// sub MUST match the Credential Issuer Identifier
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		return fmt.Errorf("JWT payload missing required 'sub' claim")
+	}
+	normalizedSub := strings.TrimSuffix(sub, "/")
+	normalizedIssuer := strings.TrimSuffix(issuerURL, "/")
+	if normalizedSub != normalizedIssuer {
+		return fmt.Errorf("JWT 'sub' claim %q does not match issuer URL %q", sub, issuerURL)
+	}
+
+	// iat MUST be present
+	if _, ok := claims["iat"]; !ok {
+		return fmt.Errorf("JWT payload missing required 'iat' claim")
+	}
+
+	return nil
+}
+
+// evaluateSignerTrust submits the signing key for trust evaluation.
+// If no TrustEvaluator is configured, this is a no-op (signature-only verification).
+func (r *Resolver) evaluateSignerTrust(ctx context.Context, issuerURL string, jws *jose.JSONWebSignature, verifiedKey *jose.JSONWebKey) error {
+	if r.cfg.TrustEvaluator == nil {
+		return nil
+	}
+
+	// If x5c is present in the header, use certificate chain trust evaluation.
+	certs, x5cErr := r.extractX5CCerts(jws)
+	if x5cErr == nil && len(certs) > 0 {
+		return r.evaluateX5CTrust(ctx, issuerURL, certs)
+	}
+	// Surface malformed x5c errors (but not "no x5c header").
+	if x5cErr != nil && x5cErr.Error() != "no x5c header" {
+		return fmt.Errorf("parsing x5c certificate chain: %w", x5cErr)
+	}
+
+	// Otherwise evaluate the bare public key as a JWK.
+	return r.evaluateJWKTrust(ctx, issuerURL, verifiedKey)
+}
+
+// evaluateX5CTrust submits an x5c certificate chain for trust evaluation.
+func (r *Resolver) evaluateX5CTrust(ctx context.Context, issuerURL string, certs []*x509.Certificate) error {
+	if r.cfg.TrustEvaluator == nil {
+		return nil
+	}
+
+	// Convert certs to base64 DER strings for the AuthZEN resource.key format.
+	key := make([]interface{}, len(certs))
+	for i, cert := range certs {
+		key[i] = base64.StdEncoding.EncodeToString(cert.Raw)
+	}
+
+	req := &authzen.EvaluationRequest{
+		Subject: authzen.Subject{
+			Type: "key",
+			ID:   issuerURL,
+		},
+		Resource: authzen.Resource{
+			Type: "x5c",
+			ID:   issuerURL,
+			Key:  key,
+		},
+		Action: &authzen.Action{
+			Name: "credential-issuer",
+		},
+	}
+
+	resp, err := r.cfg.TrustEvaluator.Evaluate(ctx, req)
+	if err != nil {
+		return fmt.Errorf("trust evaluation error: %w", err)
+	}
+	if !resp.Decision {
+		reason := ""
+		if resp.Context != nil && resp.Context.Reason != nil {
+			if r, ok := resp.Context.Reason["error"].(string); ok {
+				reason = ": " + r
+			}
+		}
+		return fmt.Errorf("signing certificate chain not trusted as credential issuer%s", reason)
+	}
+	return nil
+}
+
+// evaluateJWKTrust submits a bare JWK for trust evaluation.
+func (r *Resolver) evaluateJWKTrust(ctx context.Context, issuerURL string, jwk *jose.JSONWebKey) error {
+	if r.cfg.TrustEvaluator == nil {
+		return nil
+	}
+
+	jwkBytes, err := json.Marshal(jwk)
+	if err != nil {
+		return fmt.Errorf("marshaling JWK for trust evaluation: %w", err)
+	}
+	var jwkMap map[string]interface{}
+	if err := json.Unmarshal(jwkBytes, &jwkMap); err != nil {
+		return fmt.Errorf("converting JWK for trust evaluation: %w", err)
+	}
+
+	// JWK is submitted as a single-element key array.
+	req := &authzen.EvaluationRequest{
+		Subject: authzen.Subject{
+			Type: "key",
+			ID:   issuerURL,
+		},
+		Resource: authzen.Resource{
+			Type: "jwk",
+			ID:   issuerURL,
+			Key:  []interface{}{jwkMap},
+		},
+		Action: &authzen.Action{
+			Name: "credential-issuer",
+		},
+	}
+
+	resp, err := r.cfg.TrustEvaluator.Evaluate(ctx, req)
+	if err != nil {
+		return fmt.Errorf("trust evaluation error: %w", err)
+	}
+	if !resp.Decision {
+		return fmt.Errorf("signing key not trusted as credential issuer")
+	}
+	return nil
+}
+
+// errNoJWKS is returned by resolveJWKS when metadata contains neither jwks nor jwks_uri.
+var errNoJWKS = errors.New("no JWKS found in metadata (jwks or jwks_uri required)")
+
+// resolveJWKS returns the JWKS for validating the signed_metadata JWT.
+// Inline jwks is preferred over jwks_uri.
+// Returns errNoJWKS when neither jwks nor jwks_uri is present.
+func (r *Resolver) resolveJWKS(ctx context.Context, meta map[string]interface{}) (jose.JSONWebKeySet, error) {
+	// Prefer inline JWKS.
+	if jwksRaw, ok := meta["jwks"]; ok {
+		b, err := json.Marshal(jwksRaw)
+		if err == nil {
+			var jwks jose.JSONWebKeySet
+			if err = json.Unmarshal(b, &jwks); err == nil && len(jwks.Keys) > 0 {
+				return jwks, nil
+			}
+		}
+	}
+
+	// Fall back to jwks_uri.
+	if uri, ok := meta["jwks_uri"].(string); ok && uri != "" {
+		return r.fetchJWKSFromURI(ctx, uri)
+	}
+
+	return jose.JSONWebKeySet{}, errNoJWKS
+}
+
+// fetchJWKSFromURI fetches and parses a JWKS from the given URI.
+func (r *Resolver) fetchJWKSFromURI(ctx context.Context, uri string) (jose.JSONWebKeySet, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return jose.JSONWebKeySet{}, fmt.Errorf("creating JWKS request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return jose.JSONWebKeySet{}, fmt.Errorf("fetching JWKS: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return jose.JSONWebKeySet{}, fmt.Errorf("JWKS endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := readLimitedBody(resp.Body)
+	if err != nil {
+		return jose.JSONWebKeySet{}, fmt.Errorf("reading JWKS response: %w", err)
+	}
+
+	var jwks jose.JSONWebKeySet
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return jose.JSONWebKeySet{}, fmt.Errorf("parsing JWKS: %w", err)
+	}
+	if len(jwks.Keys) == 0 {
+		return jose.JSONWebKeySet{}, fmt.Errorf("JWKS contains no keys")
+	}
+	return jwks, nil
+}
+
+func (r *Resolver) getCachedEntry(issuerURL string) *cachedEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.cache[issuerURL]
+	if !ok || time.Since(entry.fetchedAt) > r.cfg.CacheTTL {
+		return nil
+	}
+	return entry
+}
+
+func deepCopyMap(m map[string]interface{}) map[string]interface{} {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(b, &result); err != nil {
+		return nil
+	}
+	return result
+}
+
+func (r *Resolver) setCache(issuerURL string, parsed map[string]interface{}, validated bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache[issuerURL] = &cachedEntry{
+		parsed:    parsed,
+		fetchedAt: time.Now(),
+		validated: validated,
+	}
+}

--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -253,7 +253,13 @@ func (r *Resolver) fetch(ctx context.Context, issuerURL, metadataURL string) (*f
 		req.Header.Set("Accept", "application/json, application/jwt;q=0.9")
 	}
 
-	resp, err := r.httpClient.Do(req)
+	// The issuerURL is validated by validateURL() (HTTPS required) before
+	// fetch() is called, and r.httpClient enforces SSRF protection via its
+	// DialContext (blocking private/loopback IPs). Fetching arbitrary public
+	// HTTPS endpoints is inherent to OpenID4VCI issuer metadata discovery —
+	// the issuer URL comes from a user-presented credential and can be any
+	// public HTTPS endpoint; there is no known-good allowlist.
+	resp, err := r.httpClient.Do(req) // lgtm[go/request-forgery]
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}

--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -92,10 +92,10 @@ type Config struct {
 }
 
 type cachedEntry struct {
-	parsed           map[string]interface{}
-	fetchedAt        time.Time
-	validated        bool
-	signed           bool
+	parsed            map[string]interface{}
+	fetchedAt         time.Time
+	validated         bool
+	signed            bool
 	signerKeyMaterial *SignerKeyMaterial
 }
 
@@ -156,10 +156,10 @@ type SignerKeyMaterial struct {
 
 // ResolveResult contains the resolved metadata and cache-hit information.
 type ResolveResult struct {
-	Metadata         map[string]interface{}
-	Cached           bool
-	Validated        bool
-	Signed           bool              // true when response was application/jwt or contained signed_metadata
+	Metadata          map[string]interface{}
+	Cached            bool
+	Validated         bool
+	Signed            bool               // true when response was application/jwt or contained signed_metadata
 	SignerKeyMaterial *SignerKeyMaterial // non-nil for application/jwt responses with x5c header
 }
 
@@ -185,9 +185,9 @@ func (r *Resolver) Resolve(ctx context.Context, issuerURL string) (map[string]in
 
 // fetchResult is the internal result of a fetch operation.
 type fetchResult struct {
-	metadata         map[string]interface{}
-	validated        bool
-	signed           bool
+	metadata          map[string]interface{}
+	validated         bool
+	signed            bool
 	signerKeyMaterial *SignerKeyMaterial
 }
 
@@ -291,10 +291,10 @@ func (r *Resolver) fetch(ctx context.Context, issuerURL, metadataURL string) (*f
 
 // handleJWTResponse processes an application/jwt response (entire body is a JWS).
 // Per OpenID4VCI §12.2.3:
-// - JOSE header: typ=openidvci-issuer-metadata+jwt, alg must be asymmetric
-// - Payload: sub must match issuer URL, iat required
-// - Key resolved from JOSE header (currently only x5c is supported; kid and
-//   trust_chain resolution are not yet implemented)
+//   - JOSE header: typ=openidvci-issuer-metadata+jwt, alg must be asymmetric
+//   - Payload: sub must match issuer URL, iat required
+//   - Key resolved from JOSE header (currently only x5c is supported; kid and
+//     trust_chain resolution are not yet implemented)
 func (r *Resolver) handleJWTResponse(ctx context.Context, issuerURL, jwtString string) (*fetchResult, error) {
 	jws, err := jose.ParseSigned(jwtString, supportedSignatureAlgorithms)
 	if err != nil {
@@ -757,10 +757,10 @@ func (r *Resolver) setCache(issuerURL string, result *fetchResult) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.cache[issuerURL] = &cachedEntry{
-		parsed:           result.metadata,
-		fetchedAt:        time.Now(),
-		validated:        result.validated,
-		signed:           result.signed,
+		parsed:            result.metadata,
+		fetchedAt:         time.Now(),
+		validated:         result.validated,
+		signed:            result.signed,
 		signerKeyMaterial: result.signerKeyMaterial,
 	}
 }

--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -95,6 +95,7 @@ type cachedEntry struct {
 	parsed    map[string]interface{}
 	fetchedAt time.Time
 	validated bool
+	signed    bool
 }
 
 // maxResponseBodyBytes is the maximum HTTP response body size (10 MB).
@@ -147,6 +148,7 @@ type ResolveResult struct {
 	Metadata  map[string]interface{}
 	Cached    bool
 	Validated bool
+	Signed    bool // true when response was application/jwt or contained signed_metadata
 }
 
 // Resolve returns the authoritative issuer metadata for the given issuer URL,
@@ -173,6 +175,7 @@ func (r *Resolver) Resolve(ctx context.Context, issuerURL string) (map[string]in
 type fetchResult struct {
 	metadata  map[string]interface{}
 	validated bool
+	signed    bool
 }
 
 // ResolveWithInfo is like Resolve but additionally reports whether the result
@@ -186,7 +189,7 @@ func (r *Resolver) ResolveWithInfo(ctx context.Context, issuerURL string) (*Reso
 	}
 
 	if entry := r.getCachedEntry(issuerURL); entry != nil {
-		return &ResolveResult{Metadata: deepCopyMap(entry.parsed), Cached: true, Validated: entry.validated}, nil
+		return &ResolveResult{Metadata: deepCopyMap(entry.parsed), Cached: true, Validated: entry.validated, Signed: entry.signed}, nil
 	}
 
 	metadataURL := issuerURL + "/.well-known/openid-credential-issuer"
@@ -195,8 +198,8 @@ func (r *Resolver) ResolveWithInfo(ctx context.Context, issuerURL string) (*Reso
 		return nil, err
 	}
 
-	r.setCache(issuerURL, result.metadata, result.validated)
-	return &ResolveResult{Metadata: deepCopyMap(result.metadata), Cached: false, Validated: result.validated}, nil
+	r.setCache(issuerURL, result)
+	return &ResolveResult{Metadata: deepCopyMap(result.metadata), Cached: false, Validated: result.validated, Signed: result.signed}, nil
 }
 
 func (r *Resolver) validateURL(issuerURL string) error {
@@ -310,7 +313,7 @@ func (r *Resolver) handleJWTResponse(ctx context.Context, issuerURL, jwtString s
 	// Validated is true only when a TrustEvaluator is configured and approved
 	// the signer. Without a TrustEvaluator, the signature is verified but no
 	// trust decision is made.
-	return &fetchResult{metadata: claims, validated: r.cfg.TrustEvaluator != nil}, nil
+	return &fetchResult{metadata: claims, validated: r.cfg.TrustEvaluator != nil, signed: true}, nil
 }
 
 // handleJSONResponse processes an application/json response.
@@ -334,11 +337,11 @@ func (r *Resolver) handleJSONResponse(ctx context.Context, issuerURL string, bod
 				return nil, err
 			}
 			// Validated only when a TrustEvaluator is configured and approved.
-			return &fetchResult{metadata: claims, validated: r.cfg.TrustEvaluator != nil}, nil
+			return &fetchResult{metadata: claims, validated: r.cfg.TrustEvaluator != nil, signed: true}, nil
 		}
 	}
 
-	return &fetchResult{metadata: raw, validated: false}, nil
+	return &fetchResult{metadata: raw, validated: false, signed: false}, nil
 }
 
 // validateSignedMetadata verifies the signed_metadata JWT against the issuer's
@@ -687,11 +690,23 @@ func (r *Resolver) fetchJWKSFromURI(ctx context.Context, uri string) (jose.JSONW
 
 func (r *Resolver) getCachedEntry(issuerURL string) *cachedEntry {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
 	entry, ok := r.cache[issuerURL]
-	if !ok || time.Since(entry.fetchedAt) > r.cfg.CacheTTL {
+	if !ok {
+		r.mu.RUnlock()
 		return nil
 	}
+	if time.Since(entry.fetchedAt) > r.cfg.CacheTTL {
+		r.mu.RUnlock()
+		// Evict expired entry under write lock to prevent unbounded growth.
+		r.mu.Lock()
+		// Re-check: another goroutine may have refreshed between locks.
+		if e, ok := r.cache[issuerURL]; ok && time.Since(e.fetchedAt) > r.cfg.CacheTTL {
+			delete(r.cache, issuerURL)
+		}
+		r.mu.Unlock()
+		return nil
+	}
+	r.mu.RUnlock()
 	return entry
 }
 
@@ -707,12 +722,13 @@ func deepCopyMap(m map[string]interface{}) map[string]interface{} {
 	return result
 }
 
-func (r *Resolver) setCache(issuerURL string, parsed map[string]interface{}, validated bool) {
+func (r *Resolver) setCache(issuerURL string, result *fetchResult) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.cache[issuerURL] = &cachedEntry{
-		parsed:    parsed,
+		parsed:    result.metadata,
 		fetchedAt: time.Now(),
-		validated: validated,
+		validated: result.validated,
+		signed:    result.signed,
 	}
 }

--- a/pkg/issuermetadata/resolver_test.go
+++ b/pkg/issuermetadata/resolver_test.go
@@ -1,0 +1,1022 @@
+package issuermetadata
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+)
+
+func newTestResolver(t *testing.T) *Resolver {
+	t.Helper()
+	r, err := New(Config{
+		CacheTTL:  5 * time.Minute,
+		AllowHTTP: true,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	return r
+}
+
+// newTestKey returns a fresh ECDSA P-256 key pair and its public JWK for test use.
+func newTestKey(t *testing.T) (*ecdsa.PrivateKey, jose.JSONWebKey) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating ECDSA key: %v", err)
+	}
+	pubJWK := jose.JSONWebKey{Key: priv.Public(), Algorithm: string(jose.ES256), Use: "sig"}
+	return priv, pubJWK
+}
+
+// signClaims signs the given claims as a compact JWS using ES256.
+func signClaims(t *testing.T, priv *ecdsa.PrivateKey, claims map[string]interface{}) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: priv},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		t.Fatalf("creating signer: %v", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshaling claims: %v", err)
+	}
+	jws, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+	compact, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatalf("serializing JWS: %v", err)
+	}
+	return compact
+}
+
+// inlineJWKS returns the JSON-marshaled JWKS containing just the given public JWK.
+func inlineJWKS(t *testing.T, pub jose.JSONWebKey) map[string]interface{} {
+	t.Helper()
+	b, err := json.Marshal(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{pub}})
+	if err != nil {
+		t.Fatalf("marshaling JWKS: %v", err)
+	}
+	var jwksMap map[string]interface{}
+	if err := json.Unmarshal(b, &jwksMap); err != nil {
+		t.Fatalf("unmarshaling JWKS: %v", err)
+	}
+	return jwksMap
+}
+
+// TestResolve_NoSignedMetadata verifies that plain (unsigned) metadata is
+// returned as-is when signed_metadata is absent.
+func TestResolve_NoSignedMetadata(t *testing.T) {
+	meta := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-credential-issuer" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(meta) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	r := newTestResolver(t)
+	got, err := r.Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if got["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("credential_issuer: got %v", got["credential_issuer"])
+	}
+}
+
+// TestResolve_SignedMetadata_InlineJWKS verifies that when signed_metadata is
+// present with an inline JWKS, the JWT signature is validated and the JWT
+// payload claims are returned as the authoritative metadata.
+func TestResolve_SignedMetadata_InlineJWKS(t *testing.T) {
+	priv, pub := newTestKey(t)
+
+	// JWT claims are the authoritative metadata.
+	jwtClaims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"credential_configurations_supported": map[string]interface{}{
+			"UniversityDegree": map[string]interface{}{"format": "vc+sd-jwt"},
+		},
+	}
+	token := signClaims(t, priv, jwtClaims)
+
+	// Outer document includes the inline JWKS and signed_metadata.
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks":              inlineJWKS(t, pub),
+		"signed_metadata":   token,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-credential-issuer" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	got, err := newTestResolver(t).Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	// Authoritative claim comes from the JWT payload.
+	if got["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("credential_issuer from JWT claims: got %v", got["credential_issuer"])
+	}
+	// signed_metadata is preserved as the original compact JWS string.
+	if got["signed_metadata"] != token {
+		t.Errorf("signed_metadata not preserved: got %v", got["signed_metadata"])
+	}
+	// JWT payload claim is returned.
+	if _, ok := got["credential_configurations_supported"]; !ok {
+		t.Error("credential_configurations_supported not found in JWT payload claims")
+	}
+}
+
+// TestResolve_SignedMetadata_JWKSURI verifies that when signed_metadata is
+// present and the outer metadata only has jwks_uri (no inline jwks), the
+// resolver fetches the JWKS, validates the signature, and returns JWT claims.
+func TestResolve_SignedMetadata_JWKSURI(t *testing.T) {
+	priv, pub := newTestKey(t)
+
+	jwtClaims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+	}
+	token := signClaims(t, priv, jwtClaims)
+
+	jwksBody, err := json.Marshal(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{pub}})
+	if err != nil {
+		t.Fatalf("marshaling JWKS: %v", err)
+	}
+
+	var jwksServer *httptest.Server
+	jwksServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jwksBody) //nolint:errcheck
+	}))
+	defer jwksServer.Close()
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks_uri":          jwksServer.URL + "/jwks",
+		"signed_metadata":   token,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-credential-issuer" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	got, err := newTestResolver(t).Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if got["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("credential_issuer: got %v", got["credential_issuer"])
+	}
+	if got["signed_metadata"] != token {
+		t.Errorf("signed_metadata not preserved: got %v", got["signed_metadata"])
+	}
+}
+
+// TestResolve_SignedMetadata_InvalidSignature verifies that a signed_metadata
+// JWT with a signature that does not match the JWKS is rejected with an error.
+func TestResolve_SignedMetadata_InvalidSignature(t *testing.T) {
+	priv, _ := newTestKey(t)
+	_, differentPub := newTestKey(t) // a different key — wrong public key
+
+	jwtClaims := map[string]interface{}{"credential_issuer": "https://issuer.example.com"}
+	token := signClaims(t, priv, jwtClaims)
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks":              inlineJWKS(t, differentPub), // wrong key
+		"signed_metadata":   token,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-credential-issuer" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	_, err := newTestResolver(t).Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error for invalid signed_metadata signature, got nil")
+	}
+}
+
+// TestResolve_SignedMetadata_NoJWKS verifies that when signed_metadata is
+// present but the metadata has neither jwks nor jwks_uri, an error is returned.
+func TestResolve_SignedMetadata_NoJWKS(t *testing.T) {
+	priv, _ := newTestKey(t)
+	token := signClaims(t, priv, map[string]interface{}{"credential_issuer": "https://issuer.example.com"})
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"signed_metadata":   token,
+		// no jwks or jwks_uri, and no x5c in JWT header
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-credential-issuer" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	_, err := newTestResolver(t).Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error when signed_metadata has no JWKS and no x5c header, got nil")
+	}
+}
+
+// TestResolve_SignedMetadata_X5CFallback verifies that when signed_metadata is
+// present and the outer metadata has no jwks/jwks_uri, the resolver falls back
+// to extracting the signing key from the JWT's x5c header.
+func TestResolve_SignedMetadata_X5CFallback(t *testing.T) {
+	priv, _ := newTestKey(t)
+	cert := newTestCert(t, priv)
+
+	jwtClaims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"credential_configurations_supported": map[string]interface{}{
+			"PID": map[string]interface{}{"format": "dc+sd-jwt"},
+		},
+	}
+	// Sign with x5c in header and typ=JWT
+	token := signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "JWT", jwtClaims)
+
+	// Outer metadata has signed_metadata but no jwks or jwks_uri
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"signed_metadata":   token,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-credential-issuer" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	got, err := newTestResolver(t).Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	// Authoritative claim comes from the JWT payload.
+	if got["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("credential_issuer: got %v", got["credential_issuer"])
+	}
+	// signed_metadata is preserved.
+	if got["signed_metadata"] != token {
+		t.Errorf("signed_metadata not preserved")
+	}
+	// JWT payload claim is returned.
+	if _, ok := got["credential_configurations_supported"]; !ok {
+		t.Error("credential_configurations_supported not found in JWT payload claims")
+	}
+}
+
+// TestResolve_SignedMetadata_KIDSelection verifies that when the JWT header
+// carries a kid, only the matching key in the JWKS is used for verification
+// (the JWKS may contain additional keys for other purposes).
+func TestResolve_SignedMetadata_KIDSelection(t *testing.T) {
+	priv, pub := newTestKey(t)
+	pub.KeyID = "sig-2024"
+	_, unrelatedPub := newTestKey(t) // an unrelated key in the JWKS
+	unrelatedPub.KeyID = "enc-2024"
+
+	// Build JWKS with both keys; sign with the specific kid.
+	b, err := json.Marshal(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{unrelatedPub, pub}})
+	if err != nil {
+		t.Fatalf("marshaling JWKS: %v", err)
+	}
+	var jwksMap map[string]interface{}
+	if err := json.Unmarshal(b, &jwksMap); err != nil {
+		t.Fatalf("unmarshaling JWKS: %v", err)
+	}
+
+	// Sign with the private key carrying kid="sig-2024".
+	signingKey := jose.SigningKey{Algorithm: jose.ES256, Key: &jose.JSONWebKey{Key: priv, KeyID: "sig-2024"}}
+	signer, err := jose.NewSigner(signingKey, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		t.Fatalf("creating signer: %v", err)
+	}
+	payload, err := json.Marshal(map[string]interface{}{"credential_issuer": "https://issuer.example.com"})
+	if err != nil {
+		t.Fatalf("marshaling payload: %v", err)
+	}
+	jws, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+	token, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatalf("serializing: %v", err)
+	}
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks":              jwksMap,
+		"signed_metadata":   token,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-credential-issuer" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	got, err := newTestResolver(t).Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if got["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("credential_issuer: got %v", got["credential_issuer"])
+	}
+	if got["signed_metadata"] != token {
+		t.Errorf("signed_metadata not preserved: got %v", got["signed_metadata"])
+	}
+}
+
+func TestResolve_Cached(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"credential_issuer": "https://test.com"}) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	r := newTestResolver(t)
+
+	if _, err := r.Resolve(context.Background(), server.URL); err != nil {
+		t.Fatalf("first Resolve() error: %v", err)
+	}
+	if _, err := r.Resolve(context.Background(), server.URL); err != nil {
+		t.Fatalf("second Resolve() error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", calls)
+	}
+}
+
+func TestResolve_TrailingSlashStripped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"credential_issuer": "https://test.com"}) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	r := newTestResolver(t)
+	// URL with trailing slash should work the same
+	if _, err := r.Resolve(context.Background(), server.URL+"/"); err != nil {
+		t.Fatalf("Resolve() with trailing slash error: %v", err)
+	}
+}
+
+func TestResolve_RejectsHTTPByDefault(t *testing.T) {
+	r, _ := New(Config{}) // AllowHTTP = false
+	_, err := r.Resolve(context.Background(), "http://issuer.example.com")
+	if err == nil {
+		t.Error("expected error for HTTP URL, got nil")
+	}
+}
+
+func TestResolve_RejectsNonHTTPScheme(t *testing.T) {
+	r := newTestResolver(t)
+	_, err := r.Resolve(context.Background(), "ftp://issuer.example.com")
+	if err == nil {
+		t.Error("expected error for ftp:// URL, got nil")
+	}
+}
+
+func TestResolve_RejectsMissingHost(t *testing.T) {
+	r := newTestResolver(t)
+	_, err := r.Resolve(context.Background(), "https://")
+	if err == nil {
+		t.Error("expected error for URL without host, got nil")
+	}
+}
+
+func TestResolve_RejectsInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not json")) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	r := newTestResolver(t)
+	_, err := r.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error for invalid JSON response")
+	}
+}
+
+func TestResolve_RejectsNonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	r := newTestResolver(t)
+	_, err := r.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error for HTTP 404 response")
+	}
+}
+
+func TestResolve_CacheTTLExpiry(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]int{"call": calls}) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	r, _ := New(Config{
+		CacheTTL:  1 * time.Millisecond, // very short TTL
+		AllowHTTP: true,
+	})
+
+	if _, err := r.Resolve(context.Background(), server.URL); err != nil {
+		t.Fatalf("first Resolve() error: %v", err)
+	}
+
+	time.Sleep(5 * time.Millisecond) // let TTL expire
+
+	if _, err := r.Resolve(context.Background(), server.URL); err != nil {
+		t.Fatalf("second Resolve() error: %v", err)
+	}
+
+	if calls != 2 {
+		t.Errorf("expected 2 HTTP requests after TTL expiry, got %d", calls)
+	}
+}
+
+// mockTrustEvaluator implements TrustEvaluator for testing.
+type mockTrustEvaluator struct {
+	decision bool
+	err      error
+	requests []*authzen.EvaluationRequest
+}
+
+func (m *mockTrustEvaluator) Evaluate(_ context.Context, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+	m.requests = append(m.requests, req)
+	if m.err != nil {
+		return nil, m.err
+	}
+	resp := &authzen.EvaluationResponse{Decision: m.decision}
+	if !m.decision {
+		resp.Context = &authzen.EvaluationResponseContext{
+			Reason: map[string]interface{}{"error": "not trusted"},
+		}
+	}
+	return resp, nil
+}
+
+// newTestCert creates a self-signed X.509 certificate for the given key.
+func newTestCert(t *testing.T, priv *ecdsa.PrivateKey) *x509.Certificate {
+	t.Helper()
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("creating test certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		t.Fatalf("parsing test certificate: %v", err)
+	}
+	return cert
+}
+
+// signClaimsWithX5C signs claims as a compact JWS with x5c header.
+func signClaimsWithX5C(t *testing.T, priv *ecdsa.PrivateKey, certs []*x509.Certificate, typ string, claims map[string]interface{}) string {
+	t.Helper()
+	opts := &jose.SignerOptions{}
+	if typ != "" {
+		opts = opts.WithType(jose.ContentType(typ))
+	}
+	// Add x5c header
+	b64Certs := make([]interface{}, len(certs))
+	for i, cert := range certs {
+		b64Certs[i] = base64.StdEncoding.EncodeToString(cert.Raw)
+	}
+	opts = opts.WithHeader("x5c", b64Certs)
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: priv},
+		opts,
+	)
+	if err != nil {
+		t.Fatalf("creating signer: %v", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshaling claims: %v", err)
+	}
+	jws, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+	compact, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatalf("serializing JWS: %v", err)
+	}
+	return compact
+}
+
+// TestResolveWithInfo_Validated_SignedMetadata verifies that ResolveWithInfo
+// reports Validated=true when signed_metadata is present, valid, and a
+// TrustEvaluator is configured that approves the signer.
+func TestResolveWithInfo_Validated_SignedMetadata(t *testing.T) {
+	priv, pub := newTestKey(t)
+	jwtClaims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+	}
+	token := signClaims(t, priv, jwtClaims)
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks":              inlineJWKS(t, pub),
+		"signed_metadata":   token,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	evaluator := &mockTrustEvaluator{decision: true}
+	resolver, _ := New(Config{
+		AllowHTTP:      true,
+		TrustEvaluator: evaluator,
+	})
+	result, err := resolver.ResolveWithInfo(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("ResolveWithInfo() error: %v", err)
+	}
+	if !result.Validated {
+		t.Error("expected Validated=true for signed_metadata response with TrustEvaluator")
+	}
+}
+
+// TestResolveWithInfo_NotValidated_SignedWithoutEvaluator verifies that
+// Validated=false when signed_metadata is present but no TrustEvaluator is configured.
+func TestResolveWithInfo_NotValidated_SignedWithoutEvaluator(t *testing.T) {
+	priv, pub := newTestKey(t)
+	jwtClaims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+	}
+	token := signClaims(t, priv, jwtClaims)
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks":              inlineJWKS(t, pub),
+		"signed_metadata":   token,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	result, err := newTestResolver(t).ResolveWithInfo(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("ResolveWithInfo() error: %v", err)
+	}
+	if result.Validated {
+		t.Error("expected Validated=false for signed_metadata without TrustEvaluator")
+	}
+}
+
+// TestResolveWithInfo_NotValidated_UnsignedJSON verifies that ResolveWithInfo
+// reports Validated=false for plain unsigned JSON.
+func TestResolveWithInfo_NotValidated_UnsignedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"credential_issuer": "https://test.com"}) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	result, err := newTestResolver(t).ResolveWithInfo(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("ResolveWithInfo() error: %v", err)
+	}
+	if result.Validated {
+		t.Error("expected Validated=false for unsigned JSON response")
+	}
+}
+
+// TestResolve_ApplicationJWT_WithX5C tests the application/jwt Content-Type
+// response path with x5c certificate chain in the JOSE header.
+func TestResolve_ApplicationJWT_WithX5C(t *testing.T) {
+	priv, _ := newTestKey(t)
+	cert := newTestCert(t, priv)
+
+	evaluator := &mockTrustEvaluator{decision: true}
+
+	// We need the server URL for the sub claim, so create server first with a handler
+	// that will be set after we know the URL.
+	var token string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jwt")
+		w.Write([]byte(token)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	// Now create the token with sub matching the test server URL
+	claims := map[string]interface{}{
+		"credential_issuer": server.URL,
+		"sub":               server.URL,
+		"iat":               time.Now().Unix(),
+	}
+	token = signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "openidvci-issuer-metadata+jwt", claims)
+
+	resolver, err := New(Config{
+		CacheTTL:       5 * time.Minute,
+		AllowHTTP:      true,
+		TrustEvaluator: evaluator,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	result, err := resolver.ResolveWithInfo(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("ResolveWithInfo() error: %v", err)
+	}
+	if !result.Validated {
+		t.Error("expected Validated=true for application/jwt response")
+	}
+	if result.Metadata["sub"] != server.URL {
+		t.Errorf("expected sub=%q, got %v", server.URL, result.Metadata["sub"])
+	}
+
+	// Verify trust evaluator was called with x5c
+	if len(evaluator.requests) != 1 {
+		t.Fatalf("expected 1 trust evaluation request, got %d", len(evaluator.requests))
+	}
+	req := evaluator.requests[0]
+	if req.Resource.Type != "x5c" {
+		t.Errorf("expected resource.type=x5c, got %q", req.Resource.Type)
+	}
+	if req.Action == nil || req.Action.Name != "credential-issuer" {
+		t.Error("expected action.name=credential-issuer")
+	}
+}
+
+// TestResolve_ApplicationJWT_TrustEvaluatorRejects tests that when the trust
+// evaluator rejects the signer, the metadata is not returned.
+func TestResolve_ApplicationJWT_TrustEvaluatorRejects(t *testing.T) {
+	priv, _ := newTestKey(t)
+	cert := newTestCert(t, priv)
+
+	evaluator := &mockTrustEvaluator{decision: false}
+
+	var token string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jwt")
+		w.Write([]byte(token)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	claims := map[string]interface{}{
+		"credential_issuer": server.URL,
+		"sub":               server.URL,
+		"iat":               time.Now().Unix(),
+	}
+	token = signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "openidvci-issuer-metadata+jwt", claims)
+
+	resolver, _ := New(Config{
+		CacheTTL:       5 * time.Minute,
+		AllowHTTP:      true,
+		TrustEvaluator: evaluator,
+	})
+
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error when trust evaluator rejects signer")
+	}
+	if !strings.Contains(err.Error(), "not trusted") {
+		t.Errorf("expected 'not trusted' in error, got: %v", err)
+	}
+}
+
+// TestResolve_ApplicationJWT_WrongTyp tests that a JWT with wrong typ header is rejected.
+func TestResolve_ApplicationJWT_WrongTyp(t *testing.T) {
+	priv, _ := newTestKey(t)
+	cert := newTestCert(t, priv)
+
+	issuerURL := "https://issuer.example.com"
+	claims := map[string]interface{}{
+		"credential_issuer": issuerURL,
+		"sub":               issuerURL,
+		"iat":               time.Now().Unix(),
+	}
+	// Wrong typ
+	token := signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "JWT", claims)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jwt")
+		w.Write([]byte(token)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{
+		AllowHTTP: true,
+	})
+
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error for wrong typ header")
+	}
+	if !strings.Contains(err.Error(), "openidvci-issuer-metadata+jwt") {
+		t.Errorf("expected typ error message, got: %v", err)
+	}
+}
+
+// TestResolve_ApplicationJWT_MissingSub tests that a JWT without sub claim is rejected.
+func TestResolve_ApplicationJWT_MissingSub(t *testing.T) {
+	priv, _ := newTestKey(t)
+	cert := newTestCert(t, priv)
+
+	claims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		// missing "sub"
+		"iat": time.Now().Unix(),
+	}
+	token := signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "openidvci-issuer-metadata+jwt", claims)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jwt")
+		w.Write([]byte(token)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{AllowHTTP: true})
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error for missing sub claim")
+	}
+}
+
+// TestResolve_ApplicationJWT_SubMismatch tests that a JWT with sub not matching issuer URL is rejected.
+func TestResolve_ApplicationJWT_SubMismatch(t *testing.T) {
+	priv, _ := newTestKey(t)
+	cert := newTestCert(t, priv)
+
+	claims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"sub":               "https://different.example.com",
+		"iat":               time.Now().Unix(),
+	}
+	token := signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "openidvci-issuer-metadata+jwt", claims)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jwt")
+		w.Write([]byte(token)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{AllowHTTP: true})
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error for sub mismatch")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("expected sub mismatch error, got: %v", err)
+	}
+}
+
+// TestResolve_ApplicationJWT_MissingIat tests that a JWT without iat claim is rejected.
+func TestResolve_ApplicationJWT_MissingIat(t *testing.T) {
+	priv, _ := newTestKey(t)
+	cert := newTestCert(t, priv)
+
+	claims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"sub":               "https://issuer.example.com",
+		// missing "iat"
+	}
+	token := signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "openidvci-issuer-metadata+jwt", claims)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jwt")
+		w.Write([]byte(token)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{AllowHTTP: true})
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error for missing iat claim")
+	}
+}
+
+// TestResolve_SignedMetadata_TrustEvaluatorCalled verifies that the trust evaluator
+// is called for the legacy signed_metadata field in JSON responses.
+func TestResolve_SignedMetadata_TrustEvaluatorCalled(t *testing.T) {
+	priv, pub := newTestKey(t)
+	jwtClaims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+	}
+	token := signClaims(t, priv, jwtClaims)
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks":              inlineJWKS(t, pub),
+		"signed_metadata":   token,
+	}
+
+	evaluator := &mockTrustEvaluator{decision: true}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{
+		AllowHTTP:      true,
+		TrustEvaluator: evaluator,
+	})
+
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	// Trust evaluator should have been called with jwk type
+	// (legacy signed_metadata uses JWKS keys, not x5c)
+	if len(evaluator.requests) != 1 {
+		t.Fatalf("expected 1 trust evaluation request, got %d", len(evaluator.requests))
+	}
+	req := evaluator.requests[0]
+	if req.Resource.Type != "jwk" {
+		t.Errorf("expected resource.type=jwk, got %q", req.Resource.Type)
+	}
+}
+
+// TestResolve_SignedMetadata_TrustEvaluatorRejects verifies that when the trust
+// evaluator rejects the signer of signed_metadata, an error is returned.
+func TestResolve_SignedMetadata_TrustEvaluatorRejects(t *testing.T) {
+	priv, pub := newTestKey(t)
+	token := signClaims(t, priv, map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+	})
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks":              inlineJWKS(t, pub),
+		"signed_metadata":   token,
+	}
+
+	evaluator := &mockTrustEvaluator{decision: false}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{
+		AllowHTTP:      true,
+		TrustEvaluator: evaluator,
+	})
+
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error when trust evaluator rejects signer")
+	}
+}
+
+// TestResolve_AcceptHeader verifies the Accept header is sent correctly.
+func TestResolve_AcceptHeader(t *testing.T) {
+	var acceptHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		acceptHeader = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"credential_issuer": "https://test.com"}) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{AllowHTTP: true})
+	resolver.Resolve(context.Background(), server.URL) //nolint:errcheck
+
+	if !strings.Contains(acceptHeader, "application/jwt") {
+		t.Errorf("expected Accept header to include application/jwt, got %q", acceptHeader)
+	}
+	if !strings.Contains(acceptHeader, "application/json") {
+		t.Errorf("expected Accept header to include application/json, got %q", acceptHeader)
+	}
+}
+
+// TestResolve_UnsupportedContentType verifies that unsupported Content-Types are rejected.
+func TestResolve_UnsupportedContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, "<html>not metadata</html>")
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{AllowHTTP: true})
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error for unsupported Content-Type")
+	}
+	if !strings.Contains(err.Error(), "unsupported Content-Type") {
+		t.Errorf("expected Content-Type error, got: %v", err)
+	}
+}
+
+// TestResolve_TrustEvaluatorError verifies that trust evaluator errors propagate.
+func TestResolve_TrustEvaluatorError(t *testing.T) {
+	priv, pub := newTestKey(t)
+	token := signClaims(t, priv, map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+	})
+
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"jwks":              inlineJWKS(t, pub),
+		"signed_metadata":   token,
+	}
+
+	evaluator := &mockTrustEvaluator{err: fmt.Errorf("trust engine unavailable")}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	resolver, _ := New(Config{
+		AllowHTTP:      true,
+		TrustEvaluator: evaluator,
+	})
+
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err == nil {
+		t.Error("expected error when trust evaluator returns error")
+	}
+	if !strings.Contains(err.Error(), "trust engine unavailable") {
+		t.Errorf("expected propagated error, got: %v", err)
+	}
+}

--- a/pkg/trust/jwtutil.go
+++ b/pkg/trust/jwtutil.go
@@ -63,6 +63,10 @@ func ExtractKeyMaterialFromJWT(jwtStr string) *KeyMaterial {
 	return nil
 }
 
+// ErrNoEmbeddedKey is returned by VerifyJWTWithEmbeddedKey when the JWT header
+// contains neither an x5c certificate chain nor an embedded JWK.
+var ErrNoEmbeddedKey = errors.New("JWT header contains neither x5c nor jwk")
+
 // VerifyJWTWithEmbeddedKey verifies a JWT's signature using the key material
 // embedded in its own header (x5c or jwk). This ensures the JWT was actually
 // signed by the claimed key, preventing header injection attacks.
@@ -121,7 +125,7 @@ func VerifyJWTWithEmbeddedKey(jwtStr string, ext ...*cryptoutil.Extensions) (*Ke
 		pubKey = key
 		km = &KeyMaterial{Type: "jwk", JWK: header.JWK}
 	} else {
-		return nil, errors.New("JWT header contains neither x5c nor jwk")
+		return nil, ErrNoEmbeddedKey
 	}
 
 	// Verify the JWT signature using the extracted public key

--- a/tests/integration/trust_test.go
+++ b/tests/integration/trust_test.go
@@ -26,7 +26,7 @@ func TestTrustService_WithGoTrustTestServer(t *testing.T) {
 		defer srv.Close()
 
 		// Create trust service pointing to testserver
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,
@@ -52,7 +52,7 @@ func TestTrustService_WithGoTrustTestServer(t *testing.T) {
 		defer srv.Close()
 
 		// Create trust service pointing to testserver
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,
@@ -73,7 +73,7 @@ func TestTrustService_WithGoTrustTestServer(t *testing.T) {
 
 	t.Run("No trust endpoint configured", func(t *testing.T) {
 		// Create trust service without endpoint
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: "", // No endpoint
 			},
@@ -102,7 +102,7 @@ func TestTrustService_VerifierEvaluation(t *testing.T) {
 		srv := testserver.New(testserver.WithRegistry(reg))
 		defer srv.Close()
 
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,
@@ -128,7 +128,7 @@ func TestTrustService_VerifierEvaluation(t *testing.T) {
 		srv := testserver.New(testserver.WithRegistry(reg))
 		defer srv.Close()
 
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,
@@ -158,7 +158,7 @@ func TestTrustService_EndpointOverride(t *testing.T) {
 	defer deniedSrv.Close()
 
 	// Default endpoint allows everything
-	cfg := &config.Config{
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 		Trust: config.TrustConfig{
 			DefaultEndpoint: trustedSrv.URL(),
 			Timeout:         10,
@@ -186,7 +186,7 @@ func TestTrustService_EvaluatorCaching(t *testing.T) {
 	srv := testserver.New(testserver.WithRegistry(reg))
 	defer srv.Close()
 
-	cfg := &config.Config{
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 		Trust: config.TrustConfig{
 			DefaultEndpoint: srv.URL(),
 			Timeout:         10,
@@ -215,7 +215,7 @@ func TestTrustService_Timeout(t *testing.T) {
 	srv := testserver.New(testserver.WithRegistry(reg))
 	defer srv.Close()
 
-	cfg := &config.Config{
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 		Trust: config.TrustConfig{
 			DefaultEndpoint: srv.URL(),
 			Timeout:         1, // 1 second timeout
@@ -239,7 +239,7 @@ func TestTrustService_ConcurrentRequests(t *testing.T) {
 	srv := testserver.New(testserver.WithRegistry(reg))
 	defer srv.Close()
 
-	cfg := &config.Config{
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 		Trust: config.TrustConfig{
 			DefaultEndpoint: srv.URL(),
 			Timeout:         10,
@@ -286,7 +286,7 @@ func TestTrustService_JWKKeyMaterial(t *testing.T) {
 		srv := testserver.New(testserver.WithRegistry(reg))
 		defer srv.Close()
 
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,
@@ -319,7 +319,7 @@ func TestTrustService_JWKKeyMaterial(t *testing.T) {
 		srv := testserver.New(testserver.WithRegistry(reg))
 		defer srv.Close()
 
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,
@@ -356,7 +356,7 @@ func TestTrustService_JWKKeyMaterial(t *testing.T) {
 		srv := testserver.New(testserver.WithRegistry(reg))
 		defer srv.Close()
 
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,
@@ -387,7 +387,7 @@ func TestTrustService_JWKKeyMaterial(t *testing.T) {
 		srv := testserver.New(testserver.WithRegistry(reg))
 		defer srv.Close()
 
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,
@@ -419,7 +419,7 @@ func TestTrustService_JWKKeyMaterial(t *testing.T) {
 		srv := testserver.New(testserver.WithRegistry(reg))
 		defer srv.Close()
 
-		cfg := &config.Config{
+		cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 			Trust: config.TrustConfig{
 				DefaultEndpoint: srv.URL(),
 				Timeout:         10,


### PR DESCRIPTION
Move OpenID4VCI issuer metadata resolution from the PDP into the PEP for `subject_type=url` requests on `/v1/resolve`. The handler now performs a composite operation that the frontend sees as a single call.

## What changed

### Core resolution flow
1. Resolves `.well-known/openid-credential-issuer` metadata locally via `issuermetadata.Resolver` (go-trust)
2. Extracts key material in order: `signed_metadata` JWT → inline `jwks` → `jwks_uri`
3. Sends a key-based trust evaluation request to the PDP
4. Inlines logo images from `display[].logo.uri` as `data:` URIs when metadata is trusted
5. Returns a composite `EvaluationResponse` with `decision`, `context.trust_metadata` (with inlined logos), and `reason`

Key subjects (`subject_type=key`) continue to proxy directly to the PDP. When no metadata resolver is configured, URL subjects also fall back to PDP proxy for backward compatibility.

### Registered issuer enrichment
When the resolved issuer URL matches an issuer registered in the backend storage for the authenticated tenant, the response includes a `registered_issuer` object with:
- `client_id` — custom OIDC client identifier
- `visible` — whether the issuer is shown in the UI
- `trust_status` — tenant-level trust classification
- `trust_framework` — applicable framework identifier

Cross-tenant isolation is enforced: all lookups are scoped exclusively to the tenant extracted from the JWT — never to a caller-supplied tenant ID.

### Security hardening (from review)
- **signed_metadata hard failure**: if a `signed_metadata` JWT is present but embedded-key verification fails, the request is rejected (HTTP 502) rather than silently falling back to unsigned metadata. An issuer claiming a binding it cannot prove must not succeed.
- **SSRF protection for `jwks_uri` and logo fetching**: `NewHTTPClient` now installs a custom `DialContext` that blocks private, loopback, link-local, and cloud-metadata IPs when `AllowPrivateIPs=false`. This prevents SSRF via issuer-controlled URIs even after DNS resolution (DNS rebinding protection).
- **nil resolver → PDP fallback**: when the metadata resolver is not configured, URL subjects fall back to the PDP proxy instead of returning HTTP 503.

### Cache sharing
`issuermetadata.Resolver` is now constructed once in `BackendProvider` and shared with `EngineProvider` (for the OID4VCI WebSocket flow) via `BackendProvider.MetadataResolver()`. This ensures the TTL cache is not duplicated — a `.well-known` fetch from any flow benefits all others. `NewEngineProvider` accepts a `sharedResolver` parameter (nil = create its own, for standalone engine deployments).

## Files changed
- `internal/api/authzen_proxy.go` — URL subject resolution, registered issuer enrichment, security hardening
- `internal/api/authzen_proxy_test.go` — tests for registered issuer enrichment paths
- `internal/server/providers.go` — shared resolver wiring, `MetadataResolver()` accessor
- `cmd/server/main.go` — pass shared resolver to `NewEngineProvider`
- `pkg/config/config.go` — SSRF-blocking `DialContext` in `NewHTTPClient` when `AllowPrivateIPs=false`

Closes #150