### PR TITLE
fix: preserve trailing slash in WellKnownURL per RFC 8615

### DIFF
--- a/pkg/oidc/wellknown.go
+++ b/pkg/oidc/wellknown.go
@@ -3,7 +3,6 @@ package oidc
 import (
 	"fmt"
 	"net/url"
-	"strings"
 )
 
 // WellKnownURL constructs a well-known URI per RFC 8615.
@@ -14,16 +13,15 @@ import (
 //	https://example.com/.well-known/openid-credential-issuer/path/to/issuer
 //
 // The function preserves percent-encoded path segments (uses EscapedPath)
-// and strips any trailing slash from the path per OID4VCI §12.2.1 (the
-// Credential Issuer Identifier must not contain query or fragment components
-// and trailing slashes are not part of the canonical identifier).
+// and preserves any trailing slash from the issuer identifier path so the
+// well-known URL exactly matches what the issuer expects.
 func WellKnownURL(baseURL, suffix string) (string, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
 		return "", fmt.Errorf("parsing base URL: %w", err)
 	}
 
-	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	path := parsed.EscapedPath()
 
 	return fmt.Sprintf("%s://%s/.well-known/%s%s", parsed.Scheme, parsed.Host, suffix, path), nil
 }

--- a/pkg/oidc/wellknown_test.go
+++ b/pkg/oidc/wellknown_test.go
@@ -23,10 +23,10 @@ func TestWellKnownURL(t *testing.T) {
 			want:    "https://example.com/.well-known/openid-credential-issuer/test/a/alias",
 		},
 		{
-			name:    "trailing slash stripped",
+			name:    "trailing slash preserved",
 			baseURL: "https://example.com/issuer/",
 			suffix:  "openid-credential-issuer",
-			want:    "https://example.com/.well-known/openid-credential-issuer/issuer",
+			want:    "https://example.com/.well-known/openid-credential-issuer/issuer/",
 		},
 		{
 			name:    "oauth authorization server",


### PR DESCRIPTION
Closes #213

## Problem

`WellKnownURL()` stripped trailing slashes from the issuer identifier path via `strings.TrimRight(path, "/")`. Per RFC 8615, the well-known URI must use the exact path from the identifier. External issuers (e.g. the OIDF Conformance Suite) include trailing slashes in their `credential_issuer` identifier, causing metadata discovery to fail.

## Fix

- Remove `strings.TrimRight(path, "/")` — preserve the path exactly as provided
- Remove unused `strings` import
- Update test to expect trailing slash preserved

## Testing

- Unit tests pass (`go test ./pkg/oidc/...`)
- Verified with OIDF VCI conformance suite: all 3 modules pass (2 PASSED + 1 SKIPPED)

## Note

Our own issuer identifiers never include trailing slashes. This fix only affects interop with external issuers that do.