### PR TITLE
ci: adopt composite action for conformance workflow

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,5 +1,5 @@
 # Trigger conformance tests via @conformance in a PR comment.
-# See https://developers.siros.org/docs/howto/running-conformance-tests
+# See https://developers.siros.org/howto/running-conformance-tests
 #
 # Prerequisites:
 #   - CONFORMANCE_DISPATCH_TOKEN secret: fine-grained PAT with Contents

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,24 +1,9 @@
 # Trigger conformance tests via @conformance in a PR comment.
-#
-# Copy this file into your repo as .github/workflows/conformance.yml.
-#
-# Usage — add a comment on any PR:
-#   @conformance                                    → all profiles, :latest
-#   @conformance issuer                             → issuer profile only
-#   @conformance wallet                             → wallet profile only
-#   @conformance vc-issuer:pr-42                    → auto-detect profile
-#   @conformance wallet wallet-frontend:pr-111      → explicit profile + override
-#   @conformance vc-issuer:pr-42 go-trust:sha-abc   → multiple overrides
+# See https://developers.siros.org/docs/howto/running-conformance-tests
 #
 # Prerequisites:
 #   - CONFORMANCE_DISPATCH_TOKEN secret: fine-grained PAT with Contents
 #     read/write on sirosfoundation/siros-conformance (to trigger repository_dispatch)
-#
-# Flow:
-#   1. Comment containing @conformance is posted on a PR
-#   2. This workflow parses the comment for profile + image overrides
-#   3. Fires repository_dispatch on siros-conformance for each profile
-#   4. Conformance results are posted back as a comment on the PR
 
 name: Conformance Tests
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,110 @@
+# Trigger conformance tests via @conformance in a PR comment.
+#
+# Copy this file into your repo as .github/workflows/conformance.yml.
+#
+# Usage — add a comment on any PR:
+#   @conformance                                    → all profiles, :latest
+#   @conformance issuer                             → issuer profile only
+#   @conformance wallet                             → wallet profile only
+#   @conformance vc-issuer:pr-42                    → auto-detect profile
+#   @conformance wallet wallet-frontend:pr-111      → explicit profile + override
+#   @conformance vc-issuer:pr-42 go-trust:sha-abc   → multiple overrides
+#
+# Prerequisites:
+#   - CONFORMANCE_DISPATCH_TOKEN secret: PAT with repo scope for
+#     sirosfoundation/siros-conformance (to trigger repository_dispatch)
+#
+# Flow:
+#   1. Comment containing @conformance is posted on a PR
+#   2. This workflow parses the comment for profile + image overrides
+#   3. Fires repository_dispatch on siros-conformance for each profile
+#   4. Conformance results are posted back as a comment on the PR
+
+name: Conformance Tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-conformance:
+    runs-on: ubuntu-latest
+    # Only run on PR comments (not issue comments) containing @conformance
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@conformance')
+    steps:
+      - name: Acknowledge trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=rocket \
+            --silent
+
+      - name: Checkout siros-conformance scripts
+        uses: actions/checkout@v4
+        with:
+          repository: sirosfoundation/siros-conformance
+          sparse-checkout: scripts
+          path: _conformance
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Parse comment
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          PARSED=$(echo "$COMMENT_BODY" | node _conformance/scripts/parse-comment.mjs)
+          echo "parsed=${PARSED}" >> $GITHUB_OUTPUT
+          echo "Parsed: ${PARSED}"
+
+      - name: Dispatch conformance tests
+        env:
+          GH_TOKEN: ${{ secrets.CONFORMANCE_DISPATCH_TOKEN }}
+        run: |
+          PARSED='${{ steps.parse.outputs.parsed }}'
+          EVENTS=$(echo "$PARSED" | jq -r '.["dispatch-events"][]')
+          OVERRIDES=$(echo "$PARSED" | jq -c '.["image-overrides"]')
+          PR_NUMBER=${{ github.event.issue.number }}
+          REPO=${{ github.repository }}
+
+          for EVENT in $EVENTS; do
+            echo "Dispatching ${EVENT} with overrides=${OVERRIDES}"
+            gh api repos/sirosfoundation/siros-conformance/dispatches \
+              -f event_type="${EVENT}" \
+              -f "client_payload[target-repo]=${REPO}" \
+              -f "client_payload[target-pr]=${PR_NUMBER}" \
+              -f "client_payload[image-overrides]=${OVERRIDES}"
+          done
+
+      - name: Post status comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PARSED='${{ steps.parse.outputs.parsed }}'
+          PROFILES=$(echo "$PARSED" | jq -r '.profiles | join(", ")')
+          OVERRIDES=$(echo "$PARSED" | jq -r '
+            .["image-overrides"] |
+            to_entries |
+            if length == 0 then "none (using :latest)"
+            else map("\(.key):\(.value)") | join(", ")
+            end
+          ')
+          RUN_URL="${{ github.server_url }}/sirosfoundation/siros-conformance/actions"
+
+          BODY="🚀 **Conformance tests triggered**
+          
+          | | |
+          |---|---|
+          | **Profiles** | ${PROFILES} |
+          | **Image overrides** | ${OVERRIDES} |
+          | **Results** | [siros-conformance actions](${RUN_URL}) |
+          
+          Results will be posted here when complete."
+
+          gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            -f body="${BODY}"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -11,8 +11,8 @@
 #   @conformance vc-issuer:pr-42 go-trust:sha-abc   → multiple overrides
 #
 # Prerequisites:
-#   - CONFORMANCE_DISPATCH_TOKEN secret: PAT with repo scope for
-#     sirosfoundation/siros-conformance (to trigger repository_dispatch)
+#   - CONFORMANCE_DISPATCH_TOKEN secret: fine-grained PAT with Contents
+#     read/write on sirosfoundation/siros-conformance (to trigger repository_dispatch)
 #
 # Flow:
 #   1. Comment containing @conformance is posted on a PR
@@ -26,13 +26,23 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 jobs:
   trigger-conformance:
     runs-on: ubuntu-latest
-    # Only run on PR comments (not issue comments) containing @conformance
+    # Only run on PR comments from org members/collaborators starting with @conformance
     if: |
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@conformance')
+      startsWith(github.event.comment.body, '@conformance') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     steps:
       - name: Acknowledge trigger
         env:
@@ -43,13 +53,14 @@ jobs:
             --silent
 
       - name: Checkout siros-conformance scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: sirosfoundation/siros-conformance
+          ref: main
           sparse-checkout: scripts
           path: _conformance
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -29,78 +29,12 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR'
       )
     steps:
