### PR TITLE
fix: clear stale write deadline after WebSocket upgrade

### DIFF
--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -152,6 +152,11 @@ func (m *Manager) HandleConnection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Clear the write deadline inherited from net/http's WriteTimeout.
+	// After upgrade, the WebSocket connection manages its own deadlines;
+	// the stale deadline would cause writes to fail after the timeout elapses.
+	_ = conn.SetWriteDeadline(time.Time{})
+
 	m.logger.Debug("WebSocket client connected")
 	go m.handleNewConnection(conn)
 }

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -193,7 +193,10 @@ func (m *Manager) handleNewConnection(conn *websocket.Conn) {
 	// Validate token and extract claims
 	userID, tenantID, err := m.validateToken(handshake.AppToken)
 	if err != nil {
-		m.logger.Warn("Authentication failed", zap.Error(err))
+		m.logger.Warn("Authentication failed",
+			zap.Error(err),
+			zap.Int("token_len", len(handshake.AppToken)),
+		)
 		m.sendError(conn, "", ErrCodeAuthFailed, "Invalid or expired token")
 		return
 	}

--- a/internal/websocket/manager.go
+++ b/internal/websocket/manager.go
@@ -117,6 +117,11 @@ func (m *Manager) HandleConnection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Clear the write deadline inherited from net/http's WriteTimeout.
+	// After upgrade, the WebSocket connection manages its own deadlines;
+	// the stale deadline would cause writes to fail after the timeout elapses.
+	_ = conn.SetWriteDeadline(time.Time{})
+
 	m.logger.Info("WebSocket client connected")
 
 	// Read the first message which should be the handshake with appToken


### PR DESCRIPTION
Fixes #177

Clear the write deadline inherited from net/http's WriteTimeout immediately after WebSocket upgrade. Without this, all writes to the connection fail once 15s have elapsed since the upgrade response was sent.

Both the engine and legacy WebSocket handlers are fixed.