### PR TITLE
Add debug logging for credential assertion response

### DIFF
--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -492,7 +492,7 @@ func (s *WebAuthnService) FinishRegistration(ctx context.Context, req *FinishReg
 	s.logger.Debug("Parsing credential response",
 		zap.Int("original_len", len(req.Credential)),
 		zap.Int("decoded_len", len(credData)),
-		zap.ByteString("decoded_preview", credData[:min(500, len(credData))]),
+		zap.ByteString("decoded_preview", credData[:min(1000, len(credData))]),
 	)
 
 	parsedResponse, err := protocol.ParseCredentialCreationResponseBody(
@@ -829,6 +829,14 @@ func (s *WebAuthnService) FinishLogin(ctx context.Context, req *FinishLoginReque
 
 	// Delete challenge (one-time use)
 	_ = s.store.Challenges().Delete(ctx, req.ChallengeID)
+
+	// Debug: log the credential data being parsed
+	credData := taggedbinary.MustDecodeJSON(req.Credential)
+	s.logger.Debug("Parsing credential assertion response",
+		zap.Int("original_len", len(req.Credential)),
+		zap.Int("decoded_len", len(credData)),
+		zap.ByteString("decoded_preview", credData[:min(1000, len(credData))]),
+	)
 
 	// Parse the credential assertion response
 	parsedResponse, err := protocol.ParseCredentialRequestResponseBody(


### PR DESCRIPTION
This change adds additional debug logging before parsing of credential
assertion response in the "FinishLogin" function.

It also bumps the preview limit for credential responses to capture relevant parts.