-      - name: Acknowledge trigger
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-            -f content=rocket \
-            --silent
-
-      - name: Checkout siros-conformance scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Trigger conformance tests
+        uses: sirosfoundation/siros-conformance/.github/actions/trigger-conformance@main
         with:
-          repository: sirosfoundation/siros-conformance
-          ref: main
-          sparse-checkout: scripts
-          path: _conformance
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: '22'
-
-      - name: Parse comment
-        id: parse
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          PARSED=$(echo "$COMMENT_BODY" | node _conformance/scripts/parse-comment.mjs)
-          echo "parsed=${PARSED}" >> $GITHUB_OUTPUT
-          echo "Parsed: ${PARSED}"
-
-      - name: Dispatch conformance tests
-        env:
-          GH_TOKEN: ${{ secrets.CONFORMANCE_DISPATCH_TOKEN }}
-        run: |
-          PARSED='${{ steps.parse.outputs.parsed }}'
-          EVENTS=$(echo "$PARSED" | jq -r '.["dispatch-events"][]')
-          OVERRIDES=$(echo "$PARSED" | jq -c '.["image-overrides"]')
-          PR_NUMBER=${{ github.event.issue.number }}
-          REPO=${{ github.repository }}
-
-          for EVENT in $EVENTS; do
-            echo "Dispatching ${EVENT} with overrides=${OVERRIDES}"
-            gh api repos/sirosfoundation/siros-conformance/dispatches \
-              -f event_type="${EVENT}" \
-              -f "client_payload[target-repo]=${REPO}" \
-              -f "client_payload[target-pr]=${PR_NUMBER}" \
-              -f "client_payload[image-overrides]=${OVERRIDES}"
-          done
-
-      - name: Post status comment
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PARSED='${{ steps.parse.outputs.parsed }}'
-          PROFILES=$(echo "$PARSED" | jq -r '.profiles | join(", ")')
-          OVERRIDES=$(echo "$PARSED" | jq -r '
-            .["image-overrides"] |
-            to_entries |
-            if length == 0 then "none (using :latest)"
-            else map("\(.key):\(.value)") | join(", ")
-            end
-          ')
-          RUN_URL="${{ github.server_url }}/sirosfoundation/siros-conformance/actions"
-
-          BODY="🚀 **Conformance tests triggered**
-          
-          | | |
-          |---|---|
-          | **Profiles** | ${PROFILES} |
-          | **Image overrides** | ${OVERRIDES} |
-          | **Results** | [siros-conformance actions](${RUN_URL}) |
-          
-          Results will be posted here when complete."
-
-          gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
-            -f body="${BODY}"
+          comment-body: ${{ github.event.comment.body }}
+          dispatch-token: ${{ secrets.CONFORMANCE_DISPATCH_TOKEN }}
+          github-token: ${{ github.token }}
+          repo: ${{ github.repository }}
+          pr-number: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}


### PR DESCRIPTION
Replace the inline conformance workflow (~80 lines of shell logic) with the centralised [`trigger-conformance` composite action](https://github.com/sirosfoundation/siros-conformance/tree/main/.github/actions/trigger-conformance).

**What changes:**
- Inline parsing, dispatch, and status comment logic → single `uses:` call
- Adds variant-filter support (`@conformance wallet/mdoc`)
- Fixes GITHUB_OUTPUT injection vulnerability (heredoc delimiter)
- Future updates to the action auto-propagate — no workflow file changes needed