### PR TITLE
fix: RFC 8615 well-known URI construction for issuer metadata

### DIFF
--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -1063,7 +1063,12 @@ func (h *OID4VCIHandler) fetchOAuthMetadata(ctx context.Context, metadata *Issue
 		authServer = metadata.CredentialIssuer
 	}
 
-	oauthMetadataURL := strings.TrimSuffix(authServer, "/") + "/.well-known/oauth-authorization-server"
+	// RFC 8615 well-known URI construction for OAuth AS metadata
+	parsed, err := url.Parse(strings.TrimSuffix(authServer, "/"))
+	if err != nil {
+		return nil
+	}
+	oauthMetadataURL := fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server%s", parsed.Scheme, parsed.Host, parsed.Path)
 	req, err := http.NewRequestWithContext(ctx, "GET", oauthMetadataURL, nil)
 	if err != nil {
 		return nil

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/issuermetadata"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/oidc"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/trust"
 )
 
@@ -1064,11 +1065,10 @@ func (h *OID4VCIHandler) fetchOAuthMetadata(ctx context.Context, metadata *Issue
 	}
 
 	// RFC 8615 well-known URI construction for OAuth AS metadata
-	parsed, err := url.Parse(strings.TrimSuffix(authServer, "/"))
+	oauthMetadataURL, err := oidc.WellKnownURL(authServer, "oauth-authorization-server")
 	if err != nil {
 		return nil
 	}
