### PR TITLE
feat: add resource_type vctm_url to /v1/resolve

### DIFF
--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -388,6 +388,10 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 			h.resolveCredentialOfferURI(c, ctx, req.SubjectID)
 			return
 		}
+		if resourceType == "vctm_url" {
+			h.resolveVCTMURL(c, ctx, req.SubjectID)
+			return
+		}
 		// Default: resolve as credential issuer (fetches /.well-known/openid-credential-issuer)
 		if h.metadataResolver == nil {
 			h.logger.Debug("no metadata resolver configured for URL subject — proxying to PDP")
@@ -400,6 +404,83 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 
 	// For key subjects, proxy to PDP
 	h.proxyToPDP(c, ctx, tenantID, evalReq)
+}
+
+// resolveVCTMURL fetches an SD-JWT VC Type Metadata document from the given URL
+// and returns it as trust_metadata. The URL must already be validated as HTTPS.
+// The document must contain a "vct" field per the SD-JWT VC Type Metadata spec.
+//
+// Response: { "decision": true, "context": { "trust_metadata": <vctm doc> } }
+func (h *AuthZENProxyHandler) resolveVCTMURL(c *gin.Context, ctx context.Context, vctURL string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, vctURL, nil)
+	if err != nil {
+		h.logger.Error("failed to build VCTM request",
+			zap.String("vct_url", vctURL),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch VCTM"})
+		return
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.logger.Error("VCTM fetch failed",
+			zap.String("vct_url", vctURL),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch VCTM"})
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		h.logger.Warn("VCTM endpoint returned non-200",
+			zap.String("vct_url", vctURL),
+			zap.Int("status", resp.StatusCode),
+		)
+		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("VCTM endpoint returned status %d", resp.StatusCode)})
+		return
+	}
+
+	const maxVCTMSize = 1 << 20
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxVCTMSize))
+	if err != nil {
+		h.logger.Error("failed to read VCTM response",
+			zap.String("vct_url", vctURL),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read VCTM response"})
+		return
+	}
+
+	var vctm map[string]interface{}
+	if err := json.Unmarshal(body, &vctm); err != nil {
+		h.logger.Warn("VCTM response is not valid JSON",
+			zap.String("vct_url", vctURL),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "VCTM response is not valid JSON"})
+		return
+	}
+
+	// Validate required field per SD-JWT VC Type Metadata spec
+	if _, ok := vctm["vct"].(string); !ok {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "VCTM missing required field: vct"})
+		return
+	}
+
+	h.logger.Info("VCTM URL resolved",
+		zap.String("vct_url", vctURL),
+		zap.String("vct", vctm["vct"].(string)),
+	)
+
+	c.JSON(http.StatusOK, gin.H{
+		"decision": true,
+		"context": gin.H{
+			"trust_metadata": vctm,
+		},
+	})
 }
 
 // resolveCredentialOfferURI fetches a credential_offer_uri and returns the parsed

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -742,6 +742,273 @@ func TestResolve_URLSubject_SPOCP_DefaultRules_Authorized(t *testing.T) {
 }
 
 // ============================================================================
