### PR TITLE
feat: implement OID4VCI credential notification (§10)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -216,7 +216,12 @@ func main() {
 		if backendProvider != nil {
 			issuerLookup = backendProvider.Store().Issuers()
 		}
-		provider, err := server.NewEngineProvider(backendCfg, logger, verifierStore, sharedResolver, issuerLookup)
+		// Share credential store for notification forwarding
+		var credStore storage.CredentialStore
+		if backendProvider != nil {
+			credStore = backendProvider.Store().Credentials()
+		}
+		provider, err := server.NewEngineProvider(backendCfg, logger, verifierStore, credStore, sharedResolver, issuerLookup)
 		if err != nil {
 			logger.Fatal("Failed to create engine provider", zap.Error(err))
 		}

--- a/internal/domain/credential.go
+++ b/internal/domain/credential.go
@@ -27,6 +27,8 @@ type VerifiableCredential struct {
 	CredentialIssuerIdentifier string           `json:"credentialIssuerIdentifier" bson:"credential_issuer_identifier" gorm:"not null"`
 	InstanceID                 int              `json:"instanceId" bson:"instance_id" gorm:"default:0"`
 	SigCount                   int              `json:"sigCount" bson:"sig_count" gorm:"default:0"`
+	NotificationID             string           `json:"notificationId,omitempty" bson:"notification_id,omitempty" gorm:"default:''"`
+	NotificationEndpoint       string           `json:"notificationEndpoint,omitempty" bson:"notification_endpoint,omitempty" gorm:"default:''"`
 	CreatedAt                  time.Time        `json:"createdAt,omitempty" bson:"created_at" gorm:"autoCreateTime"`
 	UpdatedAt                  time.Time        `json:"updatedAt,omitempty" bson:"updated_at" gorm:"autoUpdateTime"`
 }
@@ -45,6 +47,8 @@ type StoreCredentialRequest struct {
 	CredentialConfigurationID  string           `json:"credentialConfigurationId"`
 	CredentialIssuerIdentifier string           `json:"credentialIssuerIdentifier"`
 	InstanceID                 int              `json:"instanceId"`
+	NotificationID             string           `json:"notificationId,omitempty"`
+	NotificationEndpoint       string           `json:"notificationEndpoint,omitempty"`
 }
 
 // UpdateCredentialRequest represents a request to update a credential

--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -25,11 +25,12 @@ type MessageType string
 
 const (
 	// Client → Server
-	TypeHandshake     MessageType = "handshake"
-	TypeFlowStart     MessageType = "flow_start"
-	TypeFlowAction    MessageType = "flow_action"
-	TypeSignResponse  MessageType = "sign_response"
-	TypeMatchResponse MessageType = "match_response"
+	TypeHandshake              MessageType = "handshake"
+	TypeFlowStart              MessageType = "flow_start"
+	TypeFlowAction             MessageType = "flow_action"
+	TypeSignResponse           MessageType = "sign_response"
+	TypeMatchResponse          MessageType = "match_response"
+	TypeCredentialNotification MessageType = "credential_notification"
 
 	// Server → Client
 	TypeHandshakeComplete MessageType = "handshake_complete"
@@ -325,15 +326,28 @@ type ErrorMessage struct {
 
 // CredentialResult represents an issued credential
 type CredentialResult struct {
-	Format       string          `json:"format"`
-	Credential   string          `json:"credential"`
-	VCT          string          `json:"vct,omitempty"`
-	TypeMetadata json.RawMessage `json:"type_metadata,omitempty"`
+	Format               string          `json:"format"`
+	Credential           string          `json:"credential"`
+	VCT                  string          `json:"vct,omitempty"`
+	TypeMetadata         json.RawMessage `json:"type_metadata,omitempty"`
+	NotificationID       string          `json:"notification_id,omitempty"`
+	NotificationEndpoint string          `json:"notification_endpoint,omitempty"`
 }
 
 // TrustInfo contains trust evaluation results.
 // Deprecated: Use trust.TrustInfo directly when writing new code.
 type TrustInfo = trust.TrustInfo
+
+// CredentialNotificationMessage is sent by the client to request a credential
+// lifecycle notification be sent to the issuer (OID4VCI §10).
+// Used for credential_deleted and credential_failure events; credential_accepted
+// is sent automatically by the backend after successful issuance.
+type CredentialNotificationMessage struct {
+	Message
+	CredentialIdentifier string `json:"credential_identifier"`
+	Event                string `json:"event"`
+	EventDescription     string `json:"event_description,omitempty"`
+}
 
 // VerifierInfo contains verifier metadata
 type VerifierInfo struct {

--- a/internal/engine/notification_test.go
+++ b/internal/engine/notification_test.go
@@ -1,0 +1,276 @@
+package engine
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
+	"github.com/sirosfoundation/go-wallet-backend/internal/storage/memory"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+)
+
+func TestSendNotification_Success(t *testing.T) {
+	var received atomic.Value
+
+	// Mock issuer notification endpoint
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req notificationRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		received.Store(req)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	logger := zap.NewNop()
+	h := &OID4VCIHandler{
+		BaseHandler: BaseHandler{Logger: logger},
+		httpClient:  srv.Client(),
+	}
+
+	metadata := &IssuerMetadata{
+		NotificationEndpoint: srv.URL,
+	}
+	token := &TokenResponse{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+	}
+
+	h.sendNotification(t.Context(), metadata, token, "notif-123", NotificationEventAccepted, "")
+
+	req := received.Load().(notificationRequest)
+	assert.Equal(t, "notif-123", req.NotificationID)
+	assert.Equal(t, "credential_accepted", req.Event)
+	assert.Empty(t, req.EventDescription)
+}
+
+func TestSendNotification_WithDescription(t *testing.T) {
+	var received atomic.Value
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req notificationRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		received.Store(req)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	logger := zap.NewNop()
+	h := &OID4VCIHandler{
+		BaseHandler: BaseHandler{Logger: logger},
+		httpClient:  srv.Client(),
+	}
+
+	metadata := &IssuerMetadata{NotificationEndpoint: srv.URL}
+	token := &TokenResponse{AccessToken: "tok", TokenType: "Bearer"}
+
+	h.sendNotification(t.Context(), metadata, token, "notif-456", NotificationEventDeleted, "User removed credential")
+
+	req := received.Load().(notificationRequest)
+	assert.Equal(t, "notif-456", req.NotificationID)
+	assert.Equal(t, "credential_deleted", req.Event)
+	assert.Equal(t, "User removed credential", req.EventDescription)
+}
+
+func TestSendNotification_NoEndpoint(t *testing.T) {
+	logger := zap.NewNop()
+	h := &OID4VCIHandler{
+		BaseHandler: BaseHandler{Logger: logger},
+		httpClient:  http.DefaultClient,
+	}
+
+	// Should not panic or make any HTTP call
+	metadata := &IssuerMetadata{NotificationEndpoint: ""}
+	token := &TokenResponse{AccessToken: "tok", TokenType: "Bearer"}
+	h.sendNotification(t.Context(), metadata, token, "notif-789", NotificationEventAccepted, "")
+}
+
+func TestSendNotification_NoNotificationID(t *testing.T) {
+	logger := zap.NewNop()
+	h := &OID4VCIHandler{
+		BaseHandler: BaseHandler{Logger: logger},
+		httpClient:  http.DefaultClient,
+	}
+
+	metadata := &IssuerMetadata{NotificationEndpoint: "http://example.com/notify"}
+	token := &TokenResponse{AccessToken: "tok", TokenType: "Bearer"}
+	// Empty notification_id should be a no-op
+	h.sendNotification(t.Context(), metadata, token, "", NotificationEventAccepted, "")
+}
+
+func TestSendNotification_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	logger := zap.NewNop()
+	h := &OID4VCIHandler{
+		BaseHandler: BaseHandler{Logger: logger},
+		httpClient:  srv.Client(),
+	}
+
+	metadata := &IssuerMetadata{NotificationEndpoint: srv.URL}
+	token := &TokenResponse{AccessToken: "tok", TokenType: "Bearer"}
+
+	// Should not panic — errors are logged but not returned
+	h.sendNotification(t.Context(), metadata, token, "notif-err", NotificationEventAccepted, "")
+}
+
+func TestHandleCredentialNotification_Success(t *testing.T) {
+	var received atomic.Value
+
+	// Mock issuer notification endpoint
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req notificationRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		received.Store(req)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	logger := zap.NewNop()
+	cfg := &config.Config{
+		JWT: config.JWTConfig{Secret: "test-secret"},
+	}
+	m := NewManager(cfg, logger)
+
+	// Set up in-memory credential store
+	store := memory.NewStore()
+	m.SetCredentialStore(store.Credentials())
+
+	// Store a credential with notification info
+	cred := &domain.VerifiableCredential{
+		TenantID:                   "default",
+		HolderDID:                  "user-123",
+		CredentialIdentifier:       "cred-abc",
+		Credential:                 "jwt-here",
+		Format:                     "vc+sd-jwt",
+		CredentialConfigurationID:  "config-1",
+		CredentialIssuerIdentifier: "https://issuer.example.com",
+		NotificationID:             "notif-stored",
+		NotificationEndpoint:       srv.URL,
+	}
+	err := store.Credentials().Create(t.Context(), cred)
+	require.NoError(t, err)
+
+	// Simulate a session
+	session := &Session{
+		UserID:   "user-123",
+		TenantID: "default",
+		logger:   logger,
+	}
+
+	// Handle the notification message
+	msg := &CredentialNotificationMessage{
+		CredentialIdentifier: "cred-abc",
+		Event:                "credential_deleted",
+		EventDescription:     "User deleted credential",
+	}
+	m.handleCredentialNotification(session, msg)
+
+	req := received.Load().(notificationRequest)
+	assert.Equal(t, "notif-stored", req.NotificationID)
+	assert.Equal(t, "credential_deleted", req.Event)
+	assert.Equal(t, "User deleted credential", req.EventDescription)
+}
+
+func TestHandleCredentialNotification_InvalidEvent(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := &config.Config{
+		JWT: config.JWTConfig{Secret: "test-secret"},
+	}
+	m := NewManager(cfg, logger)
+
+	session := &Session{
+		UserID:   "user-123",
+		TenantID: "default",
+		logger:   logger,
+	}
+
+	msg := &CredentialNotificationMessage{
+		CredentialIdentifier: "cred-abc",
+		Event:                "invalid_event",
+	}
+
+	// Should not panic
+	m.handleCredentialNotification(session, msg)
+}
+
+func TestHandleCredentialNotification_NoCredentialStore(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := &config.Config{
+		JWT: config.JWTConfig{Secret: "test-secret"},
+	}
+	m := NewManager(cfg, logger)
+
+	session := &Session{
+		UserID:   "user-123",
+		TenantID: "default",
+		logger:   logger,
+	}
+
+	msg := &CredentialNotificationMessage{
+		CredentialIdentifier: "cred-abc",
+		Event:                "credential_deleted",
+	}
+
+	// Should not panic when credentialStore is nil
+	m.handleCredentialNotification(session, msg)
+}
+
+func TestBuildCredentialResults_IncludesNotificationFields(t *testing.T) {
+	logger := zap.NewNop()
+	h := &OID4VCIHandler{
+		BaseHandler: BaseHandler{Logger: logger},
+	}
+
+	metadata := &IssuerMetadata{
+		NotificationEndpoint: "https://issuer.example.com/notify",
+	}
+	resp := &CredentialResponse{
+		Credential:     "eyJhbGciOi...",
+		NotificationID: "notif-xyz",
+	}
+	cfg := &CredentialConfig{
+		Format: "vc+sd-jwt",
+		VCT:    "https://example.com/vct/1",
+	}
+
+	results := h.buildCredentialResults(t.Context(), resp, cfg, nil, metadata)
+	require.Len(t, results, 1)
+	assert.Equal(t, "notif-xyz", results[0].NotificationID)
+	assert.Equal(t, "https://issuer.example.com/notify", results[0].NotificationEndpoint)
+	assert.Equal(t, "eyJhbGciOi...", results[0].Credential)
+	assert.Equal(t, "vc+sd-jwt", results[0].Format)
+}
+
+func TestCredentialNotificationMessage_JSONRoundtrip(t *testing.T) {
+	msg := CredentialNotificationMessage{
+		Message:              Message{Type: TypeCredentialNotification},
+		CredentialIdentifier: "cred-123",
+		Event:                "credential_deleted",
+		EventDescription:     "Removed by user",
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var parsed CredentialNotificationMessage
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, TypeCredentialNotification, parsed.Type)
+	assert.Equal(t, "cred-123", parsed.CredentialIdentifier)
+	assert.Equal(t, "credential_deleted", parsed.Event)
+	assert.Equal(t, "Removed by user", parsed.EventDescription)
+}

--- a/internal/engine/notification_test.go
+++ b/internal/engine/notification_test.go
@@ -140,7 +140,8 @@ func TestHandleCredentialNotification_Success(t *testing.T) {
 
 	logger := zap.NewNop()
 	cfg := &config.Config{
-		JWT: config.JWTConfig{Secret: "test-secret"},
+		JWT:        config.JWTConfig{Secret: "test-secret"},
+		HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: true},
 	}
 	m := NewManager(cfg, logger)
 
@@ -203,6 +204,28 @@ func TestHandleCredentialNotification_InvalidEvent(t *testing.T) {
 	}
 
 	// Should not panic
+	m.handleCredentialNotification(session, msg)
+}
+
+func TestHandleCredentialNotification_RejectsAccepted(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := &config.Config{
+		JWT: config.JWTConfig{Secret: "test-secret"},
+	}
+	m := NewManager(cfg, logger)
+
+	session := &Session{
+		UserID:   "user-123",
+		TenantID: "default",
+		logger:   logger,
+	}
+
+	msg := &CredentialNotificationMessage{
+		CredentialIdentifier: "cred-abc",
+		Event:                "credential_accepted",
+	}
+
+	// Should not panic — credential_accepted is rejected from frontend
 	m.handleCredentialNotification(session, msg)
 }
 

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -162,6 +162,8 @@ type IssuerMetadata struct {
 	AuthorizationServer               string                      `json:"authorization_server,omitempty"`
 	Display                           []IssuerDisplay             `json:"display,omitempty"`
 	CredentialConfigurationsSupported map[string]CredentialConfig `json:"credential_configurations_supported,omitempty"`
+	// Notification endpoint for credential lifecycle events (OID4VCI §10)
+	NotificationEndpoint string `json:"notification_endpoint,omitempty"`
 	// Credential response encryption configuration
 	CredentialResponseEncryption *CredentialResponseEncryptionConfig `json:"credential_response_encryption,omitempty"`
 	// Batch credential issuance configuration (OID4VCI §E.1)
@@ -719,12 +721,24 @@ func (h *OID4VCIHandler) Execute(ctx context.Context, msg *FlowStartMessage) err
 		}
 
 		// Complete with the issued credential
-		results := h.buildCredentialResults(ctx, deferredResp, selectedConfig, trust)
+		results := h.buildCredentialResults(ctx, deferredResp, selectedConfig, trust, metadata)
+
+		// Send credential_accepted notification to issuer (best-effort, OID4VCI §10)
+		if deferredResp.NotificationID != "" {
+			h.sendNotification(ctx, metadata, token, deferredResp.NotificationID, NotificationEventAccepted, "")
+		}
+
 		return h.Complete(results, "")
 	}
 
 	// Step 9: Complete with issued credential (fetch VCTM for display)
