### PR TITLE
fix: set X-Served-By header on WebSocket upgrade responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 WORKDIR /app
 

--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 WORKDIR /app
 

--- a/Dockerfile.wallet-admin
+++ b/Dockerfile.wallet-admin
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 WORKDIR /app
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -166,6 +166,8 @@ func main() {
 
 	if backendCfg != nil {
 		serverCfg.ServedByHeader = backendCfg.Server.ResolvedServedBy()
+	} else if registryCfg != nil {
+		serverCfg.ServedByHeader = registryCfg.Server.ResolvedServedBy()
 	}
 	serverCfg.IsProduction = isProduction
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -164,6 +164,9 @@ func main() {
 		serverCfg.LoggingLevel = registryCfg.Logging.Level
 	}
 
+	if backendCfg != nil {
+		serverCfg.ServedByHeader = backendCfg.Server.ResolvedServedBy()
+	}
 	serverCfg.IsProduction = isProduction
 
 	// Create unified server manager

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sirosfoundation/go-wallet-backend
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/descope/virtualwebauthn v1.0.3

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -147,7 +147,9 @@ func (m *Manager) RegisterFlowHandler(protocol Protocol, factory FlowHandlerFact
 // HandleConnection handles a new WebSocket connection
 func (m *Manager) HandleConnection(w http.ResponseWriter, r *http.Request) {
 	responseHeader := http.Header{}
-	responseHeader.Set("X-Served-By", m.cfg.Server.ResolvedServedBy())
+	if servedBy := m.cfg.Server.ResolvedServedBy(); servedBy != "" {
+		responseHeader.Set("X-Served-By", servedBy)
+	}
 	conn, err := m.upgrader.Upgrade(w, r, responseHeader)
 	if err != nil {
 		m.logger.Error("Failed to upgrade connection", zap.Error(err))

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -146,7 +146,9 @@ func (m *Manager) RegisterFlowHandler(protocol Protocol, factory FlowHandlerFact
 
 // HandleConnection handles a new WebSocket connection
 func (m *Manager) HandleConnection(w http.ResponseWriter, r *http.Request) {
-	conn, err := m.upgrader.Upgrade(w, r, nil)
+	responseHeader := http.Header{}
+	responseHeader.Set("X-Served-By", m.cfg.Server.ResolvedServedBy())
+	conn, err := m.upgrader.Upgrade(w, r, responseHeader)
 	if err != nil {
 		m.logger.Error("Failed to upgrade connection", zap.Error(err))
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,10 @@ type ServerConfig struct {
 	// Active roles for status endpoint
 	Roles []string
 
+	// ServedByHeader is the value for the X-Served-By response header.
+	// Empty string disables the header.
+	ServedByHeader string
+
 	// IsProduction is true when the server runs in a production environment.
 	// In production, admin token auto-generation is disabled and the server
 	// refuses to start without a pre-configured admin token.
@@ -321,6 +325,9 @@ func (m *Manager) buildRouter() *gin.Engine {
 	router.Use(gin.Recovery())
 	router.Use(middleware.Prometheus("/status", "/health", "/healthz", "/readyz"))
 	router.Use(middleware.Logger(m.logger, "/status", "/health", "/healthz", "/readyz"))
+	if m.cfg.ServedByHeader != "" {
+		router.Use(middleware.ServedByMiddleware(m.cfg.ServedByHeader))
+	}
 	router.Use(cors.New(cors.Config{
 		AllowOrigins:     m.cfg.CORS.AllowedOrigins,
 		AllowMethods:     m.cfg.CORS.AllowedMethods,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -394,6 +394,9 @@ func (m *Manager) startAdminServer() error {
 	// Admin router
 	adminRouter := gin.New()
 	adminRouter.Use(gin.Recovery())
+	if m.cfg.ServedByHeader != "" {
+		adminRouter.Use(middleware.ServedByMiddleware(m.cfg.ServedByHeader))
+	}
 
 	// Public admin status endpoint (no auth required)
 	adminRouter.GET("/admin/status", func(c *gin.Context) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -395,30 +395,50 @@ func TestStartAdminServer_DevAutoGeneratesToken(t *testing.T) {
 func TestManager_ServedByMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	cfg := &ServerConfig{
-		Roles: []string{"test"},
-		CORS: config.CORSConfig{
-			AllowedOrigins: []string{"*"},
-		},
-	}
-	// Use a custom logger to capture any issues
-	logger := zap.NewNop()
-	manager := NewManager(cfg, logger)
+	t.Run("enabled", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Roles:          []string{"test"},
+			ServedByHeader: "test-instance-42",
+			CORS: config.CORSConfig{
+				AllowedOrigins: []string{"*"},
+			},
+		}
+		manager := NewManager(cfg, zap.NewNop())
+		router := manager.buildRouter()
+		router.GET("/test", func(c *gin.Context) {
+			c.String(http.StatusOK, "ok")
+		})
 
-	// Build router and add test route
-	router := manager.buildRouter()
-	router.GET("/test", func(c *gin.Context) {
-		c.String(http.StatusOK, "ok")
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		servedBy := w.Header().Get("X-Served-By")
+		if servedBy != "test-instance-42" {
+			t.Errorf("expected X-Served-By = %q, got %q", "test-instance-42", servedBy)
+		}
 	})
 
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/test", nil)
-	router.ServeHTTP(w, req)
+	t.Run("disabled", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Roles: []string{"test"},
+			CORS: config.CORSConfig{
+				AllowedOrigins: []string{"*"},
+			},
+		}
+		manager := NewManager(cfg, zap.NewNop())
+		router := manager.buildRouter()
+		router.GET("/test", func(c *gin.Context) {
+			c.String(http.StatusOK, "ok")
+		})
 
-	// Check that X-Served-By header is set
-	servedBy := w.Header().Get("X-Served-By")
-	if servedBy == "" {
-		// Middleware might not set if no config - this is optional
-		t.Log("X-Served-By header not set (may be expected)")
-	}
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		servedBy := w.Header().Get("X-Served-By")
+		if servedBy != "" {
+			t.Errorf("expected no X-Served-By header, got %q", servedBy)
+		}
+	})
 }

--- a/internal/websocket/manager.go
+++ b/internal/websocket/manager.go
@@ -111,7 +111,9 @@ func NewManager(cfg *config.Config, logger *zap.Logger) *Manager {
 
 // HandleConnection handles a new WebSocket connection
 func (m *Manager) HandleConnection(w http.ResponseWriter, r *http.Request) {
-	conn, err := m.upgrader.Upgrade(w, r, nil)
+	responseHeader := http.Header{}
+	responseHeader.Set("X-Served-By", m.cfg.Server.ResolvedServedBy())
+	conn, err := m.upgrader.Upgrade(w, r, responseHeader)
 	if err != nil {
 		m.logger.Error("Failed to upgrade connection", zap.Error(err))
 		return

--- a/internal/websocket/manager.go
+++ b/internal/websocket/manager.go
@@ -111,8 +111,11 @@ func NewManager(cfg *config.Config, logger *zap.Logger) *Manager {
 
 // HandleConnection handles a new WebSocket connection
 func (m *Manager) HandleConnection(w http.ResponseWriter, r *http.Request) {
-	responseHeader := http.Header{}
-	responseHeader.Set("X-Served-By", m.cfg.Server.ResolvedServedBy())
+	var responseHeader http.Header
+	if servedBy := m.cfg.Server.ResolvedServedBy(); servedBy != "" {
+		responseHeader = http.Header{}
+		responseHeader.Set("X-Served-By", servedBy)
+	}
 	conn, err := m.upgrader.Upgrade(w, r, responseHeader)
 	if err != nil {
 		m.logger.Error("Failed to upgrade connection", zap.Error(err))


### PR DESCRIPTION
## Summary

The gin middleware `ServedByMiddleware` (restored in #179) sets the `X-Served-By` header for regular HTTP responses, but **not** for WebSocket upgrade responses. Once `gorilla/websocket` hijacks the connection, gin middleware can no longer inject response headers.

## Changes

- Pass a `responseHeader` with `X-Served-By` to `upgrader.Upgrade(w, r, responseHeader)` in both WebSocket handlers (`internal/engine/session.go` and `internal/websocket/manager.go`).
- Bump Go from 1.26.2 → 1.26.3 in `go.mod` (matching `go.work`).
- Pin Dockerfiles to `golang:1.26.3-alpine` for reproducible builds.

## Testing

- Pre-commit lint passes.
- After deployment, verify with: `websocat ws://host:8082/ws -H 'Upgrade: websocket' --dump-headers` and confirm `X-Served-By` is present in the 101 response.