+// vctm_url Resource Type Tests
+// ============================================================================
+
+func TestResolve_VCTMURL_Success(t *testing.T) {
+	vctm := map[string]interface{}{
+		"vct":         "https://credentials.example.com/identity_credential",
+		"name":        "Identity Credential",
+		"description": "An identity credential",
+		"display": []interface{}{
+			map[string]interface{}{
+				"lang": "en-US",
+				"name": "Identity Credential",
+			},
+		},
+	}
+
+	vctmServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(vctm) //nolint:errcheck
+	}))
+	defer vctmServer.Close()
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{},
+		},
+	}
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, vctmServer.Client(), logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":    vctmServer.URL + "/identity_credential",
+		"subject_type":  "url",
+		"resource_type": "vctm_url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if resp["decision"] != true {
+		t.Errorf("Expected decision=true, got %v", resp["decision"])
+	}
+	ctx, ok := resp["context"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected context object, got %T", resp["context"])
+	}
+	tm, ok := ctx["trust_metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected context.trust_metadata object, got %T", ctx["trust_metadata"])
+	}
+	if tm["vct"] != "https://credentials.example.com/identity_credential" {
+		t.Errorf("Unexpected vct value: %v", tm["vct"])
+	}
+}
+
+func TestResolve_VCTMURL_NonHTTPS_Rejected(t *testing.T) {
+	_, router, pdpServer := setupAuthZENProxyHandler(t, &mockAuthorizer{allowAll: true}, nil)
+	if pdpServer != nil {
+		defer pdpServer.Close()
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":    "http://credentials.example.com/identity_credential",
+		"subject_type":  "url",
+		"resource_type": "vctm_url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+}
+
+func TestResolve_VCTMURL_FetchFailure(t *testing.T) {
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{},
+		},
+	}
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":    "https://127.0.0.1:1/vctm",
+		"subject_type":  "url",
+		"resource_type": "vctm_url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusBadGateway, w.Code, w.Body.String())
+	}
+}
+
+func TestResolve_VCTMURL_InvalidJSON(t *testing.T) {
+	vctmServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not valid json")) //nolint:errcheck
+	}))
+	defer vctmServer.Close()
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{},
+		},
+	}
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, vctmServer.Client(), logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":    vctmServer.URL + "/vctm",
+		"subject_type":  "url",
+		"resource_type": "vctm_url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusBadGateway, w.Code, w.Body.String())
+	}
+}
+
+func TestResolve_VCTMURL_MissingVCTField(t *testing.T) {
+	vctmServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+			"name": "No VCT field here",
+		})
+	}))
+	defer vctmServer.Close()
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{},
+		},
+	}
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, vctmServer.Client(), logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":    vctmServer.URL + "/vctm",
+		"subject_type":  "url",
+		"resource_type": "vctm_url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusBadGateway, w.Code, w.Body.String())
+	}
+}
+
+func TestResolve_VCTMURL_NonOKStatus(t *testing.T) {
+	vctmServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer vctmServer.Close()
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{
+			Metadata: map[string]interface{}{},
+		},
+	}
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, resolver, vctmServer.Client(), logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":    vctmServer.URL + "/vctm",
+		"subject_type":  "url",
+		"resource_type": "vctm_url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("Expected status %d, got %d: %s", http.StatusBadGateway, w.Code, w.Body.String())
+	}
+}
+
+// ============================================================================
 // credential_offer_uri Resource Type Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Adds `resource_type: "vctm_url"` support to `POST /v1/resolve`. Backend side of sirosfoundation/wallet-frontend#105.

When the client sends:
```json
{
  "subject_id": "https://credentials.example.com/identity_credential",
  "subject_type": "url",
  "resource_type": "vctm_url"
}
```

The endpoint fetches the SD-JWT VC Type Metadata document server-side and returns it:
```json
{
  "decision": true,
  "context": {
    "trust_metadata": {
      "vct": "https://credentials.example.com/identity_credential",
      "name": "...",
      "display": [...]
    }
  }
}
```

## Design

- Uses `trust_metadata` (not a new field) — symmetric with `credential_issuer` resolution; both are metadata documents looked up by URL
- Same primitives as `resolveCredentialOfferURI`: `h.httpClient`, 1MB body limit, HTTPS-only gate, SPOCP auth runs first
- No new dependencies, no wiring changes to `providers.go`
- Document validated to contain required `vct` string field (SD-JWT VC Type Metadata spec)

## Frontend follow-up

The wallet-frontend change (replacing `VCT_REGISTRY_URL`/`httpProxy.get` with `authzenClient.resolve(..., { resourceType: 'vctm_url' })` and deprecating `VCT_REGISTRY_URL`) will be a separate PR tracking sirosfoundation/wallet-frontend#105.

## Tests (6 new)

- ✅ Success with well-formed TLS VCTM server → `trust_metadata` in response
- ✅ Non-HTTPS `subject_id` rejected (400)
- ✅ Fetch failure → 502
- ✅ Invalid JSON response → 502
- ✅ Missing `vct` field → 502
- ✅ Non-200 status from VCTM endpoint → 502

## Dependency

Stacked on #153 (both modify the same handler). Targets `feat/resolve-credential-offer-uri`.