-	results := h.buildCredentialResults(ctx, credential, selectedConfig, trust)
+	results := h.buildCredentialResults(ctx, credential, selectedConfig, trust, metadata)
+
+	// Send credential_accepted notification to issuer (best-effort, OID4VCI §10)
+	if credential.NotificationID != "" {
+		h.sendNotification(ctx, metadata, token, credential.NotificationID, NotificationEventAccepted, "")
+	}
+
 	return h.Complete(results, "")
 }
 
@@ -1917,7 +1931,7 @@ func (h *OID4VCIHandler) pollDeferredCredential(ctx context.Context, metadata *I
 	return nil, fmt.Errorf("deferred credential polling timeout after %d attempts", maxAttempts)
 }
 
-func (h *OID4VCIHandler) buildCredentialResults(ctx context.Context, resp *CredentialResponse, config *CredentialConfig, trust *TrustInfo) []CredentialResult {
+func (h *OID4VCIHandler) buildCredentialResults(ctx context.Context, resp *CredentialResponse, config *CredentialConfig, trust *TrustInfo, metadata *IssuerMetadata) []CredentialResult {
 	var results []CredentialResult
 
 	// Fetch VCTM for display metadata embedding
@@ -1943,10 +1957,12 @@ func (h *OID4VCIHandler) buildCredentialResults(ctx context.Context, resp *Crede
 			credStr = string(bytes)
 		}
 		results = append(results, CredentialResult{
-			Format:       config.Format,
-			Credential:   credStr,
-			VCT:          config.VCT,
-			TypeMetadata: typeMetadata,
+			Format:               config.Format,
+			Credential:           credStr,
+			VCT:                  config.VCT,
+			TypeMetadata:         typeMetadata,
+			NotificationID:       resp.NotificationID,
+			NotificationEndpoint: metadata.NotificationEndpoint,
 		})
 	}
 
@@ -1968,12 +1984,86 @@ func (h *OID4VCIHandler) buildCredentialResults(ctx context.Context, resp *Crede
 		}
 
 		results = append(results, CredentialResult{
-			Format:       config.Format,
-			Credential:   credStr,
-			VCT:          config.VCT,
-			TypeMetadata: typeMetadata,
+			Format:               config.Format,
+			Credential:           credStr,
+			VCT:                  config.VCT,
+			TypeMetadata:         typeMetadata,
+			NotificationID:       resp.NotificationID,
+			NotificationEndpoint: metadata.NotificationEndpoint,
 		})
 	}
 
 	return results
