### PR TITLE
feat: forward credential_types through AuthZEN proxy /v1/resolve endpoint

### DIFF
--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -406,6 +406,17 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 		},
 	}
 
+	// Attach credential_types as action.parameters so they reach the PDP
+	// on all code paths (proxy fallback, key subjects, URL resolution).
+	if len(req.CredentialTypes) > 0 {
+		evalReq.Action = &gotrust.Action{
+			Name: resourceType,
+			Parameters: map[string]interface{}{
+				"credential_types": req.CredentialTypes,
+			},
+		}
+	}
+
 	// Authorize the query
 	authzReq := &authz.AuthorizationRequest{
 		TenantID: tenantID,

--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -355,9 +355,10 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 
 	// Parse the resolve request
 	var req struct {
-		SubjectID    string `json:"subject_id" binding:"required"`
-		SubjectType  string `json:"subject_type"`  // "key" (default) or "url"
-		ResourceType string `json:"resource_type"` // e.g. "credential_issuer" (default for url subjects)
+		SubjectID       string   `json:"subject_id" binding:"required"`
+		SubjectType     string   `json:"subject_type"`     // "key" (default) or "url"
+		ResourceType    string   `json:"resource_type"`    // e.g. "credential_issuer" (default for url subjects)
+		CredentialTypes []string `json:"credential_types"` // optional credential type filter (e.g. VCT values)
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -428,7 +429,7 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 		case "oauth-authorization-server":
 			h.resolveAuthorizationServerMetadata(c, ctx, tenantID, req.SubjectID)
 		default:
-			h.resolveURLSubject(c, ctx, tenantID, req.SubjectID)
+			h.resolveURLSubject(c, ctx, tenantID, req.SubjectID, req.CredentialTypes)
 		}
 		return
 	}
@@ -444,7 +445,7 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 //   - metadata is signed AND the PDP returns trusted
 //
 // If metadata is signed but untrusted, an error is returned.
