### PR TITLE
feat: relay transaction_data from OID4VP to sign_request (TS12)

### DIFF
--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -264,6 +264,9 @@ type SignRequestParams struct {
 	// verifier's encryption key (for direct_post.jwt). Empty for other response modes.
 	// The frontend uses this to build the OID4VP 1.0 OpenID4VPHandover session transcript.
 	VerifierJwkThumbprint string `json:"verifier_jwk_thumbprint,omitempty"`
+	// TransactionData carries TS12 transaction data from the verifier's OID4VP request.
+	// The frontend must hash each item and include transaction_data_hashes in the KB-JWT.
+	TransactionData []TransactionData `json:"transaction_data,omitempty"`
 }
 
 // CredentialRef references a credential for signing

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -56,6 +56,16 @@ const (
 	ClientIDSchemeVerifierAttestation = "verifier_attestation"
 )
 
+// TransactionData represents a single transaction data object from
+// the verifier's OID4VP authorization request (TS12/SCA per OID4VP draft §7.4).
+type TransactionData struct {
+	Type                     string                 `json:"type"`
+	Params                   map[string]interface{} `json:"params,omitempty"`
+	CredentialIDs            []string               `json:"credential_ids,omitempty"`
+	HashAlgorithm            string                 `json:"hash_alg,omitempty"`
+	TransactionDataHashesAlg string                 `json:"transaction_data_hashes_alg,omitempty"`
+}
+
 // AuthorizationRequest represents an OpenID4VP authorization request
 type AuthorizationRequest struct {
 	ResponseType      string          `json:"response_type"`
@@ -70,6 +80,8 @@ type AuthorizationRequest struct {
 	DCQLQuery         json.RawMessage `json:"dcql_query,omitempty"`
 	ClientMetadata    *ClientMetadata `json:"client_metadata,omitempty"`
 	ClientMetadataURI string          `json:"client_metadata_uri,omitempty"`
+	// TransactionData carries TS12 transaction data from the verifier (OID4VP draft §7.4).
+	TransactionData []TransactionData `json:"transaction_data,omitempty"`
 	// RequestJWT stores the raw request JWT (if the request was JWT-secured).
 	// Used to extract x5c/jwk key material from the JWT header for trust evaluation.
 	RequestJWT string `json:"-"`
@@ -776,6 +788,7 @@ func (h *OID4VPHandler) requestVPSignature(ctx context.Context, authReq *Authori
 		CredentialsToInclude:  credRefs,
 		ResponseURI:           responseURI,
 		VerifierJwkThumbprint: verifierJwkThumbprint,
+		TransactionData:       authReq.TransactionData,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary

Relays the verifier's `transaction_data` array from the OID4VP authorization request through to the frontend's sign request message. The frontend/SDK can then hash each item and include `transaction_data_hashes` + `transaction_data_hashes_alg` in the KB-JWT.

## EUDI Compliance

Phase I step I8 — TS12 payment SCA requires that transaction data from the verifier is bound into the holder's key binding proof.

## Changes

- New `TransactionData` struct in `oid4vp.go` (type, params, credential_ids, hash_alg)
- `AuthorizationRequest.TransactionData` field — parsed from verifier JWT
- `SignRequestParams.TransactionData` field — relayed to frontend sign request
- OID4VP handler passes `authReq.TransactionData` into the sign request

## Related

- sirosfoundation/go-wmp#7 (WMP protocol extension)
- sirosfoundation/wmp-js#8 (TypeScript client)
- sirosfoundation/security#20 (implementation plan)