### PR TITLE
fix: inline logos in credential_metadata.display

### DIFF
--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -796,6 +796,16 @@ func (h *AuthZENProxyHandler) inlineLogos(ctx context.Context, metadata map[stri
 					}
 				}
 			}
+			// Inline logos in credential_metadata.display (merged VCTM)
+			if credMeta, ok := cc["credential_metadata"].(map[string]interface{}); ok {
+				if display, ok := credMeta["display"].([]interface{}); ok {
+					for _, d := range display {
+						if dm, ok := d.(map[string]interface{}); ok {
+							h.inlineLogoField(ctx, dm)
+						}
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
We want to inline these logos as well. The existing implementation didn't go all the way down here
