### PR TITLE
fix(registry): add jwt.secret_path support matching main backend

### DIFF
--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/sirosfoundation/go-wallet-backend/internal/embed"
@@ -260,6 +261,10 @@ type JWTConfig struct {
 	// Secret is the shared secret for validating JWT signatures (HMAC)
 	Secret string `yaml:"secret"`
 
+	// SecretPath is an alternative to Secret: path to a file containing the JWT secret.
+	// If both Secret and SecretPath are set, SecretPath takes precedence.
+	SecretPath string `yaml:"secret_path" envconfig:"SECRET_PATH"`
+
 	// Issuer is the expected issuer claim in the JWT
 	Issuer string `yaml:"issuer"`
 
@@ -391,8 +396,15 @@ func (c *Config) Validate() error {
 	}
 
 	// JWT secret is only required if RequireAuth is true
+	if c.JWT.SecretPath != "" {
+		data, err := os.ReadFile(c.JWT.SecretPath)
+		if err != nil {
+			return fmt.Errorf("jwt.secret_path: %w", err)
+		}
+		c.JWT.Secret = strings.TrimSpace(string(data))
+	}
 	if c.JWT.RequireAuth && c.JWT.Secret == "" {
-		return fmt.Errorf("JWT secret is required when authentication is required")
+		return fmt.Errorf("JWT secret is required when authentication is required (set jwt.secret or jwt.secret_path)")
 	}
 
 	return nil

--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -395,13 +395,17 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// JWT secret is only required if RequireAuth is true
+	// Load JWT secret from file if secret_path is set (always loaded regardless of RequireAuth)
 	if c.JWT.SecretPath != "" {
 		data, err := os.ReadFile(c.JWT.SecretPath)
 		if err != nil {
 			return fmt.Errorf("jwt.secret_path: %w", err)
 		}
-		c.JWT.Secret = strings.TrimSpace(string(data))
+		secret := strings.TrimSpace(string(data))
+		if secret == "" {
+			return fmt.Errorf("jwt.secret_path: file is empty or contains only whitespace")
+		}
+		c.JWT.Secret = secret
 	}
 	if c.JWT.RequireAuth && c.JWT.Secret == "" {
 		return fmt.Errorf("JWT secret is required when authentication is required (set jwt.secret or jwt.secret_path)")

--- a/internal/registry/config_test.go
+++ b/internal/registry/config_test.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -228,6 +230,53 @@ func TestConfig_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfig_Validate_SecretPath(t *testing.T) {
+	t.Run("populates Secret from file", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "secret")
+		require.NoError(t, os.WriteFile(f, []byte("file-secret\n"), 0600))
+
+		cfg := DefaultConfig()
+		cfg.JWT.RequireAuth = true
+		cfg.JWT.SecretPath = f
+		require.NoError(t, cfg.Validate())
+		assert.Equal(t, "file-secret", cfg.JWT.Secret)
+	})
+
+	t.Run("SecretPath overrides Secret", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "secret")
+		require.NoError(t, os.WriteFile(f, []byte("from-file"), 0600))
+
+		cfg := DefaultConfig()
+		cfg.JWT.RequireAuth = true
+		cfg.JWT.Secret = "inline-secret"
+		cfg.JWT.SecretPath = f
+		require.NoError(t, cfg.Validate())
+		assert.Equal(t, "from-file", cfg.JWT.Secret)
+	})
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.JWT.SecretPath = "/nonexistent/path/secret"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "jwt.secret_path:")
+	})
+
+	t.Run("empty file returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "secret")
+		require.NoError(t, os.WriteFile(f, []byte("  \n"), 0600))
+
+		cfg := DefaultConfig()
+		cfg.JWT.SecretPath = f
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "file is empty or contains only whitespace")
+	})
 }
 
 func TestFilterConfig_Compile(t *testing.T) {


### PR DESCRIPTION
The registry server's `JWTConfig` only supported inline `jwt.secret` but not `jwt.secret_path` (reading from a file). This caused `JWT secret is empty, rejecting token` errors when deployments use `secret_path` (common in Docker/Kubernetes where secrets are mounted as files).

Now mirrors the behavior in `pkg/config`: if `secret_path` is set, the file is read during `Validate()` and its contents populate the `Secret` field.

**Symptom:**
```json
{"level":"debug","msg":"JWT secret is empty, rejecting token"}
```