-	oauthMetadataURL := fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server%s", parsed.Scheme, parsed.Host, parsed.Path)
 	req, err := http.NewRequestWithContext(ctx, "GET", oauthMetadataURL, nil)
 	if err != nil {
 		return nil

--- a/internal/metadata/issuer.go
+++ b/internal/metadata/issuer.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -81,9 +83,16 @@ func DiscoverIssuer(ctx context.Context, issuerURL string, httpClient *http.Clie
 	return result
 }
 
-// fetchIssuerMetadata fetches OpenID4VCI issuer metadata from well-known endpoint
+// fetchIssuerMetadata fetches OpenID4VCI issuer metadata from well-known endpoint.
+// Uses RFC 8615 well-known URI construction as required by OID4VCI draft 16+:
+// https://{host}/.well-known/openid-credential-issuer{path}
 func fetchIssuerMetadata(ctx context.Context, issuerURL string, client *http.Client) (*IssuerMetadata, error) {
-	wellKnownURL := issuerURL + "/.well-known/openid-credential-issuer"
+	parsed, err := url.Parse(issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing issuer URL: %w", err)
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	wellKnownURL := fmt.Sprintf("%s://%s/.well-known/openid-credential-issuer%s", parsed.Scheme, parsed.Host, path)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnownURL, nil)
 	if err != nil {

--- a/internal/metadata/issuer.go
+++ b/internal/metadata/issuer.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strings"
 	"time"
+
+	"github.com/sirosfoundation/go-wallet-backend/pkg/oidc"
 )
 
 // IssuerMetadata represents the credential issuer metadata from
@@ -87,12 +87,10 @@ func DiscoverIssuer(ctx context.Context, issuerURL string, httpClient *http.Clie
 // Uses RFC 8615 well-known URI construction as required by OID4VCI draft 16+:
 // https://{host}/.well-known/openid-credential-issuer{path}
 func fetchIssuerMetadata(ctx context.Context, issuerURL string, client *http.Client) (*IssuerMetadata, error) {
-	parsed, err := url.Parse(issuerURL)
+	wellKnownURL, err := oidc.WellKnownURL(issuerURL, "openid-credential-issuer")
 	if err != nil {
-		return nil, fmt.Errorf("parsing issuer URL: %w", err)
+		return nil, err
 	}
-	path := strings.TrimRight(parsed.Path, "/")
-	wellKnownURL := fmt.Sprintf("%s://%s/.well-known/openid-credential-issuer%s", parsed.Scheme, parsed.Host, path)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnownURL, nil)
 	if err != nil {

--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/sirosfoundation/go-trust/pkg/authzen"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/oidc"
 )
 
 // supportedSignatureAlgorithms is the set of JWS algorithms accepted for
@@ -167,8 +168,8 @@ type ResolveResult struct {
 // using a TTL-cached result when available.
 //
 // The issuerURL must use HTTPS (unless AllowHTTP is set in Config).
-// A trailing slash is stripped before fetching. The endpoint queried is
-// <issuerURL>/.well-known/openid-credential-issuer.
+// A trailing slash is stripped before fetching. The endpoint queried follows
+// RFC 8615: https://{host}/.well-known/openid-credential-issuer{path}.
 //
 // When the fetched document contains a signed_metadata field, its JWT
 // signature is verified against the issuer's JWKS (inline jwks or jwks_uri).
@@ -207,8 +208,7 @@ func (r *Resolver) ResolveWithInfo(ctx context.Context, issuerURL string) (*Reso
 
 	// RFC 8615 well-known URI construction (required since OID4VCI draft 16):
 	// https://{host}/.well-known/openid-credential-issuer{path}
-	parsed, _ := url.Parse(issuerURL) // already validated above
-	metadataURL := fmt.Sprintf("%s://%s/.well-known/openid-credential-issuer%s", parsed.Scheme, parsed.Host, parsed.Path)
+	metadataURL, _ := oidc.WellKnownURL(issuerURL, "openid-credential-issuer") // already validated above
 	result, err := r.fetch(ctx, issuerURL, metadataURL)
 	if err != nil {
 		return nil, err

--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -205,7 +205,10 @@ func (r *Resolver) ResolveWithInfo(ctx context.Context, issuerURL string) (*Reso
 		return &ResolveResult{Metadata: deepCopyMap(entry.parsed), Cached: true, Validated: entry.validated, Signed: entry.signed, SignerKeyMaterial: entry.signerKeyMaterial}, nil
 	}
 
-	metadataURL := issuerURL + "/.well-known/openid-credential-issuer"
+	// RFC 8615 well-known URI construction (required since OID4VCI draft 16):
+	// https://{host}/.well-known/openid-credential-issuer{path}
+	parsed, _ := url.Parse(issuerURL) // already validated above
+	metadataURL := fmt.Sprintf("%s://%s/.well-known/openid-credential-issuer%s", parsed.Scheme, parsed.Host, parsed.Path)
 	result, err := r.fetch(ctx, issuerURL, metadataURL)
 	if err != nil {
 		return nil, err

--- a/pkg/oidc/wellknown.go
+++ b/pkg/oidc/wellknown.go
@@ -1,0 +1,29 @@
+package oidc
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// WellKnownURL constructs a well-known URI per RFC 8615.
+//
+// Given a base URL like "https://example.com/path/to/issuer" and a suffix
+// like "openid-credential-issuer", it returns:
+//
+//	https://example.com/.well-known/openid-credential-issuer/path/to/issuer
+//
+// The function preserves percent-encoded path segments (uses EscapedPath)
+// and strips a single trailing slash from the path before appending.
+func WellKnownURL(baseURL, suffix string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing base URL: %w", err)
+	}
+
+	path := parsed.EscapedPath()
+	if len(path) > 1 && path[len(path)-1] == '/' {
+		path = path[:len(path)-1]
+	}
+
+	return fmt.Sprintf("%s://%s/.well-known/%s%s", parsed.Scheme, parsed.Host, suffix, path), nil
+}

--- a/pkg/oidc/wellknown_test.go
+++ b/pkg/oidc/wellknown_test.go
@@ -1,0 +1,75 @@
+package oidc
+
+import "testing"
+
+func TestWellKnownURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		suffix  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "no path",
+			baseURL: "https://example.com",
+			suffix:  "openid-credential-issuer",
+			want:    "https://example.com/.well-known/openid-credential-issuer",
+		},
+		{
+			name:    "with path",
+			baseURL: "https://example.com/test/a/alias",
+			suffix:  "openid-credential-issuer",
+			want:    "https://example.com/.well-known/openid-credential-issuer/test/a/alias",
+		},
+		{
+			name:    "trailing slash stripped",
+			baseURL: "https://example.com/issuer/",
+			suffix:  "openid-credential-issuer",
+			want:    "https://example.com/.well-known/openid-credential-issuer/issuer",
+		},
+		{
+			name:    "oauth authorization server",
+			baseURL: "https://as.example.com/tenant/1",
+			suffix:  "oauth-authorization-server",
+			want:    "https://as.example.com/.well-known/oauth-authorization-server/tenant/1",
+		},
+		{
+			name:    "openid-configuration",
+			baseURL: "https://idp.example.com",
+			suffix:  "openid-configuration",
+			want:    "https://idp.example.com/.well-known/openid-configuration",
+		},
+		{
+			name:    "percent-encoded path preserved",
+			baseURL: "https://example.com/path%2Fwith%2Fslashes/issuer",
+			suffix:  "openid-credential-issuer",
+			want:    "https://example.com/.well-known/openid-credential-issuer/path%2Fwith%2Fslashes/issuer",
+		},
+		{
+			name:    "with port",
+			baseURL: "https://localhost:8443/test/a/siros-wallet",
+			suffix:  "openid-credential-issuer",
+			want:    "https://localhost:8443/.well-known/openid-credential-issuer/test/a/siros-wallet",
+		},
+		{
+			name:    "invalid URL",
+			baseURL: "://not-a-url",
+			suffix:  "openid-credential-issuer",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := WellKnownURL(tt.baseURL, tt.suffix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WellKnownURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("WellKnownURL()\n  got  = %s\n  want = %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Well-known metadata URLs were constructed by appending `/.well-known/openid-credential-issuer` directly to the issuer URL:
```
{issuer}/.well-known/openid-credential-issuer
```

This is incorrect per RFC 8615. Issuers with path components (e.g. `https://host/test/a/alias/`) produce invalid URLs.

## Fix

Construct well-known URIs per RFC 8615 as required by OID4VCI draft 16+:
```
https://{host}/.well-known/openid-credential-issuer{path}
```

### Files changed
- `pkg/issuermetadata/resolver.go` — `ResolveWithInfo()`
- `internal/metadata/issuer.go` — `fetchIssuerMetadata()`
- `internal/engine/oid4vci.go` — `fetchOAuthMetadata()`

## Testing

Verified with OIDF Conformance Suite (issuer URLs with path components now resolve correctly).