### PR TITLE
feat: KA claims enrichment with SecurityProperties

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -629,6 +629,25 @@ func (h *Handlers) GetCertificate(c *gin.Context) {
 	c.JSON(200, resp)
 }
 
+// SecurityPropertiesRequest carries WSCD security metadata from native SDKs.
+// When provided, these values are included in the KA JWT per CS-04 §7.1.3.
+type SecurityPropertiesRequest struct {
+	KeyStorage         string   `json:"key_storage"`
+	UserAuthentication []string `json:"user_authentication"`
+	Certification      string   `json:"certification"`
+}
+
+func (s *SecurityPropertiesRequest) toService() *service.SecurityProperties {
+	if s == nil {
+		return nil
+	}
+	return &service.SecurityProperties{
+		KeyStorage:         s.KeyStorage,
+		UserAuthentication: s.UserAuthentication,
+		Certification:      s.Certification,
+	}
+}
+
 // GenerateKeyAttestation generates a key attestation JWT
 func (h *Handlers) GenerateKeyAttestation(c *gin.Context) {
 	var req struct {
@@ -636,6 +655,7 @@ func (h *Handlers) GenerateKeyAttestation(c *gin.Context) {
 		OpenID4VCI struct {
 			Nonce string `json:"nonce"`
 		} `json:"openid4vci"`
+		SecurityProperties *SecurityPropertiesRequest `json:"security_properties,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{
@@ -661,7 +681,7 @@ func (h *Handlers) GenerateKeyAttestation(c *gin.Context) {
 		return
 	}
 
-	keyAttestation, err := h.services.WalletProvider.GenerateKeyAttestation(c.Request.Context(), req.JWKS, req.OpenID4VCI.Nonce)
+	keyAttestation, err := h.services.WalletProvider.GenerateKeyAttestation(c.Request.Context(), req.JWKS, req.OpenID4VCI.Nonce, req.SecurityProperties.toService())
 	if err != nil {
 		h.logger.Error("Failed to generate key attestation", zap.Error(err))
 		c.JSON(400, gin.H{

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -673,6 +673,24 @@ func (h *Handlers) GenerateKeyAttestation(c *gin.Context) {
 		return
 	}
 
+	// Validate that each JWK entry is non-nil and contains required fields
+	for i, jwk := range req.JWKS {
+		if jwk == nil {
+			c.JSON(400, gin.H{
+				"error":   "INVALID_JWKS",
+				"message": fmt.Sprintf("jwks[%d] is null", i),
+			})
+			return
+		}
+		if _, ok := jwk["kty"]; !ok {
+			c.JSON(400, gin.H{
+				"error":   "INVALID_JWKS",
+				"message": fmt.Sprintf("jwks[%d] is missing 'kty' field", i),
+			})
+			return
+		}
+	}
+
 	if req.OpenID4VCI.Nonce == "" {
 		c.JSON(400, gin.H{
 			"error":   "INVALID_OPENID4VCI_NONCE_VALUE",

--- a/internal/service/wallet_provider.go
+++ b/internal/service/wallet_provider.go
@@ -124,29 +124,35 @@ func (s *WalletProviderService) GenerateKeyAttestation(ctx context.Context, jwks
 		return "", ErrKeyAttestationNotSupported
 	}
 
-	// Enrich each key with security properties if provided
-	if secProps != nil {
-		for i := range jwks {
+	// Enrich each key with security properties if provided.
+	// Clone each JWK map to avoid mutating the caller's data.
+	enriched := make([]map[string]interface{}, len(jwks))
+	for i, jwk := range jwks {
+		clone := make(map[string]interface{}, len(jwk)+3)
+		for k, v := range jwk {
+			clone[k] = v
+		}
+		if secProps != nil {
 			if secProps.KeyStorage != "" {
-				jwks[i]["key_storage"] = secProps.KeyStorage
+				clone["key_storage"] = secProps.KeyStorage
 			}
 			if len(secProps.UserAuthentication) > 0 {
-				jwks[i]["user_authentication"] = secProps.UserAuthentication
+				clone["user_authentication"] = secProps.UserAuthentication
 			}
 			if secProps.Certification != "" {
-				jwks[i]["certification"] = secProps.Certification
+				clone["certification"] = secProps.Certification
 			}
 		}
+		enriched[i] = clone
 	}
 
 	// Create the JWT claims
 	now := time.Now()
 	claims := jwt.MapClaims{
-		"attested_keys":      jwks,
-		"key_storage_status": map[string]interface{}{},
-		"nonce":              nonce,
-		"iat":                now.Unix(),
-		"exp":                now.Add(15 * time.Second).Unix(),
+		"attested_keys": enriched,
+		"nonce":         nonce,
+		"iat":           now.Unix(),
+		"exp":           now.Add(15 * time.Second).Unix(),
 	}
 
 	// Create the token with ES256 and x5c header

--- a/internal/service/wallet_provider.go
+++ b/internal/service/wallet_provider.go
@@ -111,19 +111,42 @@ func (s *WalletProviderService) IsSupported() bool {
 	return s.privateKey != nil && len(s.certChain) > 0
 }
 
+// SecurityProperties carries WSCD-reported security metadata for KA claims.
+type SecurityProperties struct {
+	KeyStorage         string   `json:"key_storage"`
+	UserAuthentication []string `json:"user_authentication"`
+	Certification      string   `json:"certification"`
+}
+
 // GenerateKeyAttestation generates a key attestation JWT
-func (s *WalletProviderService) GenerateKeyAttestation(ctx context.Context, jwks []map[string]interface{}, nonce string) (string, error) {
+func (s *WalletProviderService) GenerateKeyAttestation(ctx context.Context, jwks []map[string]interface{}, nonce string, secProps *SecurityProperties) (string, error) {
 	if !s.IsSupported() {
 		return "", ErrKeyAttestationNotSupported
+	}
+
+	// Enrich each key with security properties if provided
+	if secProps != nil {
+		for i := range jwks {
+			if secProps.KeyStorage != "" {
+				jwks[i]["key_storage"] = secProps.KeyStorage
+			}
+			if len(secProps.UserAuthentication) > 0 {
+				jwks[i]["user_authentication"] = secProps.UserAuthentication
+			}
+			if secProps.Certification != "" {
+				jwks[i]["certification"] = secProps.Certification
+			}
+		}
 	}
 
 	// Create the JWT claims
 	now := time.Now()
 	claims := jwt.MapClaims{
-		"attested_keys": jwks,
-		"nonce":         nonce,
-		"iat":           now.Unix(),
-		"exp":           now.Add(15 * time.Second).Unix(),
+		"attested_keys":      jwks,
+		"key_storage_status": map[string]interface{}{},
+		"nonce":              nonce,
+		"iat":                now.Unix(),
+		"exp":                now.Add(15 * time.Second).Unix(),
 	}
 
 	// Create the token with ES256 and x5c header


### PR DESCRIPTION
## Phase B: Key Attestation Claims Enrichment

Enriches the Key Attestation (KA) JWT with WSCD security properties:

- `SecurityProperties` struct: `KeyStorageType`, `UserAuthentication`, `CertificationLevel`
- `GenerateKeyAttestation` accepts optional `*SecurityProperties`
- KA JWT now includes per-key `key_storage`, `user_authentication`, `certification` claims
- Handler bridges `SecurityPropertiesRequest` → service-layer `SecurityProperties`

Part of the WSCD/WSCA Native SDK implementation plan.

All existing KA tests pass.