### PR TITLE
fix: use unrestricted HTTP client for operator-configured PDP endpoints

### DIFF
--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -68,16 +68,23 @@ type AuthZENProxyHandler struct {
 	metadataResolver IssuerMetadataResolver
 	clients          map[string]*authzenclient.Client
 	clientsMu        sync.RWMutex
-	httpClient       *http.Client
-	allowHTTP        bool // when true, plain HTTP URLs are permitted for logos and jwks_uri (test/dev envs)
-	logger           *zap.Logger
+	// httpClient is used for external (user-visible) fetches: VCTM, credential offers, logos, jwks_uri.
+	// SSRF restrictions are applied here because these URLs originate from user-supplied content.
+	httpClient *http.Client
+	// pdpClient is used exclusively for requests to operator-configured PDP endpoints.
+	// SSRF dial restrictions are not applied because the PDP URL is operator-controlled.
+	pdpClient *http.Client
+	allowHTTP bool // when true, plain HTTP URLs are permitted for logos and jwks_uri (test/dev envs)
+	logger    *zap.Logger
 }
 
 // NewAuthZENProxyHandler creates a new AuthZEN proxy handler.
 // The tenantLookup and issuerLookup parameters are optional - if nil, the respective
 // per-tenant features are disabled.
 // The metadataResolver is required for URL subject resolution on /v1/resolve.
-func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Authorizer, tenantLookup TenantLookup, issuerLookup IssuerLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, logger *zap.Logger) *AuthZENProxyHandler {
+// httpClient is used for external/user-visible fetches (SSRF-protected).
+// pdpClient is used for PDP requests (no SSRF restriction; URL is operator-configured).
+func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Authorizer, tenantLookup TenantLookup, issuerLookup IssuerLookup, metadataResolver IssuerMetadataResolver, httpClient *http.Client, pdpClient *http.Client, logger *zap.Logger) *AuthZENProxyHandler {
 	return &AuthZENProxyHandler{
 		cfg:              cfg,
 		authorizer:       authorizer,
@@ -86,6 +93,7 @@ func NewAuthZENProxyHandler(cfg *config.AuthZENProxyConfig, authorizer authz.Aut
 		metadataResolver: metadataResolver,
 		clients:          make(map[string]*authzenclient.Client),
 		httpClient:       httpClient,
+		pdpClient:        pdpClient,
 		logger:           logger.Named("authzen-proxy"),
 	}
 }
@@ -140,6 +148,14 @@ func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLoo
 		panic("authzen: AllowResolution=true but metadataResolver is nil — check server startup")
 	}
 
