### PR TITLE
fix: restore X-Served-By middleware lost in server refactoring

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -166,6 +166,8 @@ func main() {
 
 	if backendCfg != nil {
 		serverCfg.ServedByHeader = backendCfg.Server.ResolvedServedBy()
+	} else if registryCfg != nil {
+		serverCfg.ServedByHeader = registryCfg.Server.ResolvedServedBy()
 	}
 	serverCfg.IsProduction = isProduction
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -164,6 +164,9 @@ func main() {
 		serverCfg.LoggingLevel = registryCfg.Logging.Level
 	}
 
+	if backendCfg != nil {
+		serverCfg.ServedByHeader = backendCfg.Server.ResolvedServedBy()
+	}
 	serverCfg.IsProduction = isProduction
 
 	// Create unified server manager

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,10 @@ type ServerConfig struct {
 	// Active roles for status endpoint
 	Roles []string
 
+	// ServedByHeader is the value for the X-Served-By response header.
+	// Empty string disables the header.
+	ServedByHeader string
+
 	// IsProduction is true when the server runs in a production environment.
 	// In production, admin token auto-generation is disabled and the server
 	// refuses to start without a pre-configured admin token.
@@ -321,6 +325,9 @@ func (m *Manager) buildRouter() *gin.Engine {
 	router.Use(gin.Recovery())
 	router.Use(middleware.Prometheus("/status", "/health", "/healthz", "/readyz"))
 	router.Use(middleware.Logger(m.logger, "/status", "/health", "/healthz", "/readyz"))
+	if m.cfg.ServedByHeader != "" {
+		router.Use(middleware.ServedByMiddleware(m.cfg.ServedByHeader))
+	}
 	router.Use(cors.New(cors.Config{
 		AllowOrigins:     m.cfg.CORS.AllowedOrigins,
 		AllowMethods:     m.cfg.CORS.AllowedMethods,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -394,6 +394,9 @@ func (m *Manager) startAdminServer() error {
 	// Admin router
 	adminRouter := gin.New()
 	adminRouter.Use(gin.Recovery())
+	if m.cfg.ServedByHeader != "" {
+		adminRouter.Use(middleware.ServedByMiddleware(m.cfg.ServedByHeader))
+	}
 
 	// Public admin status endpoint (no auth required)
 	adminRouter.GET("/admin/status", func(c *gin.Context) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -395,30 +395,50 @@ func TestStartAdminServer_DevAutoGeneratesToken(t *testing.T) {
 func TestManager_ServedByMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	cfg := &ServerConfig{
-		Roles: []string{"test"},
-		CORS: config.CORSConfig{
-			AllowedOrigins: []string{"*"},
-		},
-	}
-	// Use a custom logger to capture any issues
-	logger := zap.NewNop()
-	manager := NewManager(cfg, logger)
+	t.Run("enabled", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Roles:          []string{"test"},
+			ServedByHeader: "test-instance-42",
+			CORS: config.CORSConfig{
+				AllowedOrigins: []string{"*"},
+			},
+		}
+		manager := NewManager(cfg, zap.NewNop())
+		router := manager.buildRouter()
+		router.GET("/test", func(c *gin.Context) {
+			c.String(http.StatusOK, "ok")
+		})
 
-	// Build router and add test route
-	router := manager.buildRouter()
-	router.GET("/test", func(c *gin.Context) {
-		c.String(http.StatusOK, "ok")
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		servedBy := w.Header().Get("X-Served-By")
+		if servedBy != "test-instance-42" {
+			t.Errorf("expected X-Served-By = %q, got %q", "test-instance-42", servedBy)
+		}
 	})
 
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/test", nil)
-	router.ServeHTTP(w, req)
+	t.Run("disabled", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Roles: []string{"test"},
+			CORS: config.CORSConfig{
+				AllowedOrigins: []string{"*"},
+			},
+		}
+		manager := NewManager(cfg, zap.NewNop())
+		router := manager.buildRouter()
+		router.GET("/test", func(c *gin.Context) {
+			c.String(http.StatusOK, "ok")
+		})
 
-	// Check that X-Served-By header is set
-	servedBy := w.Header().Get("X-Served-By")
-	if servedBy == "" {
-		// Middleware might not set if no config - this is optional
-		t.Log("X-Served-By header not set (may be expected)")
-	}
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		servedBy := w.Header().Get("X-Served-By")
+		if servedBy != "" {
+			t.Errorf("expected no X-Served-By header, got %q", servedBy)
+		}
+	})
 }


### PR DESCRIPTION
The `ServedByMiddleware` was added in PR #40 (wired into `internal/modes/*/`) but lost when the server was refactored to the unified `internal/server/` package.

Re-wires it into `buildRouter()` so all HTTP and WebSocket upgrade responses include the `X-Served-By` header.

**Why this matters now:** We're debugging intermittent AUTH_FAILED errors on WebSocket handshake. The backend logs prove the failing connection never reached this instance — suggesting a second replica with a different JWT secret. This header will identify which instance served each response.