### PR TITLE
feat: add JWKS fetch retry with exponential backoff and circuit breaker

### DIFF
--- a/pkg/oidc/jwks.go
+++ b/pkg/oidc/jwks.go
@@ -17,6 +17,26 @@ import (
 	"go.uber.org/zap"
 )
 
+type jwksTransportError struct {
+	Err error
+}
+
+func (e *jwksTransportError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *jwksTransportError) Unwrap() error {
+	return e.Err
+}
+
+type jwksHTTPStatusError struct {
+	StatusCode int
+}
+
+func (e *jwksHTTPStatusError) Error() string {
+	return fmt.Sprintf("status %d", e.StatusCode)
+}
+
 // JWKS represents a JSON Web Key Set
 type JWKS struct {
 	Keys []JWK `json:"keys"`
@@ -136,12 +156,12 @@ func (v *Validator) fetchJWKS(ctx context.Context, jwksURI string) (*JWKS, error
 
 	resp, err := v.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrJWKSFetchFailed, err)
+		return nil, fmt.Errorf("%w: %w", ErrJWKSFetchFailed, &jwksTransportError{Err: err})
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: status %d", ErrJWKSFetchFailed, resp.StatusCode)
+		return nil, fmt.Errorf("%w: %w", ErrJWKSFetchFailed, &jwksHTTPStatusError{StatusCode: resp.StatusCode})
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit

--- a/pkg/oidc/validator.go
+++ b/pkg/oidc/validator.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -89,6 +88,9 @@ type Validator struct {
 	httpClient *http.Client
 	logger     *zap.Logger
 
+	// Base backoff for JWKS retry; kept internal so tests can run quickly.
+	jwksRetryBaseDelay time.Duration
+
 	// JWKS cache
 	jwksMu      sync.RWMutex
 	jwksCache   *JWKS
@@ -107,19 +109,19 @@ type Validator struct {
 // NewValidator creates a new OIDC token validator.
 // If httpClient is nil, a default client with 10s timeout is used.
 func NewValidator(config ValidatorConfig, httpClient *http.Client, logger *zap.Logger) *Validator {
-	if config.ClockSkew == 0 {
+	if config.ClockSkew <= 0 {
 		config.ClockSkew = time.Minute
 	}
-	if config.JWKSCacheTTL == 0 {
+	if config.JWKSCacheTTL <= 0 {
 		config.JWKSCacheTTL = time.Hour
 	}
-	if config.JWKSMaxRetries == 0 {
+	if config.JWKSMaxRetries <= 0 {
 		config.JWKSMaxRetries = 3
 	}
-	if config.JWKSCircuitBreakerThreshold == 0 {
+	if config.JWKSCircuitBreakerThreshold <= 0 {
 		config.JWKSCircuitBreakerThreshold = 5
 	}
-	if config.JWKSCircuitBreakerCooldown == 0 {
+	if config.JWKSCircuitBreakerCooldown <= 0 {
 		config.JWKSCircuitBreakerCooldown = 30 * time.Second
 	}
 	if httpClient == nil {
@@ -129,9 +131,10 @@ func NewValidator(config ValidatorConfig, httpClient *http.Client, logger *zap.L
 	}
 
 	return &Validator{
-		config:     config,
-		httpClient: httpClient,
-		logger:     logger.Named("oidc"),
+		config:             config,
+		httpClient:         httpClient,
+		logger:             logger.Named("oidc"),
+		jwksRetryBaseDelay: 500 * time.Millisecond,
 	}
 }
 
@@ -301,9 +304,10 @@ func (v *Validator) getSigningKey(ctx context.Context, kid string) (interface{},
 func (v *Validator) getJWKS(ctx context.Context) (*JWKS, error) {
 	v.jwksMu.RLock()
 	cached := v.jwksCache
+	circuitOpenedAt := v.jwksCircuitOpen
 	fresh := cached != nil && time.Since(v.jwksFetched) < v.config.JWKSCacheTTL
-	circuitOpen := !v.jwksCircuitOpen.IsZero() &&
-		time.Since(v.jwksCircuitOpen) < v.config.JWKSCircuitBreakerCooldown
+	circuitOpen := !circuitOpenedAt.IsZero() &&
+		time.Since(circuitOpenedAt) < v.config.JWKSCircuitBreakerCooldown
 	v.jwksMu.RUnlock()
 
 	if fresh {
@@ -314,7 +318,7 @@ func (v *Validator) getJWKS(ctx context.Context) (*JWKS, error) {
 	if circuitOpen {
 		if cached != nil {
 			v.logger.Warn("JWKS circuit open, returning stale cache",
-				zap.Duration("cooldown_remaining", v.config.JWKSCircuitBreakerCooldown-time.Since(v.jwksCircuitOpen)))
+				zap.Duration("cooldown_remaining", v.config.JWKSCircuitBreakerCooldown-time.Since(circuitOpenedAt)))
 			return cached, nil
 		}
 		return nil, fmt.Errorf("%w: circuit open, no cached JWKS available", ErrJWKSFetchFailed)
@@ -338,10 +342,11 @@ func (v *Validator) getJWKS(ctx context.Context) (*JWKS, error) {
 	if err != nil {
 		v.jwksMu.Lock()
 		v.jwksFailures++
+		failures := v.jwksFailures
 		if v.jwksFailures >= v.config.JWKSCircuitBreakerThreshold {
 			v.jwksCircuitOpen = time.Now()
 			v.logger.Warn("JWKS circuit breaker opened",
-				zap.Int("consecutive_failures", v.jwksFailures),
+				zap.Int("consecutive_failures", failures),
 				zap.Duration("cooldown", v.config.JWKSCircuitBreakerCooldown))
 		}
 		stale := v.jwksCache
@@ -350,7 +355,7 @@ func (v *Validator) getJWKS(ctx context.Context) (*JWKS, error) {
 		if stale != nil {
 			v.logger.Warn("JWKS fetch failed, returning stale cache",
 				zap.Error(err),
-				zap.Int("consecutive_failures", v.jwksFailures))
+				zap.Int("consecutive_failures", failures))
 			return stale, nil
 		}
 		return nil, err
@@ -371,7 +376,7 @@ func (v *Validator) getJWKS(ctx context.Context) (*JWKS, error) {
 // 4xx responses and parse errors are returned immediately.
 func (v *Validator) fetchJWKSWithRetry(ctx context.Context, jwksURI string) (*JWKS, error) {
 	var lastErr error
-	backoff := 500 * time.Millisecond
+	backoff := v.jwksRetryBaseDelay
 	for attempt := 0; attempt < v.config.JWKSMaxRetries; attempt++ {
 		if attempt > 0 {
 			select {
@@ -392,8 +397,8 @@ func (v *Validator) fetchJWKSWithRetry(ctx context.Context, jwksURI string) (*JW
 		}
 
 		lastErr = err
-		// Do not retry client errors or parse errors — only transient/network failures.
-		if isNonRetryableJWKSError(err) {
+		// Retry only transient errors (transport and 5xx responses).
+		if !isRetryableJWKSError(err) {
 			return nil, err
 		}
 		v.logger.Warn("JWKS fetch failed, retrying",
@@ -405,26 +410,26 @@ func (v *Validator) fetchJWKSWithRetry(ctx context.Context, jwksURI string) (*JW
 	return nil, fmt.Errorf("%w after %d attempts: %v", ErrJWKSFetchFailed, v.config.JWKSMaxRetries, lastErr)
 }
 
-// isNonRetryableJWKSError returns true for errors that should not be retried,
-// such as 4xx HTTP responses and JSON parse failures.
-func isNonRetryableJWKSError(err error) bool {
-	if !errors.Is(err, ErrJWKSFetchFailed) {
-		return false
+// isRetryableJWKSError returns true only for transient transport errors and 5xx HTTP responses.
+func isRetryableJWKSError(err error) bool {
+	var transportErr *jwksTransportError
+	if errors.As(err, &transportErr) {
+		return true
 	}
-	msg := err.Error()
-	// 4xx responses are client errors — retrying won't help.
-	for _, code := range []string{"status 400", "status 401", "status 403", "status 404"} {
-		if strings.Contains(msg, code) {
-			return true
-		}
+
+	var statusErr *jwksHTTPStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode >= http.StatusInternalServerError
 	}
+
 	return false
 }
 
-// invalidateJWKSCache clears the JWKS cache
+// invalidateJWKSCache marks the JWKS cache stale so next lookup refreshes,
+// while keeping keys available as stale fallback during transient outages.
 func (v *Validator) invalidateJWKSCache() {
 	v.jwksMu.Lock()
-	v.jwksCache = nil
+	v.jwksFetched = time.Time{}
 	v.jwksMu.Unlock()
 }
 

--- a/pkg/oidc/validator.go
+++ b/pkg/oidc/validator.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -52,6 +53,19 @@ type ValidatorConfig struct {
 
 	// JWKSCacheTTL is how long to cache JWKS (default: 1 hour)
 	JWKSCacheTTL time.Duration
+
+	// JWKSMaxRetries is the maximum number of fetch attempts for transient failures.
+	// Retries use exponential backoff starting at 500ms. (default: 3)
+	JWKSMaxRetries int
+
+	// JWKSCircuitBreakerThreshold is the number of consecutive fetch failures
+	// after which the circuit is opened and fetches are skipped until the
+	// cooldown period elapses. (default: 5)
+	JWKSCircuitBreakerThreshold int
+
+	// JWKSCircuitBreakerCooldown is how long the circuit stays open before a
+	// probe attempt is allowed. (default: 30s)
+	JWKSCircuitBreakerCooldown time.Duration
 }
 
 // ValidationResult contains the result of token validation
@@ -80,6 +94,10 @@ type Validator struct {
 	jwksCache   *JWKS
 	jwksFetched time.Time
 
+	// JWKS circuit breaker (guarded by jwksMu)
+	jwksFailures    int       // consecutive fetch failures
+	jwksCircuitOpen time.Time // zero = circuit closed; non-zero = when circuit was opened
+
 	// Discovery cache
 	discoveryMu      sync.RWMutex
 	discoveryCache   *DiscoveryDocument
@@ -94,6 +112,15 @@ func NewValidator(config ValidatorConfig, httpClient *http.Client, logger *zap.L
 	}
 	if config.JWKSCacheTTL == 0 {
 		config.JWKSCacheTTL = time.Hour
+	}
+	if config.JWKSMaxRetries == 0 {
+		config.JWKSMaxRetries = 3
+	}
+	if config.JWKSCircuitBreakerThreshold == 0 {
+		config.JWKSCircuitBreakerThreshold = 5
+	}
+	if config.JWKSCircuitBreakerCooldown == 0 {
+		config.JWKSCircuitBreakerCooldown = 30 * time.Second
 	}
 	if httpClient == nil {
 		httpClient = &http.Client{
@@ -264,38 +291,134 @@ func (v *Validator) getSigningKey(ctx context.Context, kid string) (interface{},
 	return key.PublicKey()
 }
 
-// getJWKS retrieves the JWKS, using cache if valid
+// getJWKS retrieves the JWKS, using cache if valid.
+//
+// Fetch failures are handled with exponential backoff retry (up to JWKSMaxRetries).
+// A circuit breaker opens after JWKSCircuitBreakerThreshold consecutive failures,
+// skipping further fetch attempts for JWKSCircuitBreakerCooldown to protect the IdP.
+// When a fetch fails but a stale cached JWKS exists, it is returned as a fallback
+// rather than failing the request outright (the cache may still have the needed key).
 func (v *Validator) getJWKS(ctx context.Context) (*JWKS, error) {
 	v.jwksMu.RLock()
-	if v.jwksCache != nil && time.Since(v.jwksFetched) < v.config.JWKSCacheTTL {
-		jwks := v.jwksCache
-		v.jwksMu.RUnlock()
-		return jwks, nil
-	}
+	cached := v.jwksCache
+	fresh := cached != nil && time.Since(v.jwksFetched) < v.config.JWKSCacheTTL
+	circuitOpen := !v.jwksCircuitOpen.IsZero() &&
+		time.Since(v.jwksCircuitOpen) < v.config.JWKSCircuitBreakerCooldown
 	v.jwksMu.RUnlock()
 
-	// Need to fetch JWKS
+	if fresh {
+		return cached, nil
+	}
+
+	// Circuit is open — skip the fetch and return stale cache if available.
+	if circuitOpen {
+		if cached != nil {
+			v.logger.Warn("JWKS circuit open, returning stale cache",
+				zap.Duration("cooldown_remaining", v.config.JWKSCircuitBreakerCooldown-time.Since(v.jwksCircuitOpen)))
+			return cached, nil
+		}
+		return nil, fmt.Errorf("%w: circuit open, no cached JWKS available", ErrJWKSFetchFailed)
+	}
+
+	// Need to fetch (fresh cache miss or circuit just closed for probe).
 	jwksURI := v.config.JWKSURI
 	if jwksURI == "" {
-		// Discover JWKS URI from issuer
 		discovery, err := v.getDiscovery(ctx)
 		if err != nil {
+			if cached != nil {
+				v.logger.Warn("JWKS discovery failed, returning stale cache", zap.Error(err))
+				return cached, nil
+			}
 			return nil, fmt.Errorf("failed to discover JWKS URI: %w", err)
 		}
 		jwksURI = discovery.JWKSURI
 	}
 
-	jwks, err := v.fetchJWKS(ctx, jwksURI)
+	jwks, err := v.fetchJWKSWithRetry(ctx, jwksURI)
 	if err != nil {
+		v.jwksMu.Lock()
+		v.jwksFailures++
+		if v.jwksFailures >= v.config.JWKSCircuitBreakerThreshold {
+			v.jwksCircuitOpen = time.Now()
+			v.logger.Warn("JWKS circuit breaker opened",
+				zap.Int("consecutive_failures", v.jwksFailures),
+				zap.Duration("cooldown", v.config.JWKSCircuitBreakerCooldown))
+		}
+		stale := v.jwksCache
+		v.jwksMu.Unlock()
+
+		if stale != nil {
+			v.logger.Warn("JWKS fetch failed, returning stale cache",
+				zap.Error(err),
+				zap.Int("consecutive_failures", v.jwksFailures))
+			return stale, nil
+		}
 		return nil, err
 	}
 
 	v.jwksMu.Lock()
 	v.jwksCache = jwks
 	v.jwksFetched = time.Now()
+	v.jwksFailures = 0
+	v.jwksCircuitOpen = time.Time{} // close circuit on success
 	v.jwksMu.Unlock()
 
 	return jwks, nil
+}
+
+// fetchJWKSWithRetry calls fetchJWKS with exponential backoff.
+// Only transient errors (network failures, 5xx responses) are retried.
+// 4xx responses and parse errors are returned immediately.
+func (v *Validator) fetchJWKSWithRetry(ctx context.Context, jwksURI string) (*JWKS, error) {
+	var lastErr error
+	backoff := 500 * time.Millisecond
+	for attempt := 0; attempt < v.config.JWKSMaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+
+		jwks, err := v.fetchJWKS(ctx, jwksURI)
+		if err == nil {
+			if attempt > 0 {
+				v.logger.Info("JWKS fetch succeeded after retry",
+					zap.Int("attempt", attempt+1))
+			}
+			return jwks, nil
+		}
+
+		lastErr = err
+		// Do not retry client errors or parse errors — only transient/network failures.
+		if isNonRetryableJWKSError(err) {
+			return nil, err
+		}
+		v.logger.Warn("JWKS fetch failed, retrying",
+			zap.Int("attempt", attempt+1),
+			zap.Int("max_retries", v.config.JWKSMaxRetries),
+			zap.Duration("backoff", backoff),
+			zap.Error(err))
+	}
+	return nil, fmt.Errorf("%w after %d attempts: %v", ErrJWKSFetchFailed, v.config.JWKSMaxRetries, lastErr)
+}
+
+// isNonRetryableJWKSError returns true for errors that should not be retried,
+// such as 4xx HTTP responses and JSON parse failures.
+func isNonRetryableJWKSError(err error) bool {
+	if !errors.Is(err, ErrJWKSFetchFailed) {
+		return false
+	}
+	msg := err.Error()
+	// 4xx responses are client errors — retrying won't help.
+	for _, code := range []string{"status 400", "status 401", "status 403", "status 404"} {
+		if strings.Contains(msg, code) {
+			return true
+		}
+	}
+	return false
 }
 
 // invalidateJWKSCache clears the JWKS cache

--- a/pkg/oidc/validator_test.go
+++ b/pkg/oidc/validator_test.go
@@ -538,3 +538,269 @@ func TestValidator_ValidateWithDiscovery(t *testing.T) {
 		t.Error("expected at least one hit to /jwks, got 0")
 	}
 }
+
+// =============================================================================
+// Retry and circuit breaker tests
+// =============================================================================
+
+// TestValidator_JWKS_RetryOnTransientFailure verifies that fetchJWKSWithRetry
+// retries on transient (5xx) failures and succeeds when the IdP recovers.
+func TestValidator_JWKS_RetryOnTransientFailure(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	_, jwkJSON := createTestRSAKey(t)
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			// Fail the first two attempts with 503.
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"keys":[%s]}`, jwkJSON)
+	}))
+	defer server.Close()
+
+	v := NewValidator(ValidatorConfig{
+		Issuer:         "https://issuer.example.com",
+		Audience:       "client-id",
+		JWKSURI:        server.URL + "/jwks",
+		JWKSMaxRetries: 3,
+	}, server.Client(), logger)
+
+	ctx := context.Background()
+	jwks, err := v.fetchJWKSWithRetry(ctx, server.URL+"/jwks")
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if len(jwks.Keys) == 0 {
+		t.Fatal("expected at least one key in JWKS")
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+// TestValidator_JWKS_NoRetryOn4xx verifies that 4xx errors are not retried.
+func TestValidator_JWKS_NoRetryOn4xx(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	v := NewValidator(ValidatorConfig{
+		Issuer:         "https://issuer.example.com",
+		Audience:       "client-id",
+		JWKSURI:        server.URL + "/jwks",
+		JWKSMaxRetries: 3,
+	}, server.Client(), logger)
+
+	ctx := context.Background()
+	_, err := v.fetchJWKSWithRetry(ctx, server.URL+"/jwks")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected exactly 1 attempt (no retry on 404), got %d", attempts)
+	}
+}
+
+// TestValidator_JWKS_StaleCacheOnFailure verifies that a stale cached JWKS is
+// returned when a fresh fetch fails and no circuit breaker is involved.
+func TestValidator_JWKS_StaleCacheOnFailure(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	_, jwkJSON := createTestRSAKey(t)
+
+	// First request succeeds; subsequent ones fail.
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"keys":[%s]}`, jwkJSON)
+			return
+		}
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	v := NewValidator(ValidatorConfig{
+		Issuer:         "https://issuer.example.com",
+		Audience:       "client-id",
+		JWKSURI:        server.URL + "/jwks",
+		JWKSCacheTTL:   1 * time.Millisecond, // expire almost immediately
+		JWKSMaxRetries: 1,
+	}, server.Client(), logger)
+
+	ctx := context.Background()
+
+	// Warm the cache.
+	jwks1, err := v.getJWKS(ctx)
+	if err != nil || len(jwks1.Keys) == 0 {
+		t.Fatalf("initial JWKS fetch failed: %v", err)
+	}
+
+	// Let the cache expire.
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call should fail the fetch but return stale cache.
+	jwks2, err := v.getJWKS(ctx)
+	if err != nil {
+		t.Fatalf("expected stale cache fallback, got error: %v", err)
+	}
+	if len(jwks2.Keys) == 0 {
+		t.Error("expected stale JWKS to be returned")
+	}
+}
+
+// TestValidator_JWKS_CircuitBreaker verifies that the circuit opens after the
+// threshold of consecutive failures and returns stale cache while open.
+func TestValidator_JWKS_CircuitBreaker(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	_, jwkJSON := createTestRSAKey(t)
+
+	alwaysFail := false
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if alwaysFail {
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"keys":[%s]}`, jwkJSON)
+	}))
+	defer server.Close()
+
+	const threshold = 3
+	v := NewValidator(ValidatorConfig{
+		Issuer:                      "https://issuer.example.com",
+		Audience:                    "client-id",
+		JWKSURI:                     server.URL + "/jwks",
+		JWKSCacheTTL:                1 * time.Millisecond,
+		JWKSMaxRetries:              1, // one attempt per getJWKS call
+		JWKSCircuitBreakerThreshold: threshold,
+		JWKSCircuitBreakerCooldown:  10 * time.Second, // long enough to stay open during test
+	}, server.Client(), logger)
+
+	ctx := context.Background()
+
+	// Prime the cache.
+	if _, err := v.getJWKS(ctx); err != nil {
+		t.Fatalf("initial fetch: %v", err)
+	}
+
+	// Switch IdP to always fail.
+	alwaysFail = true
+	time.Sleep(5 * time.Millisecond) // let cache expire
+
+	requestsBefore := requestCount
+	// Exhaust the threshold — each call tries the fetch, fails, increments counter.
+	for i := 0; i < threshold; i++ {
+		jwks, err := v.getJWKS(ctx)
+		if err != nil {
+			t.Fatalf("expected stale cache at failure %d, got error: %v", i+1, err)
+		}
+		if len(jwks.Keys) == 0 {
+			t.Errorf("failure %d: expected stale JWKS", i+1)
+		}
+	}
+
+	// Circuit should now be open — getJWKS must not make more HTTP requests.
+	requestsMidway := requestCount
+	jwks, err := v.getJWKS(ctx)
+	if err != nil {
+		t.Fatalf("expected stale cache while circuit open, got error: %v", err)
+	}
+	if len(jwks.Keys) == 0 {
+		t.Error("expected stale JWKS while circuit open")
+	}
+	if requestCount != requestsMidway {
+		t.Errorf("circuit open: expected no new HTTP requests (had %d before, %d after)",
+			requestsMidway, requestCount)
+	}
+	_ = requestsBefore
+}
+
+// TestValidator_JWKS_CircuitBreakerReset verifies the circuit closes after cooldown.
+func TestValidator_JWKS_CircuitBreakerReset(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	_, jwkJSON := createTestRSAKey(t)
+
+	alwaysFail := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if alwaysFail {
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"keys":[%s]}`, jwkJSON)
+	}))
+	defer server.Close()
+
+	const threshold = 2
+	cooldown := 20 * time.Millisecond
+	v := NewValidator(ValidatorConfig{
+		Issuer:                      "https://issuer.example.com",
+		Audience:                    "client-id",
+		JWKSURI:                     server.URL + "/jwks",
+		JWKSCacheTTL:                1 * time.Millisecond,
+		JWKSMaxRetries:              1,
+		JWKSCircuitBreakerThreshold: threshold,
+		JWKSCircuitBreakerCooldown:  cooldown,
+	}, server.Client(), logger)
+
+	ctx := context.Background()
+
+	// Prime cache.
+	if _, err := v.getJWKS(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	alwaysFail = true
+	time.Sleep(5 * time.Millisecond)
+
+	// Trigger threshold failures to open circuit.
+	for i := 0; i < threshold; i++ {
+		v.getJWKS(ctx) //nolint:errcheck
+	}
+
+	// Verify circuit is open.
+	v.jwksMu.RLock()
+	open := !v.jwksCircuitOpen.IsZero()
+	v.jwksMu.RUnlock()
+	if !open {
+		t.Fatal("expected circuit to be open")
+	}
+
+	// Wait for cooldown to elapse.
+	time.Sleep(cooldown + 10*time.Millisecond)
+
+	// IdP recovers.
+	alwaysFail = false
+
+	// After cooldown, a probe attempt should succeed and close the circuit.
+	jwks, err := v.getJWKS(ctx)
+	if err != nil {
+		t.Fatalf("expected circuit reset to allow fetch: %v", err)
+	}
+	if len(jwks.Keys) == 0 {
+		t.Error("expected fresh JWKS after circuit reset")
+	}
+
+	v.jwksMu.RLock()
+	failures := v.jwksFailures
+	circuitOpen := v.jwksCircuitOpen
+	v.jwksMu.RUnlock()
+	if failures != 0 {
+		t.Errorf("expected failure counter reset to 0, got %d", failures)
+	}
+	if !circuitOpen.IsZero() {
+		t.Error("expected circuit to be closed after successful fetch")
+	}
+}

--- a/pkg/oidc/validator_test.go
+++ b/pkg/oidc/validator_test.go
@@ -568,6 +568,7 @@ func TestValidator_JWKS_RetryOnTransientFailure(t *testing.T) {
 		JWKSURI:        server.URL + "/jwks",
 		JWKSMaxRetries: 3,
 	}, server.Client(), logger)
+	v.jwksRetryBaseDelay = 1 * time.Millisecond
 
 	ctx := context.Background()
 	jwks, err := v.fetchJWKSWithRetry(ctx, server.URL+"/jwks")
@@ -699,7 +700,6 @@ func TestValidator_JWKS_CircuitBreaker(t *testing.T) {
 	alwaysFail = true
 	time.Sleep(5 * time.Millisecond) // let cache expire
 
-	requestsBefore := requestCount
 	// Exhaust the threshold — each call tries the fetch, fails, increments counter.
 	for i := 0; i < threshold; i++ {
 		jwks, err := v.getJWKS(ctx)
@@ -724,7 +724,6 @@ func TestValidator_JWKS_CircuitBreaker(t *testing.T) {
 		t.Errorf("circuit open: expected no new HTTP requests (had %d before, %d after)",
 			requestsMidway, requestCount)
 	}
-	_ = requestsBefore
 }
 
 // TestValidator_JWKS_CircuitBreakerReset verifies the circuit closes after cooldown.


### PR DESCRIPTION
Closes #63.

## Summary

Adds resilience to JWKS fetching so that transient IdP unavailability does not immediately break token validation.

### Changes

****
- New `ValidatorConfig` fields: `JWKSMaxRetries`, `JWKSCircuitBreakerThreshold`, `JWKSCircuitBreakerCooldown` (all with sensible defaults).
- New `Validator` fields: `jwksFailures` (consecutive failures), `jwksCircuitOpen` (when circuit was opened), both guarded by `jwksMu`.
- `getJWKS` updated with circuit breaker logic and stale-cache fallback.
- `fetchJWKSWithRetry` added: exponential backoff retry for transient errors.

### Behaviour

| Scenario | Before | After |
|---|---|---|
| Single fetch fails (transient) | Request fails | Up to 3 retries with exponential backoff |
| 4xx from IdP | Request fails | Immediate error (no retry) |
| Stale cache + fetch failure | Request fails | Stale JWKS returned, warning logged |
| Repeated failures (≥ threshold) | Every request hits IdP | Circuit opens; IdP is not hammered; stale JWKS returned |
| Circuit open → cooldown elapses | — | Single probe; on success circuit closes and counters reset |

### Tests

Five new tests in `validator_test.go`:
- `TestValidator_JWKS_RetryOnTransientFailure`: succeeds after 2 x 503 failures
- `TestValidator_JWKS_NoRetryOn4xx`: 404 → single attempt, immediate error
- `TestValidator_JWKS_StaleCacheOnFailure`: stale cache returned on failure
- `TestValidator_JWKS_CircuitBreaker`: circuit opens after threshold failures, no further HTTP calls
- `TestValidator_JWKS_CircuitBreakerReset`: circuit closes after cooldown + successful probe