+	// Build a separate client for PDP calls. This client:
+	// - does NOT use a proxy (PDP is an internal service, reached directly)
+	// - does NOT apply SSRF dial restrictions (PDP URL is operator-controlled)
+	// - uses PDP-specific TLS settings from cfg.Trust (CACertPath, InsecureSkipVerify)
+	pdpClient, err := cfg.Trust.NewPDPHTTPClient(0)
+	if err != nil {
+		return nil, fmt.Errorf("authzen: failed to create PDP HTTP client: %w", err)
+	}
 	handler := NewAuthZENProxyHandler(
 		&cfg.AuthZENProxy,
 		authorizerInterface,
@@ -147,6 +163,7 @@ func NewAuthZENProxyHandlerFromConfig(cfg *config.Config, tenantLookup TenantLoo
 		issuerLookup,
 		metadataResolver,
 		httpClient,
+		pdpClient,
 		logger,
 	)
 	// Propagate the HTTP client's allow_http setting so that logo and
@@ -181,7 +198,7 @@ func (h *AuthZENProxyHandler) getClient(pdpURL string) (*authzenclient.Client, e
 		return client, nil
 	}
 
-	client := authzenclient.New(pdpURL, authzenclient.WithHTTPClient(h.httpClient))
+	client := authzenclient.New(pdpURL, authzenclient.WithHTTPClient(h.pdpClient))
 	h.clients[pdpURL] = client
 	return client, nil
 }

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -87,7 +87,7 @@ func setupAuthZENProxyHandlerWithTenants(t *testing.T, authorizer authz.Authoriz
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, authorizer, tenantLookup, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, authorizer, tenantLookup, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 
@@ -169,7 +169,7 @@ func TestEvaluate_Unauthorized_NoTenant(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	// No middleware to set tenant_id
@@ -241,7 +241,7 @@ func TestEvaluate_ServiceUnavailable_NoPDP(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -377,7 +377,7 @@ func TestResolve_ServiceUnavailable_NoPDP(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -411,7 +411,7 @@ func TestResolve_Forbidden_ResolutionDisabled(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -442,7 +442,7 @@ func TestResolve_Unauthorized_NoTenantID(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	// No middleware setting tenant_id
@@ -470,7 +470,7 @@ func TestResolve_InternalError_BadTenantIDType(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -508,7 +508,7 @@ func TestResolve_BadGateway_PDPError(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -715,7 +715,7 @@ func TestResolve_URLSubject_SPOCP_DefaultRules_Authorized(t *testing.T) {
 			},
 		},
 	}
-	handler := NewAuthZENProxyHandler(cfg, spocpAuth, nil, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, spocpAuth, nil, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -789,7 +789,7 @@ func TestGetPDPURL(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	// Returns the global URL when no per-tenant config is available
 	ctx := context.Background()
@@ -810,7 +810,7 @@ func TestNewAuthZENProxyHandler(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	if handler == nil {
 		t.Fatal("Expected handler to not be nil")
@@ -837,7 +837,7 @@ func TestGetClient_Caching(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	// First call creates client
 	client1, err := handler.getClient("https://pdp1.example.com")
@@ -899,7 +899,7 @@ func TestGetPDPURL_PerTenantConfig(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	ctx := context.Background()
 
@@ -934,7 +934,7 @@ func TestGetPDPURL_PerTenantConfig(t *testing.T) {
 	})
 
 	t.Run("nil tenant lookup uses global URL", func(t *testing.T) {
-		handlerNoLookup := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, logger)
+		handlerNoLookup := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 		url, err := handlerNoLookup.getPDPURL(ctx, "any-tenant")
 		if err != nil {
 			t.Fatalf("getPDPURL() unexpected error: %v", err)
@@ -961,7 +961,7 @@ func TestGetPDPURL_FailClosedBehavior(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 	ctx := context.Background()
 
@@ -979,7 +979,7 @@ func TestGetPDPURL_FailClosedBehavior(t *testing.T) {
 			Timeout:                     30,
 			FailOpenOnTenantLookupError: true, // fail-open
 		}
-		handlerFailOpen := NewAuthZENProxyHandler(cfgFailOpen, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, logger)
+		handlerFailOpen := NewAuthZENProxyHandler(cfgFailOpen, &mockAuthorizer{allowAll: true}, tenantLookup, nil, nil, http.DefaultClient, http.DefaultClient, logger)
 
 		url, err := handlerFailOpen.getPDPURL(ctx, "any-tenant")
 		if err != nil {
@@ -1276,7 +1276,7 @@ func TestResolve_URLSubject_LocalResolution(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1352,7 +1352,7 @@ func TestResolve_URLSubject_Untrusted(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1399,7 +1399,7 @@ func TestResolve_URLSubject_MetadataResolutionFailure(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1480,7 +1480,7 @@ func TestResolve_URLSubject_LogoInlining(t *testing.T) {
 	}
 	logger := zap.NewNop()
 	// Use the TLS server's client so the handler can fetch HTTPS logo URLs.
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, logoServer.Client(), logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, logoServer.Client(), logoServer.Client(), logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1568,7 +1568,7 @@ func TestResolve_KeySubject_ProxiesToPDP(t *testing.T) {
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1633,7 +1633,7 @@ func TestResolve_URLSubject_SignedMetadata_VerificationFailed_Error(t *testing.T
 		AllowResolution: true,
 	}
 	logger := zap.NewNop()
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, logger)
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1698,7 +1698,7 @@ func TestResolve_URLSubject_RegisteredIssuerInfo_IncludedWhenFound(t *testing.T)
 		Timeout:         30,
 		AllowResolution: true,
 	}
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, issuerLookup, resolver, http.DefaultClient, zap.NewNop())
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, issuerLookup, resolver, http.DefaultClient, http.DefaultClient, zap.NewNop())
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
@@ -1771,7 +1771,7 @@ func TestResolve_URLSubject_RegisteredIssuerInfo_OmittedWhenNotFound(t *testing.
 		Timeout:         30,
 		AllowResolution: true,
 	}
-	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, issuerLookup, resolver, http.DefaultClient, zap.NewNop())
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, issuerLookup, resolver, http.DefaultClient, http.DefaultClient, zap.NewNop())
 
 	router := gin.New()
 	router.Use(func(c *gin.Context) {

--- a/internal/engine/trust.go
+++ b/internal/engine/trust.go
@@ -2,6 +2,7 @@
 package engine
 
 import (
+	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -34,7 +35,13 @@ func NewTrustService(cfg *config.Config, logger *zap.Logger) *TrustService {
 // tenant-aware transport for multi-tenant PDP routing.
 func newAuthZENEvaluatorFactory(cfg *config.Config) trust.EvaluatorFactory {
 	return func(endpoint string, timeout time.Duration) (trust.TrustEvaluator, error) {
-		httpClient := cfg.HTTPClient.NewHTTPClient(timeout)
+		// Use NewPDPHTTPClient so the SSRF dial restriction is not applied to
+		// operator-configured PDP URLs (which may use private/internal addresses).
+		// This client also uses PDP-specific TLS settings and no proxy.
+		httpClient, err := cfg.Trust.NewPDPHTTPClient(timeout)
+		if err != nil {
+			return nil, fmt.Errorf("trust: failed to create PDP HTTP client: %w", err)
+		}
 		// Wrap the transport with TenantTransport for multi-tenant support
 		httpClient.Transport = &trust.TenantTransport{
 			Base: httpClient.Transport,

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -316,6 +316,7 @@ func newTestAuthZENHandler(cfg *config.Config, logger *zap.Logger) *api.AuthZENP
 		nil,
 		nil,
 		http.DefaultClient,
+		http.DefaultClient,
 		logger,
 	)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -396,6 +397,14 @@ type TrustConfig struct {
 	// Timeout is the HTTP timeout for trust evaluation requests (seconds).
 	Timeout int `yaml:"timeout" envconfig:"TIMEOUT"`
 
+	// InsecureSkipVerify disables TLS certificate verification for PDP requests.
+	// Use only in development or when the PDP uses a self-signed certificate.
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify" envconfig:"INSECURE_SKIP_VERIFY"`
+
+	// CACertPath is the path to a PEM-encoded CA certificate used to verify the PDP's
+	// TLS certificate. Set this when the PDP is signed by an internal/private CA.
+	CACertPath string `yaml:"ca_cert_path" envconfig:"CA_CERT_PATH"`
+
 	// Issuer contains per-flow trust configuration overrides for OID4VCI (credential issuance).
 	// When not set, inherits the global trust configuration.
 	Issuer FlowTrustConfig `yaml:"issuer" envconfig:"ISSUER"`
@@ -403,6 +412,50 @@ type TrustConfig struct {
 	// Verifier contains per-flow trust configuration overrides for OID4VP (credential presentation).
 	// When not set, inherits the global trust configuration.
 	Verifier FlowTrustConfig `yaml:"verifier" envconfig:"VERIFIER"`
+}
+
+// NewPDPHTTPClient creates an *http.Client for use with operator-configured PDP endpoints.
+//
+// Unlike the global HTTP client, this client:
+//   - Does NOT use any configured HTTP proxy (PDP is expected to be directly reachable)
+//   - Does NOT apply SSRF dial restrictions (PDP URL is operator-controlled)
+//   - Uses PDP-specific TLS settings (InsecureSkipVerify, CACertPath) from this TrustConfig
+//
+// The timeout is taken from TrustConfig.Timeout unless timeoutOverride > 0.
+func (c *TrustConfig) NewPDPHTTPClient(timeoutOverride time.Duration) (*http.Client, error) {
+	timeout := time.Duration(c.Timeout) * time.Second
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	if timeoutOverride > 0 {
+		timeout = timeoutOverride
+	}
+
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12} //nolint:gosec
+	if c.InsecureSkipVerify {
+		tlsCfg.InsecureSkipVerify = true //nolint:gosec
+	}
+	if c.CACertPath != "" {
+		pem, err := os.ReadFile(c.CACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("trust: failed to read PDP CA certificate %q: %w", c.CACertPath, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("trust: failed to parse PDP CA certificate %q", c.CACertPath)
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsCfg
+	// No proxy — PDP is an internal service reached directly.
+	transport.Proxy = nil
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}, nil
 }
 
 // GetPDPURL returns the effective global PDP URL, preferring PDPURL over the deprecated DefaultEndpoint.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1184,6 +1185,81 @@ func TestHTTPClientConfig_NewHTTPClient_TimeoutOverride(t *testing.T) {
 		t.Fatal("NewHTTPClient() returned nil")
 	}
 	// Can't easily check internal timeout, but validates it doesn't panic
+}
+
+// =============================================================================
+// TrustConfig.NewPDPHTTPClient tests
+// =============================================================================
+
+func TestTrustConfig_NewPDPHTTPClient_Defaults(t *testing.T) {
+	cfg := TrustConfig{Timeout: 10}
+	client, err := cfg.NewPDPHTTPClient(0)
+	if err != nil {
+		t.Fatalf("NewPDPHTTPClient() error = %v", err)
+	}
+	if client == nil {
+		t.Fatal("NewPDPHTTPClient() returned nil client")
+	}
+	if client.Timeout != 10*time.Second {
+		t.Errorf("Timeout = %v, want %v", client.Timeout, 10*time.Second)
+	}
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("Transport is not *http.Transport")
+	}
+	// No proxy must be set
+	if tr.Proxy != nil {
+		t.Error("expected Proxy to be nil (no proxy for PDP)")
+	}
+}
+
+func TestTrustConfig_NewPDPHTTPClient_TimeoutOverride(t *testing.T) {
+	cfg := TrustConfig{Timeout: 10}
+	client, err := cfg.NewPDPHTTPClient(5 * time.Second)
+	if err != nil {
+		t.Fatalf("NewPDPHTTPClient() error = %v", err)
+	}
+	if client.Timeout != 5*time.Second {
+		t.Errorf("Timeout = %v, want %v", client.Timeout, 5*time.Second)
+	}
+}
+
+func TestTrustConfig_NewPDPHTTPClient_DefaultTimeout_WhenZero(t *testing.T) {
+	// Timeout=0 in config should fall back to 30s default
+	cfg := TrustConfig{Timeout: 0}
+	client, err := cfg.NewPDPHTTPClient(0)
+	if err != nil {
+		t.Fatalf("NewPDPHTTPClient() error = %v", err)
+	}
+	if client.Timeout != 30*time.Second {
+		t.Errorf("Timeout = %v, want 30s default", client.Timeout)
+	}
+}
+
+func TestTrustConfig_NewPDPHTTPClient_BadCACertPath(t *testing.T) {
+	cfg := TrustConfig{CACertPath: "/nonexistent/ca.pem"}
+	_, err := cfg.NewPDPHTTPClient(0)
+	if err == nil {
+		t.Fatal("expected error for missing CA cert file, got nil")
+	}
+}
+
+func TestTrustConfig_NewPDPHTTPClient_InvalidCACert(t *testing.T) {
+	// Write a temp file with invalid PEM content
+	f, err := os.CreateTemp(t.TempDir(), "ca*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString("this is not valid PEM"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := TrustConfig{CACertPath: f.Name()}
+	_, err = cfg.NewPDPHTTPClient(0)
+	if err == nil {
+		t.Fatal("expected error for invalid CA cert PEM, got nil")
+	}
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes #157.

## Problem

The default `HTTPClient` applies SSRF dial restrictions that block connections to private/loopback/link-local IPs. This same client was being used for requests to the PDP (go-trust/AuthZEN), making it impossible to run the PDP on an internal address (k8s ClusterIP, Docker bridge, localhost) without setting `AllowPrivateIPs: true` globally — which would also disable SSRF protection for user-supplied URLs.

## Solution

Add `HTTPClientConfig.NewPDPHTTPClient()`: same as `NewHTTPClient` but with SSRF dial restrictions disabled (`AllowPrivateIPs=true`, `AllowHTTP=true`). Proxy and TLS settings are preserved, so deployments using a corporate proxy or private CA continue to work.

The `AuthZENProxyHandler` now carries two clients:
- `pdpClient` — unrestricted, used for PDP evaluation calls (`getClient`)
- `httpClient` — SSRF-restricted, used for external fetches (VCTM, credential offers, logos, jwks_uri)

The engine trust evaluator factory (`newAuthZENEvaluatorFactory`) likewise switches to `NewPDPHTTPClient`.

## Security

SSRF protection remains intact for all user-visible URLs. Removing it for the PDP is safe because the PDP URL is operator-configured (not user-supplied).