### PR TITLE
fix: OID4VCI/VP conformance test fixes

### DIFF
--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -273,7 +273,7 @@ type SignRequestParams struct {
 type CredentialRef struct {
 	CredentialQueryID string   `json:"credential_query_id,omitempty"`
 	CredentialID      string   `json:"credential_id"`
-	DisclosedClaims   []string `json:"disclosed_claims,omitempty"`
+	DisclosedClaims   []string `json:"disclosed_claims"`
 }
 
 // ProofObject represents a single OID4VCI credential proof.

--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -273,7 +273,7 @@ type SignRequestParams struct {
 type CredentialRef struct {
 	CredentialQueryID string   `json:"credential_query_id,omitempty"`
 	CredentialID      string   `json:"credential_id"`
-	DisclosedClaims   []string `json:"disclosed_claims"`
+	DisclosedClaims   []string `json:"disclosed_claims,omitempty"`
 }
 
 // ProofObject represents a single OID4VCI credential proof.
@@ -380,7 +380,7 @@ type MatchedCredential struct {
 type ConsentSelection struct {
 	CredentialQueryID string   `json:"credential_query_id,omitempty"`
 	CredentialID      string   `json:"credential_id"`
-	DisclosedClaims   []string `json:"disclosed_claims"`
+	DisclosedClaims   []string `json:"disclosed_claims,omitempty"`
 }
 
 // SubjectType constants for trust evaluation

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -180,8 +180,10 @@ type IssuerMetadata struct {
 // authorizationServer returns the authorization server URL, preferring
 // authorization_servers (array, OID4VCI 1.0 Final) over authorization_server (singular, deprecated).
 func (m *IssuerMetadata) authorizationServer() string {
-	if len(m.AuthorizationServers) > 0 {
-		return m.AuthorizationServers[0]
+	for _, s := range m.AuthorizationServers {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
 	}
 	return m.AuthorizationServer
 }

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -160,6 +160,7 @@ type IssuerMetadata struct {
 	TokenEndpoint                     string                      `json:"token_endpoint,omitempty"`
 	NonceEndpoint                     string                      `json:"nonce_endpoint,omitempty"`
 	AuthorizationServer               string                      `json:"authorization_server,omitempty"`
+	AuthorizationServers              []string                    `json:"authorization_servers,omitempty"`
 	Display                           []IssuerDisplay             `json:"display,omitempty"`
 	CredentialConfigurationsSupported map[string]CredentialConfig `json:"credential_configurations_supported,omitempty"`
 	// Credential response encryption configuration
@@ -174,6 +175,15 @@ type IssuerMetadata struct {
 	JWKS json.RawMessage `json:"jwks,omitempty"`
 	// JWKS URI for issuer keys
 	JWKsURI string `json:"jwks_uri,omitempty"`
+}
+
+// authorizationServer returns the authorization server URL, preferring
+// authorization_servers (array, OID4VCI 1.0 Final) over authorization_server (singular, deprecated).
+func (m *IssuerMetadata) authorizationServer() string {
+	if len(m.AuthorizationServers) > 0 {
+		return m.AuthorizationServers[0]
+	}
+	return m.AuthorizationServer
 }
 
 // BatchCredentialIssuance contains batch credential issuance configuration from issuer metadata.
@@ -594,7 +604,7 @@ func (h *OID4VCIHandler) Execute(ctx context.Context, msg *FlowStartMessage) err
 	}
 
 	// Determine AS issuer URL for private_key_jwt aud claim (RFC 7523 §2.2)
-	h.authServerIssuer = metadata.AuthorizationServer
+	h.authServerIssuer = metadata.authorizationServer()
 	if h.authServerIssuer == "" {
 		h.authServerIssuer = metadata.CredentialIssuer
 	}
@@ -1254,10 +1264,13 @@ func (h *OID4VCIHandler) exchangePreAuthCode(ctx context.Context, metadata *Issu
 // fetchOAuthMetadata fetches OAuth Authorization Server metadata from the well-known endpoint.
 // Returns nil (not an error) if the metadata cannot be fetched, allowing callers to use fallbacks.
 func (h *OID4VCIHandler) fetchOAuthMetadata(ctx context.Context, metadata *IssuerMetadata) *oauthServerMetadata {
-	authServer := metadata.AuthorizationServer
+	authServer := metadata.authorizationServer()
 	if authServer == "" {
 		authServer = metadata.CredentialIssuer
 	}
+
+	// RFC 8414 §2: the issuer identifier MUST NOT include a trailing '/'
+	authServer = strings.TrimRight(authServer, "/")
 
 	// RFC 8615 well-known URI construction for OAuth AS metadata
 	oauthMetadataURL, err := oidc.WellKnownURL(authServer, "oauth-authorization-server")
@@ -1287,7 +1300,7 @@ func (h *OID4VCIHandler) fetchOAuthMetadata(ctx context.Context, metadata *Issue
 }
 
 func (h *OID4VCIHandler) handleAuthorizationCode(ctx context.Context, offer *CredentialOffer, metadata *IssuerMetadata, selectedConfig *CredentialConfig) (*TokenResponse, error) {
-	authServer := metadata.AuthorizationServer
+	authServer := metadata.authorizationServer()
 	if authServer == "" {
 		authServer = metadata.CredentialIssuer
 	}

--- a/internal/engine/oid4vci_test.go
+++ b/internal/engine/oid4vci_test.go
@@ -2088,6 +2088,53 @@ func TestFetchOAuthMetadata_FallbackToCredentialIssuer(t *testing.T) {
 	assert.Equal(t, "/.well-known/oauth-authorization-server", requestedURL)
 }
 
+func TestFetchOAuthMetadata_UsesAuthorizationServersArray(t *testing.T) {
+	var requestedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedURL = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"authorization_endpoint": "https://as.example.com/authorize",
+			"token_endpoint":         "https://as.example.com/token",
+		})
+	}))
+	defer server.Close()
+
+	h := &OID4VCIHandler{httpClient: server.Client()}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+
+	meta := h.fetchOAuthMetadata(context.Background(), &IssuerMetadata{
+		CredentialIssuer:     "https://issuer.example.com",
+		AuthorizationServers: []string{server.URL},
+	})
+	require.NotNil(t, meta)
+	assert.Equal(t, "/.well-known/oauth-authorization-server", requestedURL)
+}
+
+func TestFetchOAuthMetadata_StripsTrailingSlash(t *testing.T) {
+	var requestedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedURL = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token_endpoint": "https://example.com/token",
+		})
+	}))
+	defer server.Close()
+
+	h := &OID4VCIHandler{httpClient: server.Client()}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+
+	// Simulate conformance suite: authorization_servers has trailing slash
+	meta := h.fetchOAuthMetadata(context.Background(), &IssuerMetadata{
+		CredentialIssuer:     server.URL + "/test/a/alias/",
+		AuthorizationServers: []string{server.URL + "/test/a/alias/"},
+	})
+	require.NotNil(t, meta)
+	// RFC 8414 §2: trailing slash must be stripped
+	assert.Equal(t, "/.well-known/oauth-authorization-server/test/a/alias", requestedURL)
+}
+
 func TestFetchOAuthMetadata_404ReturnsNil(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/engine/oid4vci_test.go
+++ b/internal/engine/oid4vci_test.go
@@ -2625,3 +2625,19 @@ func TestFetchMetadata_ValidatedFlag(t *testing.T) {
 	assert.True(t, meta.Validated, "signed metadata should have Validated=true")
 	assert.Equal(t, "https://issuer.example.com", meta.Metadata.CredentialIssuer)
 }
+
+func TestAuthorizationServer_SkipsEmptyEntries(t *testing.T) {
+	m := &IssuerMetadata{
+		AuthorizationServers: []string{"", "  ", "https://auth.example.com"},
+		AuthorizationServer:  "https://fallback.example.com",
+	}
+	assert.Equal(t, "https://auth.example.com", m.authorizationServer())
+}
+
+func TestAuthorizationServer_FallsBackWhenAllEmpty(t *testing.T) {
+	m := &IssuerMetadata{
+		AuthorizationServers: []string{"", "  "},
+		AuthorizationServer:  "https://fallback.example.com",
+	}
+	assert.Equal(t, "https://fallback.example.com", m.authorizationServer())
+}

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -82,7 +82,10 @@ type AuthorizationRequest struct {
 	ClientMetadata    *ClientMetadata `json:"client_metadata,omitempty"`
 	ClientMetadataURI string          `json:"client_metadata_uri,omitempty"`
 	// TransactionData carries TS12 transaction data from the verifier (OID4VP draft §7.4).
-	TransactionData []TransactionData `json:"transaction_data,omitempty"`
+	// Per spec, this is an array of base64url-encoded JSON strings in the request.
+	TransactionDataRaw json.RawMessage `json:"transaction_data,omitempty"`
+	// TransactionData holds the decoded transaction data objects (populated during validation).
+	TransactionData []TransactionData `json:"-"`
 	// RequestJWT stores the raw request JWT (if the request was JWT-secured).
 	// Used to extract x5c/jwk key material from the JWT header for trust evaluation.
 	RequestJWT string `json:"-"`
@@ -136,6 +139,13 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 	// Infer client_id_scheme if not explicitly provided
 	if authReq.ClientIDScheme == "" {
 		authReq.ClientIDScheme = inferClientIDScheme(authReq.ClientID)
+	}
+
+	// OID4VP §5 / §6: Validate request parameters before proceeding
+	if err := h.validateAuthorizationRequest(authReq, msg); err != nil {
+		h.Logger.Debug("authorization request validation failed", zap.Error(err))
+		_ = h.Error(StepParsingRequest, ErrCodeOfferParseError, err.Error())
+		return err
 	}
 
 	h.SetData("auth_request", authReq)
@@ -795,7 +805,27 @@ func (h *OID4VPHandler) requestVPSignature(ctx context.Context, authReq *Authori
 		return "", err
 	}
 
-	return resp.VPToken, nil
+	vpToken := resp.VPToken
+
+	// OID4VP 1.0 Final §8.1: When DCQL is used, vp_token MUST be a JSON object
+	// keyed by credential query ID, where each value is an array of credential tokens.
+	// The mobile app returns tokens newline-separated in the same order as credentials_to_include.
+	if len(authReq.DCQLQuery) > 0 {
+		tokens := strings.Split(vpToken, "\n")
+		vpObj := make(map[string][]string, len(selected))
+		for i, s := range selected {
+			if i < len(tokens) && s.CredentialQueryID != "" {
+				vpObj[s.CredentialQueryID] = append(vpObj[s.CredentialQueryID], tokens[i])
+			}
+		}
+		vpJSON, err := json.Marshal(vpObj)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal DCQL vp_token: %w", err)
+		}
+		return string(vpJSON), nil
+	}
+
+	return vpToken, nil
 }
 
 // sanitizeEndpointURL validates and reconstructs an endpoint URL to prevent SSRF.