-func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Context, tenantID, issuerURL string) {
+func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Context, tenantID, issuerURL string, credentialTypes []string) {
 	// Step 1: Resolve issuer metadata locally
 	result, err := h.metadataResolver.ResolveWithInfo(ctx, issuerURL)
 	if err != nil {
@@ -503,6 +504,13 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 	// Build trust evaluation request with key material.
 	// Action is set to "credential-issuer" so PDP policy can distinguish
 	// issuer trust evaluation from verifier or general resolution requests.
+	action := &gotrust.Action{Name: "credential-issuer"}
+	if len(credentialTypes) > 0 {
+		action.Parameters = map[string]interface{}{
+			"credential_types": credentialTypes,
+		}
+	}
+
 	trustReq := &gotrust.EvaluationRequest{
 		Subject: gotrust.Subject{
 			Type: "key",
@@ -511,7 +519,7 @@ func (h *AuthZENProxyHandler) resolveURLSubject(c *gin.Context, ctx context.Cont
 		Resource: gotrust.Resource{
 			ID: issuerURL,
 		},
-		Action: &gotrust.Action{Name: "credential-issuer"},
+		Action: action,
 	}
 
 	if keyMaterial != nil {

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -1802,3 +1802,187 @@ func TestResolve_URLSubject_RegisteredIssuerInfo_OmittedWhenNotFound(t *testing.
 		t.Errorf("expected registered_issuer to be absent, got: %v", resp["registered_issuer"])
 	}
 }
+
+func TestResolve_URLSubject_CredentialTypes_ForwardedToPDP(t *testing.T) {
+	// Verify that credential_types from the resolve request are forwarded
+	// to the PDP as action.parameters.credential_types.
+	var receivedReq gotrust.EvaluationRequest
+
+	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedReq); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Return a response with credential_type_trust_marks in reason
+		resp := gotrust.EvaluationResponse{
+			Decision: true,
+			Context: &gotrust.EvaluationResponseContext{
+				Reason: map[string]interface{}{
+					"credential_types": []interface{}{"eu.europa.ec.eudi.pid.1"},
+					"credential_type_trust_marks": map[string]interface{}{
+						"eu.europa.ec.eudi.pid.1": []interface{}{"http://registry.example.com/tm/pid"},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	})
+
+	pdpServer := httptest.NewServer(pdpHandler)
+	defer pdpServer.Close()
+
+	metadata := map[string]interface{}{
+		"credential_issuer":   "https://issuer.example.com",
+		"credential_endpoint": "https://issuer.example.com/credential",
+		"jwks": map[string]interface{}{
+			"keys": []interface{}{
+				map[string]interface{}{
+					"kty": "EC",
+					"crv": "P-256",
+					"x":   "test-x",
+					"y":   "test-y",
+				},
+			},
+		},
+	}
+
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{Metadata: metadata},
+	}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Set("user_id", "test-user")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"subject_id":       "https://issuer.example.com",
+		"subject_type":     "url",
+		"credential_types": []string{"eu.europa.ec.eudi.pid.1"},
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	// Verify credential_types were forwarded to PDP in action.parameters
+	if receivedReq.Action == nil {
+		t.Fatal("expected action to be set in PDP request")
+	}
+	if receivedReq.Action.Name != "credential-issuer" {
+		t.Errorf("expected action.name='credential-issuer', got '%s'", receivedReq.Action.Name)
+	}
+	if receivedReq.Action.Parameters == nil {
+		t.Fatal("expected action.parameters to be set")
+	}
+	ct, ok := receivedReq.Action.Parameters["credential_types"]
+	if !ok {
+		t.Fatal("expected credential_types in action.parameters")
+	}
+	ctSlice, ok := ct.([]interface{})
+	if !ok {
+		t.Fatalf("expected credential_types to be a slice, got %T", ct)
+	}
+	if len(ctSlice) != 1 || ctSlice[0] != "eu.europa.ec.eudi.pid.1" {
+		t.Errorf("unexpected credential_types: %v", ctSlice)
+	}
+
+	// Verify credential_type_trust_marks is returned in response
+	var resp gotrust.EvaluationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Context == nil || resp.Context.Reason == nil {
+		t.Fatal("expected context.reason in response")
+	}
+	if _, ok := resp.Context.Reason["credential_type_trust_marks"]; !ok {
+		t.Error("expected credential_type_trust_marks in response reason")
+	}
+}
+
+func TestResolve_URLSubject_NoCredentialTypes_OmitsParameters(t *testing.T) {
+	// When credential_types is not provided, action.parameters should be nil.
+	var receivedReq gotrust.EvaluationRequest
+
+	pdpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedReq) //nolint:errcheck
+		resp := gotrust.EvaluationResponse{Decision: true}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	})
+
+	pdpServer := httptest.NewServer(pdpHandler)
+	defer pdpServer.Close()
+
+	metadata := map[string]interface{}{
+		"credential_issuer":   "https://issuer.example.com",
+		"credential_endpoint": "https://issuer.example.com/credential",
+		"jwks": map[string]interface{}{
+			"keys": []interface{}{
+				map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "test-x", "y": "test-y"},
+			},
+		},
+	}
+
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{Metadata: metadata},
+	}
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		PDPURL:          pdpServer.URL,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, http.DefaultClient, http.DefaultClient, logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Set("user_id", "test-user")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"subject_id":   "https://issuer.example.com",
+		"subject_type": "url",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	// Verify action.parameters is nil when no credential_types provided
+	if receivedReq.Action == nil {
+		t.Fatal("expected action to be set")
+	}
+	if receivedReq.Action.Parameters != nil {
+		t.Errorf("expected nil action.parameters when no credential_types, got: %v", receivedReq.Action.Parameters)
+	}
+}


### PR DESCRIPTION
Accept optional `credential_types` array in the `/v1/resolve` request body. When provided, credential types are forwarded to the upstream PDP as `action.parameters.credential_types` per the go-trust AuthZEN profile.

## What changed

The `/v1/resolve` endpoint now accepts:
```json
{
  "subject_id": "https://issuer.example.com",
  "subject_type": "url",
  "credential_types": ["eu.europa.ec.eudi.pid.1"]
}
```

When `credential_types` is provided, the PDP request includes:
```json
{
  "action": {
    "name": "credential-issuer",
    "parameters": {
      "credential_types": ["eu.europa.ec.eudi.pid.1"]
    }
  }
}
```

The PDP response's `context.reason` (which may contain `credential_type_trust_marks` mapping) was already forwarded to the frontend — no changes needed on the response path.

When `credential_types` is not provided, `action.parameters` is omitted (backward compatible).

## Tests
- `TestResolve_URLSubject_CredentialTypes_ForwardedToPDP`: verifies credential_types are forwarded in action.parameters and credential_type_trust_marks is returned in response
- `TestResolve_URLSubject_NoCredentialTypes_OmitsParameters`: verifies parameters are omitted when no credential_types provided

Closes #74