### PR TITLE
fix: :latest follows semver tags, add :latest-build for commit tracking

### DIFF
--- a/.github/workflows/docker-publish-registry.yml
+++ b/.github/workflows/docker-publish-registry.yml
@@ -86,7 +86,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest-build,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7

--- a/.github/workflows/docker-publish-registry.yml
+++ b/.github/workflows/docker-publish-registry.yml
@@ -86,7 +86,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern=latest
             type=raw,value=latest-build,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/.github/workflows/docker-publish-server.yml
+++ b/.github/workflows/docker-publish-server.yml
@@ -92,7 +92,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern=latest
             type=raw,value=latest-build,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/.github/workflows/docker-publish-server.yml
+++ b/.github/workflows/docker-publish-server.yml
@@ -92,7 +92,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest-build,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7

--- a/.github/workflows/docker-publish-wallet-admin.yml
+++ b/.github/workflows/docker-publish-wallet-admin.yml
@@ -92,7 +92,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern=latest
             type=raw,value=latest-build,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/.github/workflows/docker-publish-wallet-admin.yml
+++ b/.github/workflows/docker-publish-wallet-admin.yml
@@ -92,7 +92,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest-build,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7


### PR DESCRIPTION
## Summary

Standardize Docker image tagging policy across all three Docker workflows (server, registry, wallet-admin):

- **`:latest`** now only applied when a semver tag (`v*`) is pushed, not on every push to main
- **`:latest-build`** added — follows the latest commit on the default branch, paired with the existing SHA tag for traceability

## Rationale

Previously `:latest` was updated on every push to main, which meant it could point to unreleased/untagged code. Now `:latest` reliably tracks the most recent semver release, while `:latest-build` provides a stable tag for the newest build from main.