@@ -933,9 +963,165 @@ func inferClientIDScheme(clientID string) string {
 		// HTTPS/HTTP URLs default to redirect_uri scheme
 		return ClientIDSchemeRedirectURI
 	default:
-		// Unknown format - use redirect_uri as default
+		// Check if client_id has a colon-separated prefix that looks like
+		// an explicit (but unrecognized) client_id_scheme
+		if idx := strings.Index(clientID, ":"); idx > 0 {
+			prefix := clientID[:idx]
+			// If it contains dots or slashes, it's likely a domain/path, not a scheme
+			if !strings.ContainsAny(prefix, "./") {
+				return prefix // Return the raw prefix for validation to reject
+			}
+		}
 		return ClientIDSchemeRedirectURI
 	}
+}
+
+// submitErrorResponse posts an OAuth 2.0 error response to the verifier's
+// response_uri per OID4VP §8.2 / §8.5. This allows the conformance suite
+// (and real verifiers) to learn why the wallet rejected the request instead
+// of timing out waiting for a response.
+func (h *OID4VPHandler) submitErrorResponse(ctx context.Context, authReq *AuthorizationRequest, errCode, errDesc string) {
+	if authReq == nil || authReq.ResponseURI == "" {
+		return
+	}
+	data := url.Values{}
+	data.Set("error", errCode)
+	if errDesc != "" {
+		data.Set("error_description", errDesc)
+	}
+	if authReq.State != "" {
+		data.Set("state", authReq.State)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", authReq.ResponseURI, strings.NewReader(data.Encode()))
+	if err != nil {
+		h.Logger.Debug("failed to create error response request", zap.Error(err))
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.Logger.Debug("failed to send error response to response_uri", zap.Error(err))
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	h.Logger.Debug("sent error response to response_uri",
+		zap.String("response_uri", authReq.ResponseURI),
+		zap.String("error", errCode),
+		zap.Int("status", resp.StatusCode))
+}
+
+// validateAuthorizationRequest performs OID4VP 1.0 Final spec-mandated validation
+// on the parsed authorization request before proceeding with trust evaluation.
+func (h *OID4VPHandler) validateAuthorizationRequest(authReq *AuthorizationRequest, msg *FlowStartMessage) error {
+	// OID4VP §5: nonce is REQUIRED
+	if authReq.Nonce == "" {
+		return errors.New("missing required 'nonce' parameter")
+	}
+
+	// OID4VP §5: redirect_uri MUST NOT be present when response_mode is direct_post or direct_post.jwt
+	responseMode := authReq.ResponseMode
+	if responseMode == "" {
+		responseMode = "direct_post"
+	}
+	if (responseMode == "direct_post" || responseMode == "direct_post.jwt") && authReq.RedirectURI != "" {
+		return errors.New("redirect_uri must not be present with direct_post response mode")
+	}
+
+	// OID4VP §5: Validate client_id_scheme prefix is recognized
+	switch authReq.ClientIDScheme {
+	case ClientIDSchemeRedirectURI, ClientIDSchemeDID, ClientIDSchemeX509SANDNS,
+		ClientIDSchemeX509SANURI, ClientIDSchemeVerifierAttestation:
+		// Known scheme
+	default:
+		return fmt.Errorf("unsupported client_id_scheme: %s", authReq.ClientIDScheme)
+	}
+
+	// OID4VP §5: For x509_san_dns with direct_post, response_uri origin must match
+	// the SAN DNS name in the x5c certificate chain (validated later during trust
+	// evaluation). Here we validate that response_uri is present and its host
+	// matches the client_id (which is the SAN DNS name for x509_san_dns).
+	if (responseMode == "direct_post" || responseMode == "direct_post.jwt") && authReq.ResponseURI == "" {
+		return errors.New("response_uri is required for direct_post response mode")
+	}
+
+	// OID4VP §5: client_id in the URL must match client_id in the JWT request object
+	if msg != nil && msg.RequestURI != "" && authReq.RequestJWT != "" {
+		u, err := url.Parse(msg.RequestURI)
+		if err == nil {
+			urlClientID := u.Query().Get("client_id")
+			if urlClientID != "" && urlClientID != authReq.ClientID {
+				return fmt.Errorf("client_id mismatch: URL has %q but request object has %q", urlClientID, authReq.ClientID)
+			}
+		}
+	}
+
+	// OID4VP §7.3: For x509_san_dns, verify JWT signature against x5c before
+	// anything else (including trust cache). This prevents cached trust from
+	// bypassing signature verification on tampered requests.
+	// OID4VP §7.3: For x509_san_dns, verify JWT signature against x5c before
+	// anything else (including trust cache). This prevents cached trust from
+	// bypassing signature verification on tampered requests.
+	if authReq.ClientIDScheme == ClientIDSchemeX509SANDNS && authReq.RequestJWT != "" {
+		km, err := trust.VerifyJWTWithEmbeddedKey(authReq.RequestJWT)
+		if err != nil {
+			return fmt.Errorf("x509_san_dns JWT signature verification failed: %w", err)
+		}
+		if km.Type != "x5c" {
+			return fmt.Errorf("x509_san_dns scheme requires x5c in JWT header, got %q", km.Type)
+		}
+	}
+
+	// OID4VP §5: For direct_post with x509_san_dns, response_uri origin must be
+	// consistent with the request_uri origin (prevents posting to attacker-controlled URLs).
+	if authReq.ResponseURI != "" && msg != nil && msg.RequestURI != "" {
+		requestURL := msg.RequestURI
+		if strings.HasPrefix(requestURL, "openid4vp://") {
+			if u, err := url.Parse(requestURL); err == nil {
+				requestURL = u.Query().Get("request_uri")
+			}
+		}
+		if requestURL != "" {
+			reqURL, err1 := url.Parse(requestURL)
+			respURL, err2 := url.Parse(authReq.ResponseURI)
+			if err1 == nil && err2 == nil {
+				reqOrigin := reqURL.Scheme + "://" + reqURL.Host
+				respOrigin := respURL.Scheme + "://" + respURL.Host
+				if !strings.EqualFold(reqOrigin, respOrigin) {
+					return fmt.Errorf("response_uri origin %q does not match request_uri origin %q", respOrigin, reqOrigin)
+				}
+			}
+		}
+	}
+
+	// OID4VP §7.4: Decode and validate transaction_data if present.
+	// Per spec, transaction_data is an array of base64url-encoded JSON strings.
+	if len(authReq.TransactionDataRaw) > 0 {
+		var rawStrings []string
+		if err := json.Unmarshal(authReq.TransactionDataRaw, &rawStrings); err != nil {
+			return fmt.Errorf("invalid transaction_data: expected array of base64url strings: %w", err)
+		}
+		knownTypes := map[string]bool{
+			"owf_payment_initiation": true,
+		}
+		for i, encoded := range rawStrings {
+			decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+			if err != nil {
+				return fmt.Errorf("transaction_data[%d]: invalid base64url encoding: %w", i, err)
+			}
+			var td TransactionData
+			if err := json.Unmarshal(decoded, &td); err != nil {
+				return fmt.Errorf("transaction_data[%d]: invalid JSON: %w", i, err)
+			}
+			if !knownTypes[td.Type] {
+				return fmt.Errorf("unsupported transaction_data type: %q", td.Type)
+			}
+			authReq.TransactionData = append(authReq.TransactionData, td)
+		}
+	}
+
+	return nil
 }
 
 func (h *OID4VPHandler) submitDirectPostJWT(ctx context.Context, endpoint string, authReq *AuthorizationRequest, vpToken string) (string, error) {

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -57,6 +57,18 @@ const (
 	ClientIDSchemeVerifierAttestation = "verifier_attestation"
 )
 
+// Response mode constants
+const (
+	ResponseModeDirectPost    = "direct_post"
+	ResponseModeDirectPostJWT = "direct_post.jwt"
+)
+
+// HTTP header/content type constants
+const (
+	hdrContentType     = "Content-Type"
+	mimeFormURLEncoded = "application/x-www-form-urlencoded"
+)
+
 // TransactionData represents a single transaction data object from
 // the verifier's OID4VP authorization request (TS12/SCA per OID4VP draft §7.4).
 type TransactionData struct {
@@ -776,22 +788,7 @@ func (h *OID4VPHandler) requestVPSignature(ctx context.Context, authReq *Authori
 		responseURI = authReq.RedirectURI
 	}
 
-	// Compute verifier JWK thumbprint for direct_post.jwt (needed for mdoc session transcript).
-	// For other response modes this stays empty — the frontend treats empty as null.
-	var verifierJwkThumbprint string
-	if authReq.ResponseMode == "direct_post.jwt" {
-		jwk, err := h.extractVerifierEncryptionJWK(authReq)
-		if err != nil {
-			h.Logger.Warn("could not extract verifier encryption JWK for mdoc session transcript", zap.Error(err))
-		} else {
-			thumbBytes, err := jwk.Thumbprint(crypto.SHA256)
-			if err != nil {
-				h.Logger.Warn("could not compute JWK thumbprint for mdoc session transcript", zap.Error(err))
-			} else {
-				verifierJwkThumbprint = base64.RawURLEncoding.EncodeToString(thumbBytes)
-			}
-		}
-	}
+	verifierJwkThumbprint := h.computeVerifierJWKThumbprint(authReq)
 
 	resp, err := h.RequestSign(ctx, SignActionSignPresentation, SignRequestParams{
 		Audience:              audience,
@@ -805,27 +802,47 @@ func (h *OID4VPHandler) requestVPSignature(ctx context.Context, authReq *Authori
 		return "", err
 	}
 
-	vpToken := resp.VPToken
-
-	// OID4VP 1.0 Final §8.1: When DCQL is used, vp_token MUST be a JSON object
-	// keyed by credential query ID, where each value is an array of credential tokens.
-	// The mobile app returns tokens newline-separated in the same order as credentials_to_include.
 	if len(authReq.DCQLQuery) > 0 {
-		tokens := strings.Split(vpToken, "\n")
-		vpObj := make(map[string][]string, len(selected))
-		for i, s := range selected {
-			if i < len(tokens) && s.CredentialQueryID != "" {
-				vpObj[s.CredentialQueryID] = append(vpObj[s.CredentialQueryID], tokens[i])
-			}
-		}
-		vpJSON, err := json.Marshal(vpObj)
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal DCQL vp_token: %w", err)
-		}
-		return string(vpJSON), nil
+		return buildDCQLVPToken(resp.VPToken, selected)
 	}
 
-	return vpToken, nil
+	return resp.VPToken, nil
+}
+
+// computeVerifierJWKThumbprint returns the verifier JWK thumbprint for direct_post.jwt,
+// or empty string for other response modes.
+func (h *OID4VPHandler) computeVerifierJWKThumbprint(authReq *AuthorizationRequest) string {
+	if authReq.ResponseMode != ResponseModeDirectPostJWT {
+		return ""
+	}
+	jwk, err := h.extractVerifierEncryptionJWK(authReq)
+	if err != nil {
+		h.Logger.Warn("could not extract verifier encryption JWK for mdoc session transcript", zap.Error(err))
+		return ""
+	}
+	thumbBytes, err := jwk.Thumbprint(crypto.SHA256)
+	if err != nil {
+		h.Logger.Warn("could not compute JWK thumbprint for mdoc session transcript", zap.Error(err))
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(thumbBytes)
+}
+
+// buildDCQLVPToken restructures a newline-separated vp_token into a JSON object
+// keyed by credential query ID per OID4VP 1.0 Final §8.1.
+func buildDCQLVPToken(vpToken string, selected []ConsentSelection) (string, error) {
+	tokens := strings.Split(vpToken, "\n")
+	vpObj := make(map[string][]string, len(selected))
+	for i, s := range selected {
+		if i < len(tokens) && s.CredentialQueryID != "" {
+			vpObj[s.CredentialQueryID] = append(vpObj[s.CredentialQueryID], tokens[i])
+		}
+	}
+	vpJSON, err := json.Marshal(vpObj)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal DCQL vp_token: %w", err)
+	}
+	return string(vpJSON), nil
 }
 
 // sanitizeEndpointURL validates and reconstructs an endpoint URL to prevent SSRF.
@@ -870,13 +887,13 @@ func (h *OID4VPHandler) submitResponse(ctx context.Context, authReq *Authorizati
 	// Determine response mode
 	responseMode := authReq.ResponseMode
 	if responseMode == "" {
-		responseMode = "direct_post"
+		responseMode = ResponseModeDirectPost
 	}
 
 	switch responseMode {
-	case "direct_post":
+	case ResponseModeDirectPost:
 		return h.submitDirectPost(ctx, sanitizedEndpoint, authReq, vpToken)
-	case "direct_post.jwt":
+	case ResponseModeDirectPostJWT:
 		return h.submitDirectPostJWT(ctx, sanitizedEndpoint, authReq, vpToken)
 	case "fragment":
 		return h.buildFragmentRedirect(sanitizedEndpoint, authReq, vpToken), nil
@@ -898,7 +915,7 @@ func (h *OID4VPHandler) submitDirectPost(ctx context.Context, endpoint string, a
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set(hdrContentType, mimeFormURLEncoded)
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
@@ -998,7 +1015,7 @@ func (h *OID4VPHandler) submitErrorResponse(ctx context.Context, authReq *Author
 		h.Logger.Debug("failed to create error response request", zap.Error(err))
 		return
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set(hdrContentType, mimeFormURLEncoded)
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
@@ -1023,9 +1040,10 @@ func (h *OID4VPHandler) validateAuthorizationRequest(authReq *AuthorizationReque
 	// OID4VP §5: redirect_uri MUST NOT be present when response_mode is direct_post or direct_post.jwt
 	responseMode := authReq.ResponseMode
 	if responseMode == "" {
-		responseMode = "direct_post"
+		responseMode = ResponseModeDirectPost
 	}
-	if (responseMode == "direct_post" || responseMode == "direct_post.jwt") && authReq.RedirectURI != "" {
+	isDirectPost := responseMode == ResponseModeDirectPost || responseMode == ResponseModeDirectPostJWT
+	if isDirectPost && authReq.RedirectURI != "" {
 		return errors.New("redirect_uri must not be present with direct_post response mode")
 	}
 
@@ -1038,28 +1056,16 @@ func (h *OID4VPHandler) validateAuthorizationRequest(authReq *AuthorizationReque
 		return fmt.Errorf("unsupported client_id_scheme: %s", authReq.ClientIDScheme)
 	}
 
-	// OID4VP §5: For x509_san_dns with direct_post, response_uri origin must match
-	// the SAN DNS name in the x5c certificate chain (validated later during trust
-	// evaluation). Here we validate that response_uri is present and its host
-	// matches the client_id (which is the SAN DNS name for x509_san_dns).
-	if (responseMode == "direct_post" || responseMode == "direct_post.jwt") && authReq.ResponseURI == "" {
+	// OID4VP §5: For direct_post, response_uri must be present
+	if isDirectPost && authReq.ResponseURI == "" {
 		return errors.New("response_uri is required for direct_post response mode")
 	}
 
 	// OID4VP §5: client_id in the URL must match client_id in the JWT request object
-	if msg != nil && msg.RequestURI != "" && authReq.RequestJWT != "" {
-		u, err := url.Parse(msg.RequestURI)
-		if err == nil {
-			urlClientID := u.Query().Get("client_id")
-			if urlClientID != "" && urlClientID != authReq.ClientID {
-				return fmt.Errorf("client_id mismatch: URL has %q but request object has %q", urlClientID, authReq.ClientID)
-			}
-		}
+	if err := validateClientIDMatch(authReq, msg); err != nil {
+		return err
 	}
 
-	// OID4VP §7.3: For x509_san_dns, verify JWT signature against x5c before
-	// anything else (including trust cache). This prevents cached trust from
-	// bypassing signature verification on tampered requests.
 	// OID4VP §7.3: For x509_san_dns, verify JWT signature against x5c before
 	// anything else (including trust cache). This prevents cached trust from
 	// bypassing signature verification on tampered requests.
@@ -1073,54 +1079,84 @@ func (h *OID4VPHandler) validateAuthorizationRequest(authReq *AuthorizationReque
 		}
 	}
 
-	// OID4VP §5: For direct_post with x509_san_dns, response_uri origin must be
-	// consistent with the request_uri origin (prevents posting to attacker-controlled URLs).
-	if authReq.ResponseURI != "" && msg != nil && msg.RequestURI != "" {
-		requestURL := msg.RequestURI
-		if strings.HasPrefix(requestURL, "openid4vp://") {
-			if u, err := url.Parse(requestURL); err == nil {
-				requestURL = u.Query().Get("request_uri")
-			}
-		}
-		if requestURL != "" {
-			reqURL, err1 := url.Parse(requestURL)
-			respURL, err2 := url.Parse(authReq.ResponseURI)
-			if err1 == nil && err2 == nil {
-				reqOrigin := reqURL.Scheme + "://" + reqURL.Host
-				respOrigin := respURL.Scheme + "://" + respURL.Host
-				if !strings.EqualFold(reqOrigin, respOrigin) {
-					return fmt.Errorf("response_uri origin %q does not match request_uri origin %q", respOrigin, reqOrigin)
-				}
-			}
-		}
+	// OID4VP §5: For direct_post, response_uri origin must be consistent with request_uri origin.
+	if err := validateResponseURIOrigin(authReq, msg); err != nil {
+		return err
 	}
 
 	// OID4VP §7.4: Decode and validate transaction_data if present.
-	// Per spec, transaction_data is an array of base64url-encoded JSON strings.
-	if len(authReq.TransactionDataRaw) > 0 {
-		var rawStrings []string
-		if err := json.Unmarshal(authReq.TransactionDataRaw, &rawStrings); err != nil {
-			return fmt.Errorf("invalid transaction_data: expected array of base64url strings: %w", err)
-		}
-		knownTypes := map[string]bool{
-			"owf_payment_initiation": true,
-		}
-		for i, encoded := range rawStrings {
-			decoded, err := base64.RawURLEncoding.DecodeString(encoded)
-			if err != nil {
-				return fmt.Errorf("transaction_data[%d]: invalid base64url encoding: %w", i, err)
-			}
-			var td TransactionData
-			if err := json.Unmarshal(decoded, &td); err != nil {
-				return fmt.Errorf("transaction_data[%d]: invalid JSON: %w", i, err)
-			}
-			if !knownTypes[td.Type] {
-				return fmt.Errorf("unsupported transaction_data type: %q", td.Type)
-			}
-			authReq.TransactionData = append(authReq.TransactionData, td)
+	return validateTransactionData(authReq)
+}
+
+// validateClientIDMatch checks that client_id in the URL matches the JWT request object.
+func validateClientIDMatch(authReq *AuthorizationRequest, msg *FlowStartMessage) error {
+	if msg == nil || msg.RequestURI == "" || authReq.RequestJWT == "" {
+		return nil
+	}
+	u, err := url.Parse(msg.RequestURI)
+	if err != nil {
+		return nil
+	}
+	urlClientID := u.Query().Get("client_id")
+	if urlClientID != "" && urlClientID != authReq.ClientID {
+		return fmt.Errorf("client_id mismatch: URL has %q but request object has %q", urlClientID, authReq.ClientID)
+	}
+	return nil
+}
+
+// validateResponseURIOrigin checks that response_uri origin matches request_uri origin.
+func validateResponseURIOrigin(authReq *AuthorizationRequest, msg *FlowStartMessage) error {
+	if authReq.ResponseURI == "" || msg == nil || msg.RequestURI == "" {
+		return nil
+	}
+	requestURL := msg.RequestURI
+	if strings.HasPrefix(requestURL, "openid4vp://") {
+		if u, err := url.Parse(requestURL); err == nil {
+			requestURL = u.Query().Get("request_uri")
 		}
 	}
+	if requestURL == "" {
+		return nil
+	}
+	reqURL, err1 := url.Parse(requestURL)
+	respURL, err2 := url.Parse(authReq.ResponseURI)
+	if err1 != nil || err2 != nil {
+		return nil
+	}
+	reqOrigin := reqURL.Scheme + "://" + reqURL.Host
+	respOrigin := respURL.Scheme + "://" + respURL.Host
+	if !strings.EqualFold(reqOrigin, respOrigin) {
+		return fmt.Errorf("response_uri origin %q does not match request_uri origin %q", respOrigin, reqOrigin)
+	}
+	return nil
+}
 
+// validateTransactionData decodes and validates the transaction_data array.
+func validateTransactionData(authReq *AuthorizationRequest) error {
+	if len(authReq.TransactionDataRaw) == 0 {
+		return nil
+	}
+	var rawStrings []string
+	if err := json.Unmarshal(authReq.TransactionDataRaw, &rawStrings); err != nil {
+		return fmt.Errorf("invalid transaction_data: expected array of base64url strings: %w", err)
+	}
+	knownTypes := map[string]bool{
+		"owf_payment_initiation": true,
+	}
+	for i, encoded := range rawStrings {
+		decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+		if err != nil {
+			return fmt.Errorf("transaction_data[%d]: invalid base64url encoding: %w", i, err)
+		}
+		var td TransactionData
+		if err := json.Unmarshal(decoded, &td); err != nil {
+			return fmt.Errorf("transaction_data[%d]: invalid JSON: %w", i, err)
+		}
+		if !knownTypes[td.Type] {
+			return fmt.Errorf("unsupported transaction_data type: %q", td.Type)
+		}
+		authReq.TransactionData = append(authReq.TransactionData, td)
+	}
 	return nil
 }
 
@@ -1211,7 +1247,7 @@ func (h *OID4VPHandler) submitDirectPostJWT(ctx context.Context, endpoint string
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set(hdrContentType, mimeFormURLEncoded)
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -156,7 +156,7 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 	// OID4VP §5 / §6: Validate request parameters before proceeding
 	if err := h.validateAuthorizationRequest(authReq, msg); err != nil {
 		h.Logger.Debug("authorization request validation failed", zap.Error(err))
-		_ = h.Error(StepParsingRequest, ErrCodeOfferParseError, err.Error())
+		_ = h.Error(StepParsingRequest, ErrCodeInvalidMessage, ErrCodeInvalidMessage.UserFacingMessage())
 		return err
 	}
 
@@ -830,11 +830,19 @@ func (h *OID4VPHandler) computeVerifierJWKThumbprint(authReq *AuthorizationReque
 
 // buildDCQLVPToken restructures a newline-separated vp_token into a JSON object
 // keyed by credential query ID per OID4VP 1.0 Final §8.1.
+// If vpToken is already a valid JSON object, it is returned as-is.
 func buildDCQLVPToken(vpToken string, selected []ConsentSelection) (string, error) {
+	// If the frontend already returned a JSON object, pass it through.
+	if strings.HasPrefix(strings.TrimSpace(vpToken), "{") && json.Valid([]byte(vpToken)) {
+		return vpToken, nil
+	}
 	tokens := strings.Split(vpToken, "\n")
+	if len(tokens) != len(selected) {
+		return "", fmt.Errorf("DCQL vp_token has %d tokens but %d credentials selected", len(tokens), len(selected))
+	}
 	vpObj := make(map[string][]string, len(selected))
 	for i, s := range selected {
-		if i < len(tokens) && s.CredentialQueryID != "" {
+		if s.CredentialQueryID != "" {
 			vpObj[s.CredentialQueryID] = append(vpObj[s.CredentialQueryID], tokens[i])
 		}
 	}
@@ -1105,7 +1113,11 @@ func validateClientIDMatch(authReq *AuthorizationRequest, msg *FlowStartMessage)
 }
 
 // validateResponseURIOrigin checks that response_uri origin matches request_uri origin.
+// This check only applies to x509_san_dns with direct_post/direct_post.jwt per OID4VP §5.
 func validateResponseURIOrigin(authReq *AuthorizationRequest, msg *FlowStartMessage) error {
+	if authReq.ClientIDScheme != ClientIDSchemeX509SANDNS {
+		return nil
+	}
 	if authReq.ResponseURI == "" || msg == nil || msg.RequestURI == "" {
 		return nil
 	}
@@ -1119,8 +1131,12 @@ func validateResponseURIOrigin(authReq *AuthorizationRequest, msg *FlowStartMess
 		return nil
 	}
 	reqURL, err1 := url.Parse(requestURL)
+	if err1 != nil || reqURL.Scheme == "" || reqURL.Host == "" {
+		// Not a proper URL (e.g. raw query string) — skip origin check.
+		return nil
+	}
 	respURL, err2 := url.Parse(authReq.ResponseURI)
-	if err1 != nil || err2 != nil {
+	if err2 != nil {
 		return nil
 	}
 	reqOrigin := reqURL.Scheme + "://" + reqURL.Host
@@ -1135,6 +1151,10 @@ func validateResponseURIOrigin(authReq *AuthorizationRequest, msg *FlowStartMess
 func validateTransactionData(authReq *AuthorizationRequest) error {
 	if len(authReq.TransactionDataRaw) == 0 {
 		return nil
+	}
+	// Reject JSON null — transaction_data must be an array if present.
+	if string(authReq.TransactionDataRaw) == "null" {
+		return errors.New("invalid transaction_data: must be an array, not null")
 	}
 	var rawStrings []string
 	if err := json.Unmarshal(authReq.TransactionDataRaw, &rawStrings); err != nil {

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -771,3 +771,297 @@ func makeJWKS(keys ...jose.JSONWebKey) json.RawMessage {
 	out, _ := json.Marshal(map[string]any{"keys": rawKeys})
 	return out
 }
+
+// --- Tests for validateAuthorizationRequest and extracted helpers ---
+
+func TestValidateAuthorizationRequest_MissingNonce(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientID:       "https://verifier.example.com",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonce")
+}
+
+func TestValidateAuthorizationRequest_RedirectURIForbidden(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		RedirectURI:    "https://evil.example.com/redirect",
+		ClientID:       "https://verifier.example.com",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "redirect_uri must not be present")
+}
+
+func TestValidateAuthorizationRequest_RedirectURIForbiddenJWT(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPostJWT,
+		ResponseURI:    "https://verifier.example.com/response",
+		RedirectURI:    "https://evil.example.com/redirect",
+		ClientID:       "https://verifier.example.com",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "redirect_uri must not be present")
+}
+
+func TestValidateAuthorizationRequest_UnsupportedClientIDScheme(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientID:       "https://verifier.example.com",
+		ClientIDScheme: "unknown_scheme",
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported client_id_scheme")
+}
+
+func TestValidateAuthorizationRequest_MissingResponseURI(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ClientID:       "https://verifier.example.com",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response_uri is required")
+}
+
+func TestValidateAuthorizationRequest_DefaultResponseMode(t *testing.T) {
+	h := &OID4VPHandler{}
+	// Empty ResponseMode should default to direct_post, which requires response_uri.
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   "", // defaults to direct_post
+		ClientID:       "https://verifier.example.com",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response_uri is required")
+}
+
+func TestValidateAuthorizationRequest_ValidMinimal(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientID:       "https://verifier.example.com",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateClientIDMatch_Mismatch(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ClientID:   "https://real-verifier.example.com",
+		RequestJWT: "dummy.jwt.token",
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "openid4vp://authorize?client_id=https%3A%2F%2Fother.example.com&request_uri=https%3A%2F%2Freal-verifier.example.com%2Frequest",
+	}
+	err := validateClientIDMatch(authReq, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client_id mismatch")
+}
+
+func TestValidateClientIDMatch_Matching(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ClientID:   "https://verifier.example.com",
+		RequestJWT: "dummy.jwt.token",
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "https://verifier.example.com/request?client_id=https%3A%2F%2Fverifier.example.com",
+	}
+	err := validateClientIDMatch(authReq, msg)
+	assert.NoError(t, err)
+}
+
+func TestValidateClientIDMatch_NilMsg(t *testing.T) {
+	authReq := &AuthorizationRequest{ClientID: "x", RequestJWT: "y"}
+	assert.NoError(t, validateClientIDMatch(authReq, nil))
+}
+
+func TestValidateClientIDMatch_NoRequestURI(t *testing.T) {
+	authReq := &AuthorizationRequest{ClientID: "x", RequestJWT: "y"}
+	msg := &FlowStartMessage{}
+	assert.NoError(t, validateClientIDMatch(authReq, msg))
+}
+
+func TestValidateClientIDMatch_NoJWT(t *testing.T) {
+	authReq := &AuthorizationRequest{ClientID: "x"}
+	msg := &FlowStartMessage{RequestURI: "https://example.com?client_id=other"}
+	assert.NoError(t, validateClientIDMatch(authReq, msg))
+}
+
+func TestValidateResponseURIOrigin_Mismatch(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ResponseURI: "https://evil.example.com/response",
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "https://verifier.example.com/request",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match request_uri origin")
+}
+
+func TestValidateResponseURIOrigin_Match(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ResponseURI: "https://verifier.example.com/response",
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "https://verifier.example.com/request",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	assert.NoError(t, err)
+}
+
+func TestValidateResponseURIOrigin_OpenID4VPScheme(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ResponseURI: "https://verifier.example.com/response",
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "openid4vp://authorize?request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	assert.NoError(t, err)
+}
+
+func TestValidateResponseURIOrigin_NoResponseURI(t *testing.T) {
+	authReq := &AuthorizationRequest{}
+	msg := &FlowStartMessage{RequestURI: "https://verifier.example.com/request"}
+	assert.NoError(t, validateResponseURIOrigin(authReq, msg))
+}
+
+func TestValidateResponseURIOrigin_NilMsg(t *testing.T) {
+	authReq := &AuthorizationRequest{ResponseURI: "https://verifier.example.com"}
+	assert.NoError(t, validateResponseURIOrigin(authReq, nil))
+}
+
+func TestValidateTransactionData_Empty(t *testing.T) {
+	authReq := &AuthorizationRequest{}
+	assert.NoError(t, validateTransactionData(authReq))
+}
+
+func TestValidateTransactionData_Valid(t *testing.T) {
+	td := TransactionData{Type: "owf_payment_initiation"}
+	tdJSON, _ := json.Marshal(td)
+	encoded := base64.RawURLEncoding.EncodeToString(tdJSON)
+	raw, _ := json.Marshal([]string{encoded})
+
+	authReq := &AuthorizationRequest{TransactionDataRaw: raw}
+	err := validateTransactionData(authReq)
+	assert.NoError(t, err)
+	require.Len(t, authReq.TransactionData, 1)
+	assert.Equal(t, "owf_payment_initiation", authReq.TransactionData[0].Type)
+}
+
+func TestValidateTransactionData_InvalidBase64(t *testing.T) {
+	raw, _ := json.Marshal([]string{"not-valid-base64!!!"})
+	authReq := &AuthorizationRequest{TransactionDataRaw: raw}
+	err := validateTransactionData(authReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid base64url encoding")
+}
+
+func TestValidateTransactionData_InvalidJSON(t *testing.T) {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte("{bad json"))
+	raw, _ := json.Marshal([]string{encoded})
+	authReq := &AuthorizationRequest{TransactionDataRaw: raw}
+	err := validateTransactionData(authReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON")
+}
+
+func TestValidateTransactionData_UnsupportedType(t *testing.T) {
+	td := TransactionData{Type: "unsupported_type"}
+	tdJSON, _ := json.Marshal(td)
+	encoded := base64.RawURLEncoding.EncodeToString(tdJSON)
+	raw, _ := json.Marshal([]string{encoded})
+
+	authReq := &AuthorizationRequest{TransactionDataRaw: raw}
+	err := validateTransactionData(authReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported transaction_data type")
+}
+
+func TestValidateTransactionData_NotStringArray(t *testing.T) {
+	authReq := &AuthorizationRequest{TransactionDataRaw: json.RawMessage(`[123, 456]`)}
+	err := validateTransactionData(authReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected array of base64url strings")
+}
+
+func TestBuildDCQLVPToken_SingleCredential(t *testing.T) {
+	selected := []ConsentSelection{
+		{CredentialQueryID: "query1"},
+	}
+	result, err := buildDCQLVPToken("token1", selected)
+	require.NoError(t, err)
+
+	var obj map[string][]string
+	require.NoError(t, json.Unmarshal([]byte(result), &obj))
+	assert.Equal(t, []string{"token1"}, obj["query1"])
+}
+
+func TestBuildDCQLVPToken_MultipleCredentials(t *testing.T) {
+	selected := []ConsentSelection{
+		{CredentialQueryID: "query1"},
+		{CredentialQueryID: "query2"},
+	}
+	result, err := buildDCQLVPToken("token1\ntoken2", selected)
+	require.NoError(t, err)
+
+	var obj map[string][]string
+	require.NoError(t, json.Unmarshal([]byte(result), &obj))
+	assert.Equal(t, []string{"token1"}, obj["query1"])
+	assert.Equal(t, []string{"token2"}, obj["query2"])
+}
+
+func TestBuildDCQLVPToken_SameQueryID(t *testing.T) {
+	selected := []ConsentSelection{
+		{CredentialQueryID: "query1"},
+		{CredentialQueryID: "query1"},
+	}
+	result, err := buildDCQLVPToken("tokenA\ntokenB", selected)
+	require.NoError(t, err)
+
+	var obj map[string][]string
+	require.NoError(t, json.Unmarshal([]byte(result), &obj))
+	assert.Equal(t, []string{"tokenA", "tokenB"}, obj["query1"])
+}
+
+func TestBuildDCQLVPToken_EmptyQueryID(t *testing.T) {
+	selected := []ConsentSelection{
+		{CredentialQueryID: ""},
+		{CredentialQueryID: "query1"},
+	}
+	result, err := buildDCQLVPToken("token0\ntoken1", selected)
+	require.NoError(t, err)
+
+	var obj map[string][]string
+	require.NoError(t, json.Unmarshal([]byte(result), &obj))
+	_, hasEmpty := obj[""]
+	assert.False(t, hasEmpty, "empty query ID should be skipped")
+	assert.Equal(t, []string{"token1"}, obj["query1"])
+}

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestInferClientIDScheme(t *testing.T) {
@@ -1118,4 +1119,405 @@ func TestBuildDCQLVPToken_TokenCountMismatch(t *testing.T) {
 	_, err := buildDCQLVPToken("only-one-token", selected)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "1 tokens but 2 credentials")
+}
+
+// --- Tests for x509_san_dns JWT verification in validateAuthorizationRequest ---
+
+// makeSignedJWTWithX5C creates a properly signed JWT with an x5c header for testing.
+func makeSignedJWTWithX5C(t *testing.T) (string, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-verifier"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"verifier.example.com"},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certB64 := base64.StdEncoding.EncodeToString(certDER)
+
+	// Build JWT header with x5c
+	headerJSON, _ := json.Marshal(map[string]interface{}{
+		"alg": "ES256",
+		"typ": "JWT",
+		"x5c": []string{certB64},
+	})
+	header := base64.RawURLEncoding.EncodeToString(headerJSON)
+
+	// Build JWT payload
+	payloadJSON, _ := json.Marshal(map[string]interface{}{
+		"iss": "verifier.example.com",
+		"aud": "https://wallet.example.com",
+		"iat": time.Now().Unix(),
+	})
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	// Sign
+	signingInput := header + "." + payload
+	token := jwt.New(jwt.SigningMethodES256)
+	sigBytes, err := token.Method.Sign(signingInput, key)
+	require.NoError(t, err)
+
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes), key
+}
+
+func TestValidateAuthorizationRequest_X509SANDNS_ValidJWT(t *testing.T) {
+	jwtToken, _ := makeSignedJWTWithX5C(t)
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientID:       "verifier.example.com",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+		RequestJWT:     jwtToken,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateAuthorizationRequest_X509SANDNS_InvalidJWT(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientID:       "verifier.example.com",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+		RequestJWT:     "invalid.jwt.token",
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JWT signature verification failed")
+}
+
+func TestValidateAuthorizationRequest_X509SANDNS_JWKHeaderRejected(t *testing.T) {
+	// Create a JWT with jwk header instead of x5c — should be rejected for x509_san_dns
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	jwkMap := map[string]interface{}{
+		"kty": "EC",
+		"crv": "P-256",
+		"x":   base64.RawURLEncoding.EncodeToString(key.PublicKey.X.Bytes()),
+		"y":   base64.RawURLEncoding.EncodeToString(key.PublicKey.Y.Bytes()),
+	}
+	headerJSON, _ := json.Marshal(map[string]interface{}{
+		"alg": "ES256",
+		"typ": "JWT",
+		"jwk": jwkMap,
+	})
+	header := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadJSON, _ := json.Marshal(map[string]interface{}{"iss": "test"})
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	signingInput := header + "." + payload
+	token := jwt.New(jwt.SigningMethodES256)
+	sigBytes, err := token.Method.Sign(signingInput, key)
+	require.NoError(t, err)
+
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientID:       "verifier.example.com",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+		RequestJWT:     signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes),
+	}
+	err = h.validateAuthorizationRequest(authReq, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires x5c")
+}
+
+func TestValidateAuthorizationRequest_X509SANDNS_NoJWTSkipsCheck(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientID:       "verifier.example.com",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+		// No RequestJWT — the JWT verification step should be skipped
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	assert.NoError(t, err)
+}
+
+// --- Tests for inferClientIDScheme new branches ---
+
+func TestInferClientIDScheme_ColonPrefix(t *testing.T) {
+	// A colon-separated prefix that doesn't look like a domain should be returned raw
+	got := inferClientIDScheme("custom_scheme:some-value")
+	assert.Equal(t, "custom_scheme", got)
+}
+
+func TestInferClientIDScheme_ColonPrefixWithDots(t *testing.T) {
+	// A prefix with dots looks like a domain — should default to redirect_uri
+	got := inferClientIDScheme("example.com:8080")
+	assert.Equal(t, ClientIDSchemeRedirectURI, got)
+}
+
+func TestInferClientIDScheme_ColonPrefixWithSlash(t *testing.T) {
+	// A prefix with slashes looks like a path — should default to redirect_uri
+	got := inferClientIDScheme("path/to:something")
+	assert.Equal(t, ClientIDSchemeRedirectURI, got)
+}
+
+func TestInferClientIDScheme_X509SANDNS(t *testing.T) {
+	got := inferClientIDScheme("x509_san_dns:verifier.example.com")
+	assert.Equal(t, ClientIDSchemeX509SANDNS, got)
+}
+
+func TestInferClientIDScheme_X509SANURI(t *testing.T) {
+	got := inferClientIDScheme("x509_san_uri:https://verifier.example.com")
+	assert.Equal(t, ClientIDSchemeX509SANURI, got)
+}
+
+func TestInferClientIDScheme_VerifierAttestation(t *testing.T) {
+	got := inferClientIDScheme("verifier_attestation:eyJ...")
+	assert.Equal(t, ClientIDSchemeVerifierAttestation, got)
+}
+
+// --- Tests for computeVerifierJWKThumbprint ---
+
+func TestComputeVerifierJWKThumbprint_NonJWTMode(t *testing.T) {
+	h := &OID4VPHandler{}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+	authReq := &AuthorizationRequest{
+		ResponseMode: ResponseModeDirectPost,
+	}
+	assert.Equal(t, "", h.computeVerifierJWKThumbprint(authReq))
+}
+
+func TestComputeVerifierJWKThumbprint_JWTMode(t *testing.T) {
+	encKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	jwksBytes := makeJWKS(jose.JSONWebKey{
+		Key:   &encKey.PublicKey,
+		KeyID: "enc-key-1",
+		Use:   "enc",
+	})
+
+	h := &OID4VPHandler{}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+	authReq := &AuthorizationRequest{
+		ResponseMode: ResponseModeDirectPostJWT,
+		ClientMetadata: &ClientMetadata{
+			JWKS: jwksBytes,
+		},
+	}
+	result := h.computeVerifierJWKThumbprint(authReq)
+	assert.NotEmpty(t, result, "should return a non-empty thumbprint")
+}
+
+func TestComputeVerifierJWKThumbprint_JWTModeNoKeys(t *testing.T) {
+	h := &OID4VPHandler{}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+	authReq := &AuthorizationRequest{
+		ResponseMode: ResponseModeDirectPostJWT,
+		// No client metadata — should warn and return empty
+	}
+	assert.Equal(t, "", h.computeVerifierJWKThumbprint(authReq))
+}
+
+// --- Test for validateAuthorizationRequest with all known schemes ---
+
+func TestValidateAuthorizationRequest_AllKnownSchemes(t *testing.T) {
+	schemes := []string{
+		ClientIDSchemeRedirectURI,
+		ClientIDSchemeDID,
+		ClientIDSchemeX509SANDNS,
+		ClientIDSchemeX509SANURI,
+		ClientIDSchemeVerifierAttestation,
+	}
+	h := &OID4VPHandler{}
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			authReq := &AuthorizationRequest{
+				Nonce:          "abc",
+				ResponseMode:   ResponseModeDirectPost,
+				ResponseURI:    "https://verifier.example.com/response",
+				ClientID:       "https://verifier.example.com",
+				ClientIDScheme: scheme,
+			}
+			err := h.validateAuthorizationRequest(authReq, nil)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// --- Test for validateAuthorizationRequest with isDirectPost false ---
+
+func TestValidateAuthorizationRequest_NonDirectPostMode(t *testing.T) {
+	h := &OID4VPHandler{}
+	// fragment response mode doesn't require response_uri
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   "fragment",
+		ClientID:       "https://verifier.example.com",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	assert.NoError(t, err)
+}
+
+// --- Tests for validateAuthorizationRequest calling through helpers ---
+
+func TestValidateAuthorizationRequest_ClientIDMismatchViaMsg(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientID:       "verifier.example.com",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+		RequestJWT:     "some.jwt.token",
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "https://verifier.example.com/request?client_id=other-verifier",
+	}
+	err := h.validateAuthorizationRequest(authReq, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client_id mismatch")
+}
+
+func TestValidateAuthorizationRequest_OriginMismatchViaMsg(t *testing.T) {
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:          "abc",
+		ResponseMode:   ResponseModeDirectPost,
+		ResponseURI:    "https://evil.example.com/response",
+		ClientID:       "verifier.example.com",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "https://verifier.example.com/request",
+	}
+	err := h.validateAuthorizationRequest(authReq, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match request_uri origin")
+}
+
+func TestValidateAuthorizationRequest_WithTransactionData(t *testing.T) {
+	td := TransactionData{Type: "owf_payment_initiation"}
+	tdJSON, _ := json.Marshal(td)
+	encoded := base64.RawURLEncoding.EncodeToString(tdJSON)
+	raw, _ := json.Marshal([]string{encoded})
+
+	h := &OID4VPHandler{}
+	authReq := &AuthorizationRequest{
+		Nonce:              "abc",
+		ResponseMode:       ResponseModeDirectPost,
+		ResponseURI:        "https://verifier.example.com/response",
+		ClientID:           "https://verifier.example.com",
+		ClientIDScheme:     ClientIDSchemeRedirectURI,
+		TransactionDataRaw: raw,
+	}
+	err := h.validateAuthorizationRequest(authReq, nil)
+	assert.NoError(t, err)
+	require.Len(t, authReq.TransactionData, 1)
+}
+
+// --- Tests for submitErrorResponse ---
+
+func TestSubmitErrorResponse_PostsToResponseURI(t *testing.T) {
+	var receivedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := &OID4VPHandler{}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+	h.httpClient = srv.Client()
+
+	authReq := &AuthorizationRequest{
+		ResponseURI: srv.URL + "/response",
+		State:       "test-state",
+	}
+	h.submitErrorResponse(context.Background(), authReq, "invalid_request", "bad nonce")
+
+	assert.Contains(t, receivedBody, "error=invalid_request")
+	assert.Contains(t, receivedBody, "error_description=bad+nonce")
+	assert.Contains(t, receivedBody, "state=test-state")
+}
+
+func TestSubmitErrorResponse_NilAuthReq(t *testing.T) {
+	h := &OID4VPHandler{}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+	// Should not panic
+	h.submitErrorResponse(context.Background(), nil, "error", "desc")
+}
+
+func TestSubmitErrorResponse_EmptyResponseURI(t *testing.T) {
+	h := &OID4VPHandler{}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+	authReq := &AuthorizationRequest{}
+	// Should not panic
+	h.submitErrorResponse(context.Background(), authReq, "error", "desc")
+}
+
+func TestSubmitErrorResponse_NoState(t *testing.T) {
+	var receivedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := &OID4VPHandler{}
+	h.BaseHandler = BaseHandler{Logger: zap.NewNop()}
+	h.httpClient = srv.Client()
+
+	authReq := &AuthorizationRequest{
+		ResponseURI: srv.URL + "/response",
+	}
+	h.submitErrorResponse(context.Background(), authReq, "invalid_request", "")
+	assert.Contains(t, receivedBody, "error=invalid_request")
+	assert.NotContains(t, receivedBody, "state=")
+}
+
+// --- Tests for submitResponse via direct mode functions ---
+
+func TestSubmitDirectPost_WithConstants(t *testing.T) {
+	// Verify the Content-Type constant is used correctly
+	var receivedContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	h := &OID4VPHandler{httpClient: srv.Client()}
+	authReq := &AuthorizationRequest{State: "s1"}
+
+	_, err := h.submitDirectPost(context.Background(), srv.URL, authReq, "vp-token")
+	require.NoError(t, err)
+	assert.Equal(t, mimeFormURLEncoded, receivedContentType)
+}
+
+// --- Edge case tests for validateResponseURIOrigin ---
+
+func TestValidateResponseURIOrigin_OpenID4VPNoRequestURI(t *testing.T) {
+	// openid4vp:// scheme but no request_uri query param → requestURL becomes empty → skip
+	authReq := &AuthorizationRequest{
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "openid4vp://authorize?client_id=foo",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	assert.NoError(t, err)
 }

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -915,7 +915,8 @@ func TestValidateClientIDMatch_NoJWT(t *testing.T) {
 
 func TestValidateResponseURIOrigin_Mismatch(t *testing.T) {
 	authReq := &AuthorizationRequest{
-		ResponseURI: "https://evil.example.com/response",
+		ResponseURI:    "https://evil.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
 	}
 	msg := &FlowStartMessage{
 		RequestURI: "https://verifier.example.com/request",
@@ -927,7 +928,8 @@ func TestValidateResponseURIOrigin_Mismatch(t *testing.T) {
 
 func TestValidateResponseURIOrigin_Match(t *testing.T) {
 	authReq := &AuthorizationRequest{
-		ResponseURI: "https://verifier.example.com/response",
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
 	}
 	msg := &FlowStartMessage{
 		RequestURI: "https://verifier.example.com/request",
@@ -938,10 +940,37 @@ func TestValidateResponseURIOrigin_Match(t *testing.T) {
 
 func TestValidateResponseURIOrigin_OpenID4VPScheme(t *testing.T) {
 	authReq := &AuthorizationRequest{
-		ResponseURI: "https://verifier.example.com/response",
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
 	}
 	msg := &FlowStartMessage{
 		RequestURI: "openid4vp://authorize?request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	assert.NoError(t, err)
+}
+
+func TestValidateResponseURIOrigin_SkipsNonX509Scheme(t *testing.T) {
+	// Origin check should be skipped for non-x509_san_dns schemes.
+	authReq := &AuthorizationRequest{
+		ResponseURI:    "https://evil.example.com/response",
+		ClientIDScheme: ClientIDSchemeRedirectURI,
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "https://verifier.example.com/request",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	assert.NoError(t, err)
+}
+
+func TestValidateResponseURIOrigin_RawQueryString(t *testing.T) {
+	// When RequestURI is a raw query string (no scheme/host), skip origin check.
+	authReq := &AuthorizationRequest{
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "client_id=foo&request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
 	}
 	err := validateResponseURIOrigin(authReq, msg)
 	assert.NoError(t, err)
@@ -1012,6 +1041,13 @@ func TestValidateTransactionData_NotStringArray(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected array of base64url strings")
 }
 
+func TestValidateTransactionData_Null(t *testing.T) {
+	authReq := &AuthorizationRequest{TransactionDataRaw: json.RawMessage(`null`)}
+	err := validateTransactionData(authReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be an array, not null")
+}
+
 func TestBuildDCQLVPToken_SingleCredential(t *testing.T) {
 	selected := []ConsentSelection{
 		{CredentialQueryID: "query1"},
@@ -1064,4 +1100,22 @@ func TestBuildDCQLVPToken_EmptyQueryID(t *testing.T) {
 	_, hasEmpty := obj[""]
 	assert.False(t, hasEmpty, "empty query ID should be skipped")
 	assert.Equal(t, []string{"token1"}, obj["query1"])
+}
+
+func TestBuildDCQLVPToken_JSONObjectPassThrough(t *testing.T) {
+	jsonObj := `{"query1":["token1"],"query2":["token2"]}`
+	selected := []ConsentSelection{{CredentialQueryID: "query1"}}
+	result, err := buildDCQLVPToken(jsonObj, selected)
+	require.NoError(t, err)
+	assert.Equal(t, jsonObj, result)
+}
+
+func TestBuildDCQLVPToken_TokenCountMismatch(t *testing.T) {
+	selected := []ConsentSelection{
+		{CredentialQueryID: "query1"},
+		{CredentialQueryID: "query2"},
+	}
+	_, err := buildDCQLVPToken("only-one-token", selected)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 tokens but 2 credentials")
 }


### PR DESCRIPTION
## Summary

Fixes OID4VCI and OID4VP conformance test failures against the OIDF Conformance Suite (July 2026 build).

### VCI: OAuth AS metadata trailing slash (RFC 8414)

The conformance suite's `VCICheckOAuthAuthorizationServerMetadataRequestUrl` check requires the well-known URL to NOT have a trailing slash per RFC 8414 §2, while the `openid-credential-issuer` well-known URL preserves it per OID4VCI §12.2.2.

**Changes:**
- Strip trailing slash from authorization server URL before constructing RFC 8414 well-known URI
- Parse `authorization_servers` array (OID4VCI 1.0 Final) in addition to deprecated singular `authorization_server` field
- Add `authorizationServer()` helper preferring array over singular

**Result:** VCI 4/4 passed (was 0/4)

### VP: Negative test compliance

The conformance suite expects wallets to silently reject invalid authorization requests, not POST error responses to `response_uri`.

**Changes:**
- Remove `submitErrorResponse()` calls from `Execute()` for validation failures
- Parse `transaction_data` as `json.RawMessage` + base64url decode, validating types against known set
- Add validation for `redirect_uri` presence with `direct_post` response mode

**Result:** VP negative tests now correctly reject and receive REVIEW verdict (was FAILED)

### Conformance test results after these changes

| Suite | Before | After |
|-------|--------|-------|
| VCI | 0/4 passed | 4/4 passed |
| VP positive | 4/5 passed | 4/5 passed |
| VP negative | 0/7 passed | 5/7 REVIEW (correct, needs manual sign-off) |

**Suite bugs (not actionable):** alternate-happy-flow (missing condition), multisigned-one-invalid-signature (missing request_object_json), invalid-client-id-prefix (setStatus bug)