### PR TITLE
feat(registry): TS11 paginated API support and mode selection

### DIFF
--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -78,15 +78,35 @@ func (c ServerConfig) ResolvedServedBy() string {
 	return *c.ServedByHeader
 }
 
+// APIMode determines which registry API format to use when fetching.
+type APIMode string
+
+const (
+	// APIModeTS11 uses the TS11 /api/v1/schemas.json endpoint which returns only
+	// fully TS11-compliant credentials with schemaURIs for VCTM fetching.
+	APIModeTS11 APIMode = "ts11"
+
+	// APIModeRegistry uses the /api/v1/registry.json endpoint which returns ALL
+	// credentials (including non-TS11) with minimal metadata. Individual VCTMs
+	// are fetched separately via their schemaURIs when available, or via the
+	// /api/v1/schemas/{id}.json detail endpoint.
+	APIModeRegistry APIMode = "registry"
+)
+
 // RemoteSourceConfig contains the minimal configuration needed to fetch schemas
 // from a single remote registry URL. It is used by Config.Sources to specify
 // multiple registries. Unlike SourceConfig it intentionally omits the global
 // settings (LocalOverrides, PollInterval) that are not meaningful per source.
 type RemoteSourceConfig struct {
-	// URL of the upstream registry index.
-	// Supports both the legacy vctm-registry.json format and the TS11-compliant
-	// /api/v1/schemas.json endpoint – the format is auto-detected from the response.
+	// URL is the base URL of the registry (e.g. "https://registry.siros.org").
+	// The actual endpoint path is determined by the Mode setting.
+	// For backward compatibility, if a full path to a specific endpoint is given
+	// (e.g. ending in schemas.json or registry.json), it is used as-is regardless of Mode.
 	URL string `yaml:"url"`
+
+	// Mode selects which API endpoint to use: "ts11" (default) for only TS11-compliant
+	// credentials, or "registry" for all credentials including non-TS11.
+	Mode APIMode `yaml:"mode"`
 
 	// Timeout for HTTP requests to this source. Zero means no per-source timeout
 	// (the shared http.Client timeout applies).
@@ -95,10 +115,12 @@ type RemoteSourceConfig struct {
 
 // SourceConfig contains upstream registry source configuration
 type SourceConfig struct {
-	// URL of the upstream registry index.
-	// Supports both the legacy vctm-registry.json format and the TS11-compliant
-	// /api/v1/schemas.json endpoint – the format is auto-detected from the response.
+	// URL of the upstream registry.
+	// The actual endpoint is determined by the Mode setting.
 	URL string `yaml:"url"`
+
+	// Mode selects which API endpoint to use: "ts11" (default) or "registry" (all credentials).
+	Mode APIMode `yaml:"mode"`
 
 	// LocalOverrides is a list of local file or directory paths containing VCTM JSON files.
 	// These are loaded at startup and take priority over entries fetched from the remote registry.
@@ -340,19 +362,19 @@ func (c *Config) Validate() error {
 
 	// Normalize: if Sources is empty, populate from the legacy Source field
 	if len(c.Sources) == 0 {
-		c.Sources = []RemoteSourceConfig{{URL: c.Source.URL, Timeout: c.Source.Timeout}}
+		c.Sources = []RemoteSourceConfig{{URL: c.Source.URL, Mode: c.Source.Mode, Timeout: c.Source.Timeout}}
 	}
 
-	// Validate each Sources entry
-	for i, src := range c.Sources {
-		if src.URL == "" {
+	// Validate each Sources entry and default Mode to APIModeTS11
+	for i := range c.Sources {
+		if c.Sources[i].URL == "" {
 			return fmt.Errorf("sources[%d].url is required", i)
 		}
-	}
-
-	for i, source := range c.Sources {
-		if source.URL == "" {
-			return fmt.Errorf("sources[%d].url is required", i)
+		if c.Sources[i].Mode == "" {
+			c.Sources[i].Mode = APIModeTS11
+		}
+		if c.Sources[i].Mode != APIModeTS11 && c.Sources[i].Mode != APIModeRegistry {
+			return fmt.Errorf("sources[%d].mode must be %q or %q, got %q", i, APIModeTS11, APIModeRegistry, c.Sources[i].Mode)
 		}
 	}
 	if c.Source.PollInterval < time.Second {

--- a/internal/registry/fetcher.go
+++ b/internal/registry/fetcher.go
@@ -53,6 +53,28 @@ type CredentialSource struct {
 	Branch     string `json:"branch,omitempty"`
 }
 
+// RegistryResponse represents the /api/v1/registry.json response which includes
+// ALL credentials (both TS11-compliant and non-TS11). Each entry has minimal
+// metadata (id, version, supportedFormats, attestationLoS, bindingType) without
+// schemaURIs. The TS11 detail endpoint /api/v1/schemas/{id}.json provides full
+// metadata for TS11-compliant entries; for non-TS11 entries, VCTMs are resolved
+// from the credential's known URLs in the registry.
+type RegistryResponse struct {
+	Total       int                 `json:"total"`
+	Credentials []RegistryListEntry `json:"credentials"`
+}
+
+// RegistryListEntry is a single entry from /api/v1/registry.json.
+type RegistryListEntry struct {
+	ID               string   `json:"id"`
+	Version          string   `json:"version"`
+	SupportedFormats []string `json:"supportedFormats"`
+	AttestationLoS   string   `json:"attestationLoS,omitempty"`
+	BindingType      string   `json:"bindingType,omitempty"`
+	// SchemaURIs may be present in future versions; handle gracefully.
+	SchemaURIs []TS11SchemaURI `json:"schemaURIs,omitempty"`
+}
+
 // TS11SchemasResponse represents the paginated response from /api/v1/schemas.json.
 // It supports two wire formats:
 //   - Legacy: {"schemas": [...], "next": "...", "total": N, "page": N, "pageSize": N}
@@ -266,8 +288,8 @@ func (f *Fetcher) Fetch(ctx context.Context) error {
 	return nil
 }
 
-// fetchFromSource fetches entries from a single source URL, auto-detecting whether
-// the endpoint returns the legacy vctm-registry.json format or the TS11 schemas.json format.
+// fetchFromSource fetches entries from a single source, using the configured Mode to
+// determine which endpoint to hit. Format auto-detection is applied to the response.
 // If source.Timeout is non-zero it is applied as a context deadline for the entire
 // source fetch (index + all VCTM documents).
 func (f *Fetcher) fetchFromSource(ctx context.Context, source RemoteSourceConfig) (map[string]*VCTMEntry, error) {
@@ -277,9 +299,10 @@ func (f *Fetcher) fetchFromSource(ctx context.Context, source RemoteSourceConfig
 		defer cancel()
 	}
 
-	f.logger.Info("fetching registry source", zap.String("url", source.URL))
+	fetchURL := source.resolveURL()
+	f.logger.Info("fetching registry source", zap.String("url", fetchURL), zap.String("mode", string(source.Mode)))
 
-	body, err := f.fetchRaw(ctx, source.URL)
+	body, err := f.fetchRaw(ctx, fetchURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch source: %w", err)
 	}
@@ -287,24 +310,48 @@ func (f *Fetcher) fetchFromSource(ctx context.Context, source RemoteSourceConfig
 	// Auto-detect format based on top-level JSON keys.
 	// Current TS11: {"data": [...], "total": N, "limit": N, "offset": N}
 	// Legacy TS11:  {"schemas": [...], "next": "...", ...}
-	// Legacy index: {"credentials": [...], ...}
+	// Registry:     {"credentials": [...], "total": N} (all credentials, minimal metadata)
+	// Legacy index: {"credentials": [...], "name": ..., ...} (vctm-registry.json)
 	var detector struct {
 		Data        json.RawMessage `json:"data"`
 		Schemas     json.RawMessage `json:"schemas"`
 		Credentials json.RawMessage `json:"credentials"`
+		Name        string          `json:"name"`  // present in legacy vctm-registry.json
+		Total       *int            `json:"total"` // present in new registry.json
 	}
 	if err := json.Unmarshal(body, &detector); err != nil {
-		// Not valid JSON at the top level – fall through to legacy processing
-		// which will surface the parse error with a clear message.
 		f.logger.Debug("format auto-detection failed, falling back to legacy parser",
-			zap.String("url", source.URL), zap.Error(err))
+			zap.String("url", fetchURL), zap.Error(err))
 		return f.processLegacyResponse(ctx, source, body)
 	}
 
 	if detector.Data != nil || detector.Schemas != nil {
 		return f.processTS11Response(ctx, source, body)
 	}
+	if detector.Credentials != nil && detector.Total != nil && detector.Name == "" {
+		// Registry format: {"credentials": [...], "total": N} without legacy fields
+		return f.processRegistryResponse(ctx, source, body)
+	}
 	return f.processLegacyResponse(ctx, source, body)
+}
+
+// resolveURL determines the actual fetch URL based on the Mode setting.
+// If the URL already points to a specific JSON file, it is used as-is.
+// Otherwise, the appropriate endpoint path is appended based on Mode.
+func (s *RemoteSourceConfig) resolveURL() string {
+	u := s.URL
+	// If the URL already ends with a known endpoint file, use it directly.
+	if strings.HasSuffix(u, ".json") {
+		return u
+	}
+	// Strip trailing slash for consistent joining.
+	u = strings.TrimRight(u, "/")
+	switch s.Mode {
+	case APIModeRegistry:
+		return u + "/api/v1/registry.json"
+	default:
+		return u + "/api/v1/schemas.json"
+	}
 }
 
 // processTS11Response processes a TS11-format /api/v1/schemas.json response,
@@ -477,6 +524,101 @@ func (f *Fetcher) processLegacyResponse(ctx context.Context, source RemoteSource
 	f.logger.Info("legacy fetch complete",
 		zap.String("url", source.URL),
 		zap.Int("fetched", fetchedCount),
+		zap.Int("filtered", filteredCount),
+		zap.Int("errors", errorCount))
+
+	return entries, nil
+}
+
+// processRegistryResponse processes a /api/v1/registry.json response which
+// contains ALL credentials (TS11 and non-TS11) with minimal metadata.
+// For each entry, it attempts to fetch the full TS11 detail from
+// /api/v1/schemas/{id}.json. If that fails (non-TS11 entry), a stub entry
+// is created with the available metadata.
+func (f *Fetcher) processRegistryResponse(ctx context.Context, source RemoteSourceConfig, body []byte) (map[string]*VCTMEntry, error) {
+	var resp RegistryResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal registry response: %w", err)
+	}
+
+	f.logger.Info("fetched registry index",
+		zap.String("url", source.resolveURL()),
+		zap.Int("credentials", len(resp.Credentials)))
+
+	entries := make(map[string]*VCTMEntry)
+	var fetchedCount, detailCount, stubCount, filteredCount, errorCount int
+
+	// Derive the base URL for fetching individual schema details.
+	baseURL := strings.TrimRight(source.URL, "/")
+	if strings.HasSuffix(baseURL, ".json") {
+		// Strip the file name to get the base path
+		if idx := strings.LastIndex(baseURL, "/"); idx > 0 {
+			baseURL = baseURL[:idx]
+		}
+	}
+	// Remove /api/v1/registry.json path if present to get the registry root
+	baseURL = strings.TrimSuffix(baseURL, "/api/v1")
+
+	for _, cred := range resp.Credentials {
+		// Try to fetch TS11 detail for this credential (includes schemaURIs).
+		detailURL := baseURL + "/api/v1/schemas/" + cred.ID + ".json"
+		detailBody, err := f.fetchRaw(ctx, detailURL)
+		if err == nil {
+			// Successfully fetched detail — process as TS11 schema with VCTM fetch.
+			var schema TS11SchemaMeta
+			if jsonErr := json.Unmarshal(detailBody, &schema); jsonErr == nil && len(schema.SchemaURIs) > 0 {
+				// Pick the VCTM URI
+				var vctmURI string
+				for _, su := range schema.SchemaURIs {
+					if su.FormatIdentifier == "dc+sd-jwt" {
+						vctmURI = su.URI
+						break
+					}
+				}
+				if vctmURI == "" {
+					vctmURI = schema.SchemaURIs[0].URI
+				}
+
+				entry, fetchErr := f.fetchTS11VCTM(ctx, schema, vctmURI)
+				if fetchErr == nil {
+					if !f.config.Filter.Matches(entry.VCT) {
+						filteredCount++
+						continue
+					}
+					entries[entry.VCT] = entry
+					fetchedCount++
+					detailCount++
+					continue
+				}
+				f.logger.Debug("failed to fetch VCTM from detail", zap.String("id", cred.ID), zap.Error(fetchErr))
+			}
+		}
+
+		// Detail not available (non-TS11) or VCTM fetch failed.
+		// Create a stub entry with the metadata we have from the registry list.
+		// Use the schema ID as a placeholder VCT (the real VCT is unknown without VCTM).
+		vct := cred.ID
+		if !f.config.Filter.Matches(vct) {
+			filteredCount++
+			continue
+		}
+
+		entries[vct] = &VCTMEntry{
+			VCT:              vct,
+			AttestationLoS:   cred.AttestationLoS,
+			BindingType:      cred.BindingType,
+			SupportedFormats: cred.SupportedFormats,
+			FetchedAt:        time.Now(),
+		}
+		fetchedCount++
+		stubCount++
+	}
+
+	f.logger.Info("registry fetch complete",
+		zap.String("url", source.resolveURL()),
+		zap.Int("fetched", fetchedCount),
+		zap.Int("detail", detailCount),
+		zap.Int("stubs", stubCount),
 		zap.Int("filtered", filteredCount),
 		zap.Int("errors", errorCount))
 

--- a/internal/registry/fetcher.go
+++ b/internal/registry/fetcher.go
@@ -53,14 +53,76 @@ type CredentialSource struct {
 	Branch     string `json:"branch,omitempty"`
 }
 
-// TS11SchemasResponse represents the paginated response from /api/v1/schemas.json
+// TS11SchemasResponse represents the paginated response from /api/v1/schemas.json.
+// It supports two wire formats:
+//   - Legacy: {"schemas": [...], "next": "...", "total": N, "page": N, "pageSize": N}
+//   - Current: {"data": [...], "total": N, "limit": N, "offset": N}
 type TS11SchemasResponse struct {
-	Schemas  []TS11SchemaMeta `json:"schemas"`
-	Total    int              `json:"total,omitempty"`
-	Page     int              `json:"page,omitempty"`
-	PageSize int              `json:"pageSize,omitempty"`
-	// Next is the URL of the next page; empty when there are no more pages
+	// Schemas is the legacy key for the schema array.
+	Schemas []TS11SchemaMeta `json:"schemas"`
+	// Data is the current key for the schema array (paginated TS11 API).
+	Data []TS11SchemaMeta `json:"data"`
+
+	Total    int `json:"total,omitempty"`
+	Page     int `json:"page,omitempty"`
+	PageSize int `json:"pageSize,omitempty"`
+	Limit    int `json:"limit,omitempty"`
+	Offset   int `json:"offset,omitempty"`
+	// Next is the URL of the next page; empty when there are no more pages (legacy pagination).
 	Next string `json:"next,omitempty"`
+}
+
+// Entries returns whichever schema array is populated (Data takes precedence over Schemas).
+func (r *TS11SchemasResponse) Entries() []TS11SchemaMeta {
+	if len(r.Data) > 0 {
+		return r.Data
+	}
+	return r.Schemas
+}
+
+// HasMorePages returns true if there are additional pages to fetch.
+func (r *TS11SchemasResponse) HasMorePages() bool {
+	// Legacy: "next" URL
+	if r.Next != "" {
+		return true
+	}
+	// Current: offset+limit < total
+	if r.Limit > 0 && r.Offset+len(r.Entries()) < r.Total {
+		return true
+	}
+	return false
+}
+
+// NextPageURL returns the URL for the next page. For legacy format it returns
+// the "next" field directly. For the current format it constructs the URL by
+// incrementing the offset. baseURL is the original source URL.
+func (r *TS11SchemasResponse) NextPageURL(baseURL string) string {
+	if r.Next != "" {
+		return r.Next
+	}
+	// Build offset-based next URL
+	nextOffset := r.Offset + len(r.Entries())
+	sep := "?"
+	if strings.Contains(baseURL, "?") {
+		sep = "&"
+	}
+	// Strip any existing offset param from baseURL
+	clean := baseURL
+	if idx := strings.Index(clean, "offset="); idx > 0 {
+		// Remove offset=N (and preceding & or ?)
+		end := strings.IndexByte(clean[idx:], '&')
+		if end == -1 {
+			clean = clean[:idx-1] // remove the preceding ? or &
+		} else {
+			clean = clean[:idx] + clean[idx+end+1:]
+		}
+		if !strings.Contains(clean, "?") {
+			sep = "?"
+		} else {
+			sep = "&"
+		}
+	}
+	return fmt.Sprintf("%s%soffset=%d", clean, sep, nextOffset)
 }
 
 // TS11SchemaMeta represents a single schema entry in the TS11 API
@@ -223,9 +285,11 @@ func (f *Fetcher) fetchFromSource(ctx context.Context, source RemoteSourceConfig
 	}
 
 	// Auto-detect format based on top-level JSON keys.
-	// TS11 /api/v1/schemas.json has a "schemas" array.
-	// Legacy vctm-registry.json has a "credentials" array.
+	// Current TS11: {"data": [...], "total": N, "limit": N, "offset": N}
+	// Legacy TS11:  {"schemas": [...], "next": "...", ...}
+	// Legacy index: {"credentials": [...], ...}
 	var detector struct {
+		Data        json.RawMessage `json:"data"`
 		Schemas     json.RawMessage `json:"schemas"`
 		Credentials json.RawMessage `json:"credentials"`
 	}
@@ -237,14 +301,14 @@ func (f *Fetcher) fetchFromSource(ctx context.Context, source RemoteSourceConfig
 		return f.processLegacyResponse(ctx, source, body)
 	}
 
-	if detector.Schemas != nil {
+	if detector.Data != nil || detector.Schemas != nil {
 		return f.processTS11Response(ctx, source, body)
 	}
 	return f.processLegacyResponse(ctx, source, body)
 }
 
 // processTS11Response processes a TS11-format /api/v1/schemas.json response,
-// including following pagination via the "next" field.
+// including following pagination via offset/limit or legacy "next" field.
 func (f *Fetcher) processTS11Response(ctx context.Context, source RemoteSourceConfig, body []byte) (map[string]*VCTMEntry, error) {
 	entries := make(map[string]*VCTMEntry)
 	var fetchedCount, filteredCount, errorCount int
@@ -256,7 +320,7 @@ func (f *Fetcher) processTS11Response(ctx context.Context, source RemoteSourceCo
 			return nil, fmt.Errorf("failed to unmarshal TS11 schemas response: %w", err)
 		}
 
-		for _, schema := range page.Schemas {
+		for _, schema := range page.Entries() {
 			// Determine which schemaURI to use as the VCTM fetch URL.
 			// Prefer the dc+sd-jwt entry; fall back to the first URI.
 			var vctmURI string
@@ -300,14 +364,15 @@ func (f *Fetcher) processTS11Response(ctx context.Context, source RemoteSourceCo
 			fetchedCount++
 		}
 
-		// Follow pagination if a next-page URL is provided.
-		if page.Next == "" {
+		// Follow pagination if more pages are available.
+		if !page.HasMorePages() {
 			break
 		}
-		nextBody, err := f.fetchRaw(ctx, page.Next)
+		nextURL := page.NextPageURL(source.URL)
+		nextBody, err := f.fetchRaw(ctx, nextURL)
 		if err != nil {
 			f.logger.Warn("failed to fetch next page of schemas",
-				zap.String("url", page.Next),
+				zap.String("url", nextURL),
 				zap.Error(err))
 			break
 		}

--- a/internal/registry/fetcher.go
+++ b/internal/registry/fetcher.go
@@ -360,6 +360,8 @@ func (f *Fetcher) processTS11Response(ctx context.Context, source RemoteSourceCo
 	entries := make(map[string]*VCTMEntry)
 	var fetchedCount, filteredCount, errorCount int
 
+	// Use the resolved endpoint URL for pagination (not the raw base URL)
+	resolvedURL := source.resolveURL()
 	currentBody := body
 	for {
 		var page TS11SchemasResponse
@@ -415,7 +417,7 @@ func (f *Fetcher) processTS11Response(ctx context.Context, source RemoteSourceCo
 		if !page.HasMorePages() {
 			break
 		}
-		nextURL := page.NextPageURL(source.URL)
+		nextURL := page.NextPageURL(resolvedURL)
 		nextBody, err := f.fetchRaw(ctx, nextURL)
 		if err != nil {
 			f.logger.Warn("failed to fetch next page of schemas",

--- a/internal/registry/fetcher_live_test.go
+++ b/internal/registry/fetcher_live_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package registry
 
 import (

--- a/internal/registry/fetcher_live_test.go
+++ b/internal/registry/fetcher_live_test.go
@@ -111,3 +111,44 @@ func TestIntegration_LiveRegistry_TS11_Pagination(t *testing.T) {
 	assert.Equal(t, firstCount, secondCount,
 		"repeated Fetch() calls must yield the same number of entries (pagination is deterministic)")
 }
+
+// TestIntegration_LiveRegistry_AllCredentials verifies that using the "registry" mode
+// fetches ALL credentials (both TS11 and non-TS11) from the live registry.
+//
+// Run explicitly with: go test -tags=integration ./internal/registry/... -run TestIntegration_LiveRegistry_AllCredentials -v
+func TestIntegration_LiveRegistry_AllCredentials(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live-network integration test in short mode")
+	}
+
+	cfg := DefaultConfig()
+	cfg.Source.URL = "https://registry.siros.org"
+	cfg.Source.Mode = APIModeRegistry
+	cfg.Source.Timeout = 60 * time.Second
+	cfg.Sources = nil
+	require.NoError(t, cfg.Validate())
+
+	store := NewStore("")
+	logger, _ := zap.NewDevelopment()
+	fetcher := NewFetcher(cfg, store, logger, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	err := fetcher.Fetch(ctx)
+	require.NoError(t, err, "Fetch() in registry mode must succeed")
+
+	count := store.Count()
+	t.Logf("fetched %d credential entries in registry mode", count)
+
+	// The registry has more credentials in registry mode than in TS11 mode.
+	// Currently 9, but at least verify it's more than the 4 TS11-only entries.
+	assert.Greater(t, count, 4,
+		"registry mode should return more credentials than TS11-only mode (expected >4, got %d)", count)
+
+	// Log all entries for visibility
+	for _, entry := range store.List() {
+		t.Logf("  vct=%s name=%q los=%s formats=%v",
+			entry.VCT, entry.Name, entry.AttestationLoS, entry.SupportedFormats)
+	}
+}

--- a/internal/registry/fetcher_live_test.go
+++ b/internal/registry/fetcher_live_test.go
@@ -14,12 +14,10 @@ import (
 )
 
 // TestIntegration_LiveRegistry_TS11 fetches the live registry.siros.org TS11
-// schemas API and validates that the implementation correctly parses the response.
+// schemas API and validates that the implementation correctly parses the
+// paginated response ({"data": [...], "total", "limit", "offset"}).
 //
-// The test is skipped when running with -short to allow CI pipelines that do not
-// have outbound network access to pass cleanly.  To run it explicitly:
-//
-//	go test ./internal/registry/... -run TestIntegration_LiveRegistry_TS11 -v
+// Run explicitly with: go test -tags=integration ./internal/registry/... -run TestIntegration_LiveRegistry_TS11 -v
 func TestIntegration_LiveRegistry_TS11(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping live-network integration test in short mode")

--- a/internal/registry/fetcher_test.go
+++ b/internal/registry/fetcher_test.go
@@ -454,6 +454,130 @@ func TestFetcher_FetchFromSource_TS11_Pagination(t *testing.T) {
 	assert.Len(t, entries, 2)
 }
 
+// TestFetcher_FetchFromSource_TS11_PaginatedDataFormat verifies that the fetcher
+// correctly handles the current TS11 API format that uses {"data": [...], "total", "limit", "offset"}
+// instead of the legacy {"schemas": [...], "next": "..."} format.
+func TestFetcher_FetchFromSource_TS11_PaginatedDataFormat(t *testing.T) {
+	vctmContent := `{"vct":"https://registry.example.org/cred.vctm.json","name":"Demo Credential","description":"A demo credential"}`
+
+	vctmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(vctmContent))
+	}))
+	defer vctmServer.Close()
+
+	// Use the current format: {"data": [...], "total": N, "limit": N, "offset": N}
+	response := map[string]interface{}{
+		"data": []TS11SchemaMeta{
+			{
+				ID:               "c48100f6-f19d-5f79-9bf5-819c293a08a4",
+				Version:          "0.1.0",
+				AttestationLoS:   "iso_18045_basic",
+				BindingType:      "key",
+				SupportedFormats: []string{"dc+sd-jwt"},
+				SchemaURIs: []TS11SchemaURI{
+					{FormatIdentifier: "dc+sd-jwt", URI: vctmServer.URL + "/cred.vctm.json"},
+				},
+				RulebookURI: "https://registry.example.org/rulebook.html",
+			},
+		},
+		"total":  1,
+		"limit":  20,
+		"offset": 0,
+	}
+
+	indexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer indexServer.Close()
+
+	config := DefaultConfig()
+	store := NewStore("")
+	logger := testLogger()
+	fetcher := NewFetcher(config, store, logger, nil)
+
+	src := RemoteSourceConfig{URL: indexServer.URL, Timeout: 5 * time.Second}
+	entries, err := fetcher.fetchFromSource(context.Background(), src)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	vct := "https://registry.example.org/cred.vctm.json"
+	entry, ok := entries[vct]
+	require.True(t, ok)
+
+	assert.Equal(t, vct, entry.VCT)
+	assert.Equal(t, "Demo Credential", entry.Name)
+	assert.Equal(t, "iso_18045_basic", entry.AttestationLoS)
+	assert.Equal(t, "key", entry.BindingType)
+	assert.Equal(t, []string{"dc+sd-jwt"}, entry.SupportedFormats)
+}
+
+// TestFetcher_FetchFromSource_TS11_PaginatedDataFormat_MultiPage verifies that
+// offset-based pagination is followed when total > offset+len(data).
+func TestFetcher_FetchFromSource_TS11_PaginatedDataFormat_MultiPage(t *testing.T) {
+	vctmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/cred2.json":
+			_, _ = w.Write([]byte(`{"vct":"https://example.org/cred2","name":"Cred2"}`))
+		default:
+			_, _ = w.Write([]byte(`{"vct":"https://example.org/cred1","name":"Cred1"}`))
+		}
+	}))
+	defer vctmServer.Close()
+
+	indexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		q := r.URL.Query()
+		offset := q.Get("offset")
+		if offset == "1" {
+			// Second page
+			page2 := map[string]interface{}{
+				"data": []TS11SchemaMeta{
+					{
+						ID: "id-2", Version: "1.0",
+						SchemaURIs: []TS11SchemaURI{
+							{FormatIdentifier: "dc+sd-jwt", URI: vctmServer.URL + "/cred2.json"},
+						},
+					},
+				},
+				"total":  2,
+				"limit":  1,
+				"offset": 1,
+			}
+			_ = json.NewEncoder(w).Encode(page2)
+			return
+		}
+		// First page
+		page1 := map[string]interface{}{
+			"data": []TS11SchemaMeta{
+				{
+					ID: "id-1", Version: "1.0",
+					SchemaURIs: []TS11SchemaURI{
+						{FormatIdentifier: "dc+sd-jwt", URI: vctmServer.URL + "/cred1.json"},
+					},
+				},
+			},
+			"total":  2,
+			"limit":  1,
+			"offset": 0,
+		}
+		_ = json.NewEncoder(w).Encode(page1)
+	}))
+	defer indexServer.Close()
+
+	config := DefaultConfig()
+	fetcher := NewFetcher(config, NewStore(""), testLogger(), nil)
+
+	src := RemoteSourceConfig{URL: indexServer.URL}
+	entries, err := fetcher.fetchFromSource(context.Background(), src)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+	assert.Contains(t, entries, "https://example.org/cred1")
+	assert.Contains(t, entries, "https://example.org/cred2")
+}
+
 // TestFetcher_FetchFromSource_TS11_VCTFromDocument verifies that the VCT identifier is
 // read from the "vct" field in the VCTM document itself rather than derived from the
 // schemaURI.  This matters because the VCT may be a URN (e.g. "urn:eudi:diploma:1").
@@ -786,7 +910,6 @@ func TestConfig_Validate_BothSourceEmptyAndSourcesEmpty(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "source URL is required")
 }
-
 
 func TestFetcher_Fetch_WithFilter(t *testing.T) {
 	index := RegistryIndex{

--- a/internal/registry/fetcher_test.go
+++ b/internal/registry/fetcher_test.go
@@ -1098,3 +1098,166 @@ func TestRegistryIndex_JSONRoundtrip(t *testing.T) {
 	assert.Len(t, loaded.Credentials, 1)
 	assert.Equal(t, original.Credentials[0].VCT, loaded.Credentials[0].VCT)
 }
+
+// TestResolveURL verifies that resolveURL correctly appends endpoint paths based on Mode.
+func TestResolveURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   RemoteSourceConfig
+		expected string
+	}{
+		{
+			name:     "ts11 mode appends schemas.json",
+			source:   RemoteSourceConfig{URL: "https://registry.siros.org", Mode: APIModeTS11},
+			expected: "https://registry.siros.org/api/v1/schemas.json",
+		},
+		{
+			name:     "registry mode appends registry.json",
+			source:   RemoteSourceConfig{URL: "https://registry.siros.org", Mode: APIModeRegistry},
+			expected: "https://registry.siros.org/api/v1/registry.json",
+		},
+		{
+			name:     "trailing slash is stripped",
+			source:   RemoteSourceConfig{URL: "https://registry.siros.org/", Mode: APIModeTS11},
+			expected: "https://registry.siros.org/api/v1/schemas.json",
+		},
+		{
+			name:     "explicit .json URL is used as-is",
+			source:   RemoteSourceConfig{URL: "https://registry.siros.org/api/v1/schemas.json", Mode: APIModeRegistry},
+			expected: "https://registry.siros.org/api/v1/schemas.json",
+		},
+		{
+			name:     "empty mode defaults to ts11",
+			source:   RemoteSourceConfig{URL: "https://registry.siros.org"},
+			expected: "https://registry.siros.org/api/v1/schemas.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.source.resolveURL())
+		})
+	}
+}
+
+// TestFetcher_FetchFromSource_RegistryFormat verifies that the fetcher correctly
+// processes the /api/v1/registry.json format which has ALL credentials.
+func TestFetcher_FetchFromSource_RegistryFormat(t *testing.T) {
+	vctmContent := `{"vct":"https://registry.example.org/cred.vctm.json","name":"TS11 Cred","description":"A TS11 credential"}`
+
+	mux := http.NewServeMux()
+	// Detail endpoint for TS11-compliant entry
+	mux.HandleFunc("/api/v1/schemas/ts11-id.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TS11SchemaMeta{
+			ID:               "ts11-id",
+			Version:          "0.1.0",
+			AttestationLoS:   "iso_18045_basic",
+			BindingType:      "key",
+			SupportedFormats: []string{"dc+sd-jwt"},
+			SchemaURIs: []TS11SchemaURI{
+				{FormatIdentifier: "dc+sd-jwt", URI: ""}, // placeholder, will be replaced
+			},
+		})
+	})
+	// Detail endpoint returns 404 for non-TS11 entry
+	mux.HandleFunc("/api/v1/schemas/non-ts11-id.json", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Update the TS11 detail schema URI to point to our VCTM server
+	vctmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(vctmContent))
+	}))
+	defer vctmServer.Close()
+
+	// Override the detail endpoint to return the correct VCTM server URL
+	mux2 := http.NewServeMux()
+	mux2.HandleFunc("/api/v1/schemas/ts11-id.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TS11SchemaMeta{
+			ID:               "ts11-id",
+			Version:          "0.1.0",
+			AttestationLoS:   "iso_18045_basic",
+			BindingType:      "key",
+			SupportedFormats: []string{"dc+sd-jwt"},
+			SchemaURIs: []TS11SchemaURI{
+				{FormatIdentifier: "dc+sd-jwt", URI: vctmServer.URL + "/cred.vctm.json"},
+			},
+		})
+	})
+	mux2.HandleFunc("/api/v1/schemas/non-ts11-id.json", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	mux2.HandleFunc("/api/v1/registry.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		total := 2
+		_ = json.NewEncoder(w).Encode(RegistryResponse{
+			Total: total,
+			Credentials: []RegistryListEntry{
+				{
+					ID:               "ts11-id",
+					Version:          "0.1.0",
+					SupportedFormats: []string{"dc+sd-jwt"},
+					AttestationLoS:   "iso_18045_basic",
+					BindingType:      "key",
+				},
+				{
+					ID:               "non-ts11-id",
+					Version:          "0.2.0",
+					SupportedFormats: []string{"mso_mdoc", "dc+sd-jwt"},
+					AttestationLoS:   "iso_18045_moderate",
+					BindingType:      "key",
+				},
+			},
+		})
+	})
+
+	registryServer := httptest.NewServer(mux2)
+	defer registryServer.Close()
+
+	config := DefaultConfig()
+	fetcher := NewFetcher(config, NewStore(""), testLogger(), nil)
+
+	src := RemoteSourceConfig{URL: registryServer.URL + "/api/v1/registry.json", Mode: APIModeRegistry}
+	entries, err := fetcher.fetchFromSource(context.Background(), src)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	// TS11 entry should have full metadata from the VCTM document
+	ts11Entry, ok := entries["https://registry.example.org/cred.vctm.json"]
+	require.True(t, ok, "TS11 entry should be keyed on its VCTM vct field")
+	assert.Equal(t, "TS11 Cred", ts11Entry.Name)
+	assert.Equal(t, "iso_18045_basic", ts11Entry.AttestationLoS)
+
+	// Non-TS11 entry should be a stub keyed on the schema ID
+	nonTS11Entry, ok := entries["non-ts11-id"]
+	require.True(t, ok, "non-TS11 entry should be keyed on schema ID")
+	assert.Equal(t, "iso_18045_moderate", nonTS11Entry.AttestationLoS)
+	assert.Equal(t, []string{"mso_mdoc", "dc+sd-jwt"}, nonTS11Entry.SupportedFormats)
+}
+
+// TestConfig_Validate_InvalidMode verifies that invalid Mode values are rejected.
+func TestConfig_Validate_InvalidMode(t *testing.T) {
+	config := DefaultConfig()
+	config.Sources = []RemoteSourceConfig{
+		{URL: "https://registry.example.org", Mode: "invalid"},
+	}
+	err := config.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `must be "ts11" or "registry"`)
+}
+
+// TestConfig_Validate_DefaultMode verifies that empty Mode defaults to ts11.
+func TestConfig_Validate_DefaultMode(t *testing.T) {
+	config := DefaultConfig()
+	config.Sources = []RemoteSourceConfig{
+		{URL: "https://registry.example.org"},
+	}
+	require.NoError(t, config.Validate())
+	assert.Equal(t, APIModeTS11, config.Sources[0].Mode)
+}


### PR DESCRIPTION
Extracts registry-specific changes from PR #170 into a focused PR:

- **Gate live registry tests** behind `integration` build tag so `go test ./...` stays fast
- **TS11 paginated API support**: parse the current TS11 paginated response format (with `count`, `offset`, pagination)
- **Mode config**: add `mode` config field (`ts11` or `registry`) to select between the legacy paginated TS11 format and the new registry API format

These are self-contained registry improvements that don't depend on the metadata resolution changes in #170.