+}
+
+// NotificationEvent represents an OID4VCI credential lifecycle event (OID4VCI §10.1).
+type NotificationEvent string
+
+const (
+	NotificationEventAccepted NotificationEvent = "credential_accepted"
+	NotificationEventFailure  NotificationEvent = "credential_failure"
+	NotificationEventDeleted  NotificationEvent = "credential_deleted"
+)
+
+// notificationRequest is the JSON body sent to the issuer's notification endpoint (OID4VCI §10.1).
+type notificationRequest struct {
+	NotificationID   string `json:"notification_id"`
+	Event            string `json:"event"`
+	EventDescription string `json:"event_description,omitempty"`
+}
+
+// sendNotification sends a credential lifecycle notification to the issuer (OID4VCI §10).
+// It is best-effort: errors are logged but do not fail the flow.
+func (h *OID4VCIHandler) sendNotification(ctx context.Context, metadata *IssuerMetadata, token *TokenResponse, notificationID string, event NotificationEvent, description string) {
+	if metadata.NotificationEndpoint == "" || notificationID == "" {
+		return
+	}
+
+	body := notificationRequest{
+		NotificationID:   notificationID,
+		Event:            string(event),
+		EventDescription: description,
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		h.Logger.Warn("failed to marshal notification request", zap.Error(err))
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, metadata.NotificationEndpoint, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		h.Logger.Warn("failed to create notification request", zap.Error(err))
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	h.setAuthorizationHeader(req, token)
+	if dpopErr := h.setDPoPHeader(req, metadata.NotificationEndpoint, token.AccessToken); dpopErr != nil {
+		h.Logger.Warn("failed to set DPoP header for notification", zap.Error(dpopErr))
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.Logger.Warn("failed to send credential notification",
+			zap.String("notification_id", notificationID),
+			zap.String("event", string(event)),
+			zap.Error(err))
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// Consume and discard body to allow connection reuse
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	h.updateDPoPNonce(resp)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		h.Logger.Warn("credential notification returned non-success status",
+			zap.String("notification_id", notificationID),
+			zap.String("event", string(event)),
+			zap.Int("status", resp.StatusCode))
+		return
+	}
+
+	h.Logger.Info("credential notification sent",
+		zap.String("notification_id", notificationID),
+		zap.String("event", string(event)))
 }

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -96,6 +96,7 @@ type Manager struct {
 	registryClient  *RegistryClient
 	verifierStore   storage.VerifierStore
 	credentialStore storage.CredentialStore
+	httpClient      *http.Client // configured HTTP client with SSRF protections
 	trustCache      *TrustCache
 
 	// Persistent session store (optional, for horizontal scaling)
@@ -120,6 +121,7 @@ func NewManager(cfg *config.Config, logger *zap.Logger) *Manager {
 		flowHandlers:   make(map[Protocol]FlowHandlerFactory),
 		trustService:   NewTrustService(cfg, logger),
 		registryClient: NewRegistryClient(cfg, logger),
+		httpClient:     cfg.HTTPClient.NewHTTPClient(0),
 		trustCache:     NewTrustCache(1 * time.Hour),
 		sessionStore:   NewMemorySessionStore(logger), // Default to memory
 	}
@@ -392,7 +394,8 @@ func (m *Manager) handleSession(session *Session) {
 				session.logger.Warn("Invalid credential_notification", zap.Error(err))
 				continue
 			}
-			go m.handleCredentialNotification(session, &notifMsg)
+			// Handle synchronously to provide natural backpressure (one at a time per session)
+			m.handleCredentialNotification(session, &notifMsg)
 
 		default:
 			session.logger.Warn("Unknown message type", zap.String("type", string(msg.Type)))
@@ -497,10 +500,14 @@ func (m *Manager) handleCredentialNotification(session *Session, msg *Credential
 		return
 	}
 
-	// Validate event type
+	// Validate event type — credential_accepted is only sent by the backend
+	// after issuance, never by the frontend (prevents spoofed acceptance notifications).
 	switch NotificationEvent(msg.Event) {
-	case NotificationEventAccepted, NotificationEventFailure, NotificationEventDeleted:
-		// valid
+	case NotificationEventFailure, NotificationEventDeleted:
+		// valid for frontend-initiated notifications
+	case NotificationEventAccepted:
+		logger.Warn("credential_accepted cannot be sent by the frontend")
+		return
 	default:
 		logger.Warn("Invalid credential notification event", zap.String("event", msg.Event))
 		return
@@ -550,7 +557,9 @@ func (m *Manager) handleCredentialNotification(session *Session, msg *Credential
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	// Use the configured HTTP client which includes SSRF protections
+	// (blocks private/loopback IPs when configured)
+	resp, err := m.httpClient.Do(req)
 	if err != nil {
 		logger.Warn("Failed to send credential notification to issuer", zap.Error(err))
 		return

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
 
+	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
 )
@@ -89,10 +92,11 @@ type Manager struct {
 	flowHandlers map[Protocol]FlowHandlerFactory
 	handlersMu   sync.RWMutex
 
-	trustService   *TrustService
-	registryClient *RegistryClient
-	verifierStore  storage.VerifierStore
-	trustCache     *TrustCache
+	trustService    *TrustService
+	registryClient  *RegistryClient
+	verifierStore   storage.VerifierStore
+	credentialStore storage.CredentialStore
+	trustCache      *TrustCache
 
 	// Persistent session store (optional, for horizontal scaling)
 	sessionStore SessionStore
@@ -135,6 +139,11 @@ func (m *Manager) SessionStore() SessionStore {
 // SetVerifierStore sets the verifier store for trust caching
 func (m *Manager) SetVerifierStore(store storage.VerifierStore) {
 	m.verifierStore = store
+}
+
+// SetCredentialStore sets the credential store for notification lookups
+func (m *Manager) SetCredentialStore(store storage.CredentialStore) {
+	m.credentialStore = store
 }
 
 // RegisterFlowHandler registers a handler factory for a protocol
@@ -377,6 +386,14 @@ func (m *Manager) handleSession(session *Session) {
 				_ = session.SendFlowError(matchMsg.FlowID, StepMatchCredentials, ErrCodeTooManyRequests, "Server overloaded, please retry")
 			}
 
+		case TypeCredentialNotification:
+			var notifMsg CredentialNotificationMessage
+			if err := json.Unmarshal(message, &notifMsg); err != nil {
+				session.logger.Warn("Invalid credential_notification", zap.Error(err))
+				continue
+			}
+			go m.handleCredentialNotification(session, &notifMsg)
+
 		default:
 			session.logger.Warn("Unknown message type", zap.String("type", string(msg.Type)))
 		}
@@ -466,6 +483,87 @@ func (m *Manager) handleFlowStart(session *Session, msg *FlowStartMessage) {
 		return
 	}
 	logger.Info("Flow completed")
+}
+
+// handleCredentialNotification handles a credential_notification message from the frontend.
+// It looks up the credential's notification info and forwards the event to the issuer.
+func (m *Manager) handleCredentialNotification(session *Session, msg *CredentialNotificationMessage) {
+	logger := session.logger.With(
+		zap.String("credential_id", msg.CredentialIdentifier),
+		zap.String("event", msg.Event))
+
+	if msg.CredentialIdentifier == "" || msg.Event == "" {
+		logger.Warn("Invalid credential_notification: missing required fields")
+		return
+	}
+
+	// Validate event type
+	switch NotificationEvent(msg.Event) {
+	case NotificationEventAccepted, NotificationEventFailure, NotificationEventDeleted:
+		// valid
+	default:
+		logger.Warn("Invalid credential notification event", zap.String("event", msg.Event))
+		return
+	}
+
+	if m.credentialStore == nil {
+		logger.Warn("Credential store not configured, cannot send notification")
+		return
+	}
+
+	// Look up the credential to get notification_id and notification_endpoint
+	cred, err := m.credentialStore.GetByIdentifier(
+		context.Background(),
+		domain.TenantID(session.TenantID),
+		session.UserID,
+		msg.CredentialIdentifier,
+	)
+	if err != nil {
+		logger.Warn("Failed to look up credential for notification", zap.Error(err))
+		return
+	}
+
+	if cred.NotificationID == "" || cred.NotificationEndpoint == "" {
+		logger.Debug("Credential has no notification info, skipping")
+		return
+	}
+
+	// Send notification to the issuer
+	body := notificationRequest{
+		NotificationID:   cred.NotificationID,
+		Event:            msg.Event,
+		EventDescription: msg.EventDescription,
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		logger.Warn("Failed to marshal notification request", zap.Error(err))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cred.NotificationEndpoint, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		logger.Warn("Failed to create notification request", zap.Error(err))
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.Warn("Failed to send credential notification to issuer", zap.Error(err))
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		logger.Info("Credential notification sent to issuer")
+	} else {
+		logger.Warn("Credential notification returned non-success",
+			zap.Int("status", resp.StatusCode))
+	}
 }
 
 func (m *Manager) registerSession(session *Session) {

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -212,18 +212,24 @@ type EngineProvider struct {
 
 // NewEngineProvider creates a new WebSocket engine route provider.
 // If store is non-nil, the engine will cache verifier trust evaluations.
+// If credStore is non-nil, the engine can forward credential lifecycle notifications.
 // If sharedResolver is non-nil, it is used for issuer metadata resolution so
 // the TTL cache is shared with the HTTP /v1/resolve handler; otherwise a new
 // resolver is created from the config.
 // If issuerLookup is non-nil, the OID4VCI handler will enrich fetchMetadata results
 // with the registered-issuer record from backend storage (same data as /v1/resolve).
-func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.VerifierStore, sharedResolver *issuermetadata.Resolver, issuerLookup wsengine.CredentialIssuerLookup) (*EngineProvider, error) {
+func NewEngineProvider(cfg *config.Config, logger *zap.Logger, store storage.VerifierStore, credStore storage.CredentialStore, sharedResolver *issuermetadata.Resolver, issuerLookup wsengine.CredentialIssuerLookup) (*EngineProvider, error) {
 	// Create WebSocket manager
 	manager := wsengine.NewManager(cfg, logger)
 
 	// Wire verifier store for trust caching
 	if store != nil {
 		manager.SetVerifierStore(store)
+	}
+
+	// Wire credential store for notification lookups
+	if credStore != nil {
+		manager.SetCredentialStore(credStore)
 	}
 
 	// Configure session store based on config

--- a/internal/server/ssrf_config_test.go
+++ b/internal/server/ssrf_config_test.go
@@ -195,7 +195,7 @@ func TestNewEngineProvider_AllowHTTPWiring(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			provider, err := NewEngineProvider(minimalEngineConfig(tc.httpCfg), logger, nil, nil, nil)
+			provider, err := NewEngineProvider(minimalEngineConfig(tc.httpCfg), logger, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("NewEngineProvider failed: %v", err)
 			}

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -52,6 +52,8 @@ func (s *CredentialService) Store(ctx context.Context, tenantID domain.TenantID,
 		CredentialIssuerIdentifier: req.CredentialIssuerIdentifier,
 		InstanceID:                 req.InstanceID,
 		SigCount:                   0,
+		NotificationID:             req.NotificationID,
+		NotificationEndpoint:       req.NotificationEndpoint,
 	}
 
 	if err := s.store.Credentials().Create(ctx, credential); err != nil {

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"net/url"
 
 	"go.uber.org/zap"
 
@@ -42,6 +43,17 @@ func (s *CredentialService) Store(ctx context.Context, tenantID domain.TenantID,
 		return nil, errors.New("format is required")
 	}
 
+	// Validate notification_endpoint if provided — must be HTTPS to prevent SSRF
+	notificationEndpoint := req.NotificationEndpoint
+	if notificationEndpoint != "" {
+		u, err := url.Parse(notificationEndpoint)
+		if err != nil || u.Scheme != "https" || u.Host == "" {
+			s.logger.Warn("Ignoring invalid notification_endpoint",
+				zap.String("endpoint", notificationEndpoint))
+			notificationEndpoint = ""
+		}
+	}
+
 	credential := &domain.VerifiableCredential{
 		TenantID:                   tenantID,
 		HolderDID:                  req.HolderDID,
@@ -53,7 +65,7 @@ func (s *CredentialService) Store(ctx context.Context, tenantID domain.TenantID,
 		InstanceID:                 req.InstanceID,
 		SigCount:                   0,
 		NotificationID:             req.NotificationID,
-		NotificationEndpoint:       req.NotificationEndpoint,
+		NotificationEndpoint:       notificationEndpoint,
 	}
 
 	if err := s.store.Credentials().Create(ctx, credential); err != nil {


### PR DESCRIPTION
## Summary

Implements OID4VCI credential lifecycle notifications per [OID4VCI §10](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-notification-endpoint).

## Changes

### Backend → Issuer (automatic)
- After successful credential issuance, the backend sends `credential_accepted` to the issuer's `notification_endpoint` using the access token (Bearer or DPoP)
- Works for both immediate and deferred issuance paths
- Best-effort: errors are logged but don't fail the flow

### Frontend → Backend → Issuer (on-demand)
- New WebSocket message type `credential_notification` allows the frontend/SDK to request credential lifecycle notifications (`credential_deleted`, `credential_failure`)
- Backend looks up stored `notification_id` and `notification_endpoint` for the credential and forwards to the issuer

### Data model
- `CredentialResult` now includes `notification_id` and `notification_endpoint` in `flow_complete` messages
- `VerifiableCredential` domain model stores notification info for later use
- `StoreCredentialRequest` accepts notification fields

### Key files
- `internal/engine/oid4vci.go` — `sendNotification()` helper, notification call after issuance
- `internal/engine/messages.go` — `CredentialNotificationMessage` type, `CredentialResult` fields
- `internal/engine/session.go` — `handleCredentialNotification()` dispatcher
- `internal/domain/credential.go` — notification fields on `VerifiableCredential`
- `internal/engine/notification_test.go` — comprehensive tests

## Design decisions
- `credential_accepted` is sent automatically by the backend (has the token in scope)
- Deletion/update events come from the frontend via WebSocket (and later WMP)
- No REST endpoint for notifications — uses the engine WebSocket channel