### PR TITLE
fix: allow credential_issuer resource_type for DID key subjects

### DIFF
--- a/pkg/authz/spocp_authorizer.go
+++ b/pkg/authz/spocp_authorizer.go
@@ -206,13 +206,17 @@ func DefaultWalletRules() []sexp.Element {
 			),
 		),
 
-		// Rule 2: Allow resolution-only requests for DIDs
-		// (authzen (tenant)(action)(resource (type resolution)(id))(subject (type key)(id did:*)))
+		// Rule 2: Allow resolution and issuer metadata requests for DIDs
+		// (authzen (tenant)(action)(resource (type <resolution|credential_issuer|credential_offer_uri>)(id))(subject (type key)(id did:*)))
 		sexp.NewList("authzen",
 			sexp.NewList("tenant"),
 			sexp.NewList("action"), // empty action = resolution
 			sexp.NewList("resource",
-				sexp.NewList("type", sexp.NewAtom("resolution")),
+				sexp.NewList("type", &starform.Set{Elements: []sexp.Element{
+					sexp.NewAtom("resolution"),
+					sexp.NewAtom("credential_issuer"),
+					sexp.NewAtom("credential_offer_uri"),
+				}}),
 				sexp.NewList("id"),
 			),
 			sexp.NewList("subject",
@@ -318,12 +322,16 @@ func ProductionWalletRules() []sexp.Element {
 			),
 		),
 
-		// Allow DID resolution only (HTTPS only in production)
+		// Allow DID resolution and issuer metadata (did:web: only in production)
 		sexp.NewList("authzen",
 			sexp.NewList("tenant"),
 			sexp.NewList("action"),
 			sexp.NewList("resource",
-				sexp.NewList("type", sexp.NewAtom("resolution")),
+				sexp.NewList("type", &starform.Set{Elements: []sexp.Element{
+					sexp.NewAtom("resolution"),
+					sexp.NewAtom("credential_issuer"),
+					sexp.NewAtom("credential_offer_uri"),
+				}}),
 				sexp.NewList("id"),
 			),
 			sexp.NewList("subject",

--- a/pkg/authz/spocp_authorizer.go
+++ b/pkg/authz/spocp_authorizer.go
@@ -210,7 +210,7 @@ func DefaultWalletRules() []sexp.Element {
 		// (authzen (tenant)(action)(resource (type <resolution|credential_issuer|credential_offer_uri>)(id))(subject (type key)(id did:*)))
 		sexp.NewList("authzen",
 			sexp.NewList("tenant"),
-			sexp.NewList("action"), // empty action = resolution
+			sexp.NewList("action"), // any action (empty = match all)
 			sexp.NewList("resource",
 				sexp.NewList("type", &starform.Set{Elements: []sexp.Element{
 					sexp.NewAtom("resolution"),

--- a/pkg/authz/spocp_authorizer_test.go
+++ b/pkg/authz/spocp_authorizer_test.go
@@ -91,6 +91,51 @@ func TestSPOCPAuthorizer_DefaultRules(t *testing.T) {
 			shouldPass: true,
 		},
 		{
+			name:     "credential_issuer for DID key subject",
+			tenantID: "default",
+			request: &gotrust.EvaluationRequest{
+				Subject: gotrust.Subject{
+					Type: "key",
+					ID:   "did:web:dev-i4mlab.aegean.gr:rfc-issuer",
+				},
+				Resource: gotrust.Resource{
+					Type: "credential_issuer",
+					ID:   "did:web:dev-i4mlab.aegean.gr:rfc-issuer",
+				},
+			},
+			shouldPass: true,
+		},
+		{
+			name:     "credential_offer_uri for DID key subject",
+			tenantID: "default",
+			request: &gotrust.EvaluationRequest{
+				Subject: gotrust.Subject{
+					Type: "key",
+					ID:   "did:web:example.com:issuer",
+				},
+				Resource: gotrust.Resource{
+					Type: "credential_offer_uri",
+					ID:   "did:web:example.com:issuer",
+				},
+			},
+			shouldPass: true,
+		},
+		{
+			name:     "credential_issuer rejected for non-DID key subject",
+			tenantID: "default",
+			request: &gotrust.EvaluationRequest{
+				Subject: gotrust.Subject{
+					Type: "key",
+					ID:   "not-a-did:example.com",
+				},
+				Resource: gotrust.Resource{
+					Type: "credential_issuer",
+					ID:   "not-a-did:example.com",
+				},
+			},
+			shouldPass: false,
+		},
+		{
 			name:     "issuer metadata resolution (url type)",
 			tenantID: "default",
 			request: &gotrust.EvaluationRequest{

--- a/pkg/authz/spocp_authorizer_test.go
+++ b/pkg/authz/spocp_authorizer_test.go
@@ -10,6 +10,14 @@ import (
 	"go.uber.org/zap"
 )
 
+// didKeyReq creates an EvaluationRequest for a DID key subject with the given resource type.
+func didKeyReq(id, resourceType string) *gotrust.EvaluationRequest {
+	return &gotrust.EvaluationRequest{
+		Subject:  gotrust.Subject{Type: "key", ID: id},
+		Resource: gotrust.Resource{Type: resourceType, ID: id},
+	}
+}
+
 func TestSPOCPAuthorizer_DefaultRules(t *testing.T) {
 	logger := zap.NewNop()
 
@@ -90,51 +98,10 @@ func TestSPOCPAuthorizer_DefaultRules(t *testing.T) {
 			},
 			shouldPass: true,
 		},
-		{
-			name:     "credential_issuer for DID key subject",
-			tenantID: "default",
-			request: &gotrust.EvaluationRequest{
-				Subject: gotrust.Subject{
-					Type: "key",
-					ID:   "did:web:dev-i4mlab.aegean.gr:rfc-issuer",
-				},
-				Resource: gotrust.Resource{
-					Type: "credential_issuer",
-					ID:   "did:web:dev-i4mlab.aegean.gr:rfc-issuer",
-				},
-			},
-			shouldPass: true,
-		},
-		{
-			name:     "credential_offer_uri for DID key subject",
-			tenantID: "default",
-			request: &gotrust.EvaluationRequest{
-				Subject: gotrust.Subject{
-					Type: "key",
-					ID:   "did:web:example.com:issuer",
-				},
-				Resource: gotrust.Resource{
-					Type: "credential_offer_uri",
-					ID:   "did:web:example.com:issuer",
-				},
-			},
-			shouldPass: true,
-		},
-		{
-			name:     "credential_issuer rejected for non-DID key subject",
-			tenantID: "default",
-			request: &gotrust.EvaluationRequest{
-				Subject: gotrust.Subject{
-					Type: "key",
-					ID:   "not-a-did:example.com",
-				},
-				Resource: gotrust.Resource{
-					Type: "credential_issuer",
-					ID:   "not-a-did:example.com",
-				},
-			},
-			shouldPass: false,
-		},
+		// DID subject + credential_issuer/credential_offer_uri combinations (Rule 2)
+		{name: "credential_issuer for DID", tenantID: "default", shouldPass: true, request: didKeyReq("did:web:dev-i4mlab.aegean.gr:rfc-issuer", "credential_issuer")},
+		{name: "credential_offer_uri for DID", tenantID: "default", shouldPass: true, request: didKeyReq("did:web:example.com:issuer", "credential_offer_uri")},
+		{name: "credential_issuer rejected for non-DID", tenantID: "default", shouldPass: false, request: didKeyReq("not-a-did:example.com", "credential_issuer")},
 		{
 			name:     "issuer metadata resolution (url type)",
 			tenantID: "default",


### PR DESCRIPTION
## Problem

When a wallet sends a resolve request with `resource_type=credential_issuer` and a `did:web:` subject (using `subject_type=key`), the SPOCP authorization rejects it because no rule matches that combination.

The existing rules only allow:
- `subject_type=key` + `resource_type=resolution` (Rule 2, for DID resolution)
- `subject_type=url` + `resource_type=credential_issuer` (Rule 5, for URL-based issuers)

This blocks the did:web client_id scheme where the credential issuer identifier is a DID.

## Fix

Expand Rule 2 (DefaultWalletRules) and the production DID rule (ProductionWalletRules) to accept `credential_issuer` and `credential_offer_uri` alongside `resolution` for DID subjects, using `starform.Set`.

## Companion PR

Requires wwWallet/wallet-common fix to auto-detect `subject_type=key` for DID identifiers (instead of hardcoding `url`).
