### PR TITLE
fix: work around YubiKit SDK appending unsigned extension data to authenticatorData

### DIFF
--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -1038,13 +1038,30 @@ func (s *WebAuthnService) FinishLogin(ctx context.Context, req *FinishLoginReque
 		// must NOT be bypassed — they are validated by the library before the
 		// signature check and would indicate a genuine protocol violation.
 		rawAuthData := parsedResponse.Raw.AssertionResponse.AuthenticatorData
-		if isAssertionSignatureError(err) && len(rawAuthData) > 37 && rawAuthData[32]&0x80 != 0 {
-			if verifyAssertionWithoutExtensions(
+		isSigErr := isAssertionSignatureError(err)
+		hasED := len(rawAuthData) > 37 && rawAuthData[32]&0x80 != 0
+		s.logger.Debug("Extension workaround evaluation",
+			zap.Bool("is_signature_error", isSigErr),
+			zap.Bool("has_ed_flag", hasED),
+			zap.Int("auth_data_len", len(rawAuthData)),
+			zap.String("error_type", fmt.Sprintf("%T", err)),
+			zap.Error(err),
+		)
+		if isSigErr && hasED {
+			stripped := verifyAssertionWithoutExtensions(
 				rawAuthData,
 				parsedResponse.Raw.AssertionResponse.ClientDataJSON,
 				parsedResponse.Response.Signature,
 				matchedCred.PublicKey,
-			) {
+			)
+			s.logger.Debug("Extension workaround strip result",
+				zap.Bool("verify_succeeded", stripped),
+				zap.String("credential_id", credentialID),
+				zap.Uint32("sign_count", parsedResponse.Response.AuthenticatorData.Counter),
+				zap.Int("stored_public_key_len", len(matchedCred.PublicKey)),
+				zap.String("stripped_auth_data_sha256", sha256Hex(rawAuthData[:37])),
+			)
+			if stripped {
 				s.logger.Info("Login verified after stripping extension data (YubiKit SDK workaround)",
 					zap.String("user_id", userID.String()),
 					zap.String("credential_id", credentialID),

--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -1032,8 +1032,13 @@ func (s *WebAuthnService) FinishLogin(ctx context.Context, req *FinishLoginReque
 		// has already signed the data without extensions. This causes signature verification
 		// to fail when the ED (Extension Data) flag is set. Retry verification with
 		// extension data stripped if the ED flag is present.
+		//
+		// SECURITY: Only apply the workaround for signature verification errors.
+		// Other errors (challenge mismatch, origin mismatch, user verification, etc.)
+		// must NOT be bypassed — they are validated by the library before the
+		// signature check and would indicate a genuine protocol violation.
 		rawAuthData := parsedResponse.Raw.AssertionResponse.AuthenticatorData
-		if len(rawAuthData) > 37 && rawAuthData[32]&0x80 != 0 {
+		if isAssertionSignatureError(err) && len(rawAuthData) > 37 && rawAuthData[32]&0x80 != 0 {
 			if verifyAssertionWithoutExtensions(
 				rawAuthData,
 				parsedResponse.Raw.AssertionResponse.ClientDataJSON,
@@ -1664,6 +1669,18 @@ func sha256Hex(data []byte) string {
 
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h[:])
+}
+
+// isAssertionSignatureError returns true if the error is specifically a WebAuthn
+// assertion signature verification failure (Type "invalid_signature"). This
+// distinguishes signature errors from other validation failures (challenge,
+// origin, user verification, etc.) that must not be bypassed.
+func isAssertionSignatureError(err error) bool {
+	var protocolErr *protocol.Error
+	if errors.As(err, &protocolErr) {
+		return protocolErr.Type == "invalid_signature"
+	}
+	return false
 }
 
 // verifyAssertionWithoutExtensions performs manual signature verification after

--- a/internal/service/webauthn.go
+++ b/internal/service/webauthn.go
@@ -1027,6 +1027,36 @@ func (s *WebAuthnService) FinishLogin(ctx context.Context, req *FinishLoginReque
 		parsedResponse,
 	)
 	if err != nil {
+		// Workaround: Some YubiKey SDK implementations (notably Yubico iOS SDK / YubiKit)
+		// append hmac-secret extension output to authenticatorData AFTER the authenticator
+		// has already signed the data without extensions. This causes signature verification
+		// to fail when the ED (Extension Data) flag is set. Retry verification with
+		// extension data stripped if the ED flag is present.
+		rawAuthData := parsedResponse.Raw.AssertionResponse.AuthenticatorData
+		if len(rawAuthData) > 37 && rawAuthData[32]&0x80 != 0 {
+			if verifyAssertionWithoutExtensions(
+				rawAuthData,
+				parsedResponse.Raw.AssertionResponse.ClientDataJSON,
+				parsedResponse.Response.Signature,
+				matchedCred.PublicKey,
+			) {
+				s.logger.Info("Login verified after stripping extension data (YubiKit SDK workaround)",
+					zap.String("user_id", userID.String()),
+					zap.String("credential_id", credentialID),
+					zap.Uint32("sign_count", parsedResponse.Response.AuthenticatorData.Counter),
+				)
+				// Verification succeeded without extensions — proceed as normal.
+				// Build a minimal credential result for the sign count update below.
+				credential = &webauthn.Credential{
+					Authenticator: webauthn.Authenticator{
+						SignCount: parsedResponse.Response.AuthenticatorData.Counter,
+					},
+				}
+				err = nil
+			}
+		}
+	}
+	if err != nil {
 		s.logger.Error("Failed to verify login",
 			zap.Error(err),
 			zap.String("error_type", fmt.Sprintf("%T", err)),
@@ -1634,6 +1664,42 @@ func sha256Hex(data []byte) string {
 
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h[:])
+}
+
+// verifyAssertionWithoutExtensions performs manual signature verification after
+// stripping extension data from authenticatorData. This works around a bug in
+// Yubico iOS SDK (YubiKit) where hmac-secret extension output is appended to
+// authenticatorData AFTER the YubiKey has already signed the data without it.
+//
+// The function:
+// 1. Strips authenticatorData to the first 37 bytes (rpIdHash + flags + counter)
+// 2. Clears the ED (Extension Data) flag bit
+// 3. Verifies the signature over strippedAuthData || SHA-256(clientDataJSON)
+func verifyAssertionWithoutExtensions(rawAuthData, clientDataJSON, signature, publicKeyBytes []byte) bool {
+	if len(rawAuthData) < 37 || len(clientDataJSON) == 0 || len(signature) == 0 || len(publicKeyBytes) == 0 {
+		return false
+	}
+
+	// Build stripped authenticatorData: first 37 bytes with ED flag cleared
+	strippedAuthData := make([]byte, 37)
+	copy(strippedAuthData, rawAuthData[:37])
+	strippedAuthData[32] &^= 0x80 // Clear the ED flag (bit 7)
+
+	// Compute signature input: strippedAuthData || SHA-256(clientDataJSON)
+	clientDataHash := sha256.Sum256(clientDataJSON)
+	sigData := make([]byte, 0, 37+32)
+	sigData = append(sigData, strippedAuthData...)
+	sigData = append(sigData, clientDataHash[:]...)
+
+	// Parse COSE public key
+	key, err := webauthncose.ParsePublicKey(publicKeyBytes)
+	if err != nil {
+		return false
+	}
+
+	// Verify signature
+	valid, err := webauthncose.VerifySignature(key, sigData, signature)
+	return valid && err == nil
 }
 
 func attestationSignatureInputHash(authData, clientDataJSON []byte) string {

--- a/internal/service/webauthn_test.go
+++ b/internal/service/webauthn_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1734,5 +1735,135 @@ func TestVerifyAssertionWithoutExtensions(t *testing.T) {
 		assert.False(t, verifyAssertionWithoutExtensions(corrupted, nil, parsedResp.Response.Signature, storedPubKey))
 		assert.False(t, verifyAssertionWithoutExtensions(corrupted, parsedResp.Raw.AssertionResponse.ClientDataJSON, nil, storedPubKey))
 		assert.False(t, verifyAssertionWithoutExtensions(corrupted, parsedResp.Raw.AssertionResponse.ClientDataJSON, parsedResp.Response.Signature, nil))
+	})
+}
+
+func TestIsAssertionSignatureError(t *testing.T) {
+	t.Run("matches signature error", func(t *testing.T) {
+		err := protocol.ErrAssertionSignature.WithDetails("test").WithError(fmt.Errorf("inner"))
+		assert.True(t, isAssertionSignatureError(err))
+	})
+
+	t.Run("rejects other protocol error", func(t *testing.T) {
+		err := protocol.ErrVerification.WithDetails("challenge mismatch")
+		assert.False(t, isAssertionSignatureError(err))
+	})
+
+	t.Run("rejects non-protocol error", func(t *testing.T) {
+		assert.False(t, isAssertionSignatureError(fmt.Errorf("some other error")))
+	})
+}
+
+// TestFinishLogin_YubiKitExtensionWorkaround exercises the full FinishLogin path
+// with a mutated assertion response that simulates the YubiKit SDK bug:
+// authenticatorData has hmac-secret CBOR appended and ED flag set, while the
+// signature was computed over the original (extension-free) authenticatorData.
+func TestFinishLogin_YubiKitExtensionWorkaround(t *testing.T) {
+	setup := newTestVirtualWebAuthnSetup(t)
+
+	// Register a credential
+	beginResp, err := setup.service.BeginRegistration(setup.ctx, &BeginRegistrationRequest{DisplayName: "YubiKit Test User"})
+	require.NoError(t, err)
+
+	optionsJSON, err := json.Marshal(beginResp.CreateOptions)
+	require.NoError(t, err)
+	attestationOptions, err := virtualwebauthn.ParseAttestationOptions(string(optionsJSON))
+	require.NoError(t, err)
+
+	attestationResponse := virtualwebauthn.CreateAttestationResponse(
+		setup.rp, setup.authenticator, setup.credential, *attestationOptions,
+	)
+
+	finishRegResp, err := setup.service.FinishRegistration(setup.ctx, &FinishRegistrationRequest{
+		ChallengeID: beginResp.ChallengeID,
+		Credential:  json.RawMessage(attestationResponse),
+	})
+	require.NoError(t, err)
+
+	userID := domain.UserIDFromString(finishRegResp.UUID)
+	setup.authenticator.Options.UserHandle = userID.AsUserHandle()
+	setup.authenticator.AddCredential(setup.credential)
+
+	// Helper: create a valid assertion response and corrupt its authenticatorData
+	// by appending fake hmac-secret extension CBOR and setting the ED flag.
+	createCorruptedAssertion := func(t *testing.T) (challengeID string, mutatedJSON json.RawMessage) {
+		t.Helper()
+
+		beginLoginResp, err := setup.service.BeginLogin(setup.ctx)
+		require.NoError(t, err)
+
+		loginOptionsJSON, err := json.Marshal(beginLoginResp.GetOptions)
+		require.NoError(t, err)
+		assertionOptions, err := virtualwebauthn.ParseAssertionOptions(string(loginOptionsJSON))
+		require.NoError(t, err)
+
+		assertionResponse := virtualwebauthn.CreateAssertionResponse(
+			setup.rp, setup.authenticator, setup.credential, *assertionOptions,
+		)
+
+		// Parse JSON, mutate authenticatorData, re-marshal
+		var respMap map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(assertionResponse), &respMap))
+
+		responseField := respMap["response"].(map[string]interface{})
+		authDataB64, ok := responseField["authenticatorData"].(string)
+		require.True(t, ok)
+
+		// Decode, append fake extension CBOR, set ED flag
+		authDataBytes, err := base64.RawURLEncoding.DecodeString(authDataB64)
+		require.NoError(t, err)
+
+		fakeCBOR := []byte{
+			0xA1, 0x6B, // map(1), text(11)
+			'h', 'm', 'a', 'c', '-', 's', 'e', 'c', 'r', 'e', 't',
+			0x58, 0x20, // bytes(32)
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		}
+		corrupted := make([]byte, len(authDataBytes)+len(fakeCBOR))
+		copy(corrupted, authDataBytes)
+		corrupted[32] |= 0x80 // Set ED flag
+		copy(corrupted[len(authDataBytes):], fakeCBOR)
+
+		responseField["authenticatorData"] = base64.RawURLEncoding.EncodeToString(corrupted)
+		mutatedBytes, err := json.Marshal(respMap)
+		require.NoError(t, err)
+
+		return beginLoginResp.ChallengeID, json.RawMessage(mutatedBytes)
+	}
+
+	t.Run("login succeeds with corrupted extension data", func(t *testing.T) {
+		challengeID, mutatedJSON := createCorruptedAssertion(t)
+
+		resp, err := setup.service.FinishLogin(setup.ctx, &FinishLoginRequest{
+			ChallengeID: challengeID,
+			Credential:  mutatedJSON,
+		})
+		require.NoError(t, err, "FinishLogin should succeed via the extension-stripping workaround")
+		assert.NotEmpty(t, resp.Token)
+		assert.Equal(t, finishRegResp.UUID, resp.UUID)
+	})
+
+	t.Run("user updated_at is set after workaround login", func(t *testing.T) {
+		// Get user state before login
+		userBefore, err := setup.store.Users().GetByID(setup.ctx, userID)
+		require.NoError(t, err)
+		updatedBefore := userBefore.UpdatedAt
+
+		challengeID, mutatedJSON := createCorruptedAssertion(t)
+
+		_, err = setup.service.FinishLogin(setup.ctx, &FinishLoginRequest{
+			ChallengeID: challengeID,
+			Credential:  mutatedJSON,
+		})
+		require.NoError(t, err)
+
+		// Verify the user record was updated (UpdatedAt changed)
+		userAfter, err := setup.store.Users().GetByID(setup.ctx, userID)
+		require.NoError(t, err)
+		assert.True(t, userAfter.UpdatedAt.After(updatedBefore) || userAfter.UpdatedAt.Equal(updatedBefore),
+			"User UpdatedAt should be set after workaround login")
 	})
 }

--- a/internal/service/webauthn_test.go
+++ b/internal/service/webauthn_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/descope/virtualwebauthn"
 	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1603,4 +1605,134 @@ func TestWebAuthnService_FinishLogin_OIDCGate_Success(t *testing.T) {
 	require.NoError(t, err, "Login should succeed when OIDC binding matches stored identity")
 	assert.NotEmpty(t, resp.Token, "Should receive a valid token")
 	assert.Equal(t, string(tenant.ID), resp.TenantID, "Should return the tenant ID")
+}
+
+func TestVerifyAssertionWithoutExtensions(t *testing.T) {
+	// Use the existing test setup infrastructure to get a real credential
+	setup := newTestVirtualWebAuthnSetup(t)
+
+	// Register the credential via the standard flow
+	beginResp, err := setup.service.BeginRegistration(setup.ctx, &BeginRegistrationRequest{DisplayName: "ExtTest User"})
+	require.NoError(t, err)
+
+	optionsJSON, err := json.Marshal(beginResp.CreateOptions)
+	require.NoError(t, err)
+	attestationOptions, err := virtualwebauthn.ParseAttestationOptions(string(optionsJSON))
+	require.NoError(t, err)
+
+	attestationResponse := virtualwebauthn.CreateAttestationResponse(
+		setup.rp, setup.authenticator, setup.credential, *attestationOptions,
+	)
+
+	finishRegResp, err := setup.service.FinishRegistration(setup.ctx, &FinishRegistrationRequest{
+		ChallengeID: beginResp.ChallengeID,
+		Credential:  json.RawMessage(attestationResponse),
+	})
+	require.NoError(t, err)
+
+	// Set up authenticator with user handle for assertion
+	userID := domain.UserIDFromString(finishRegResp.UUID)
+	setup.authenticator.Options.UserHandle = userID.AsUserHandle()
+	setup.authenticator.AddCredential(setup.credential)
+
+	// Do a login to get a valid assertion
+	beginLoginResp, err := setup.service.BeginLogin(setup.ctx)
+	require.NoError(t, err)
+
+	loginOptionsJSON, err := json.Marshal(beginLoginResp.GetOptions)
+	require.NoError(t, err)
+	assertionOptions, err := virtualwebauthn.ParseAssertionOptions(string(loginOptionsJSON))
+	require.NoError(t, err)
+
+	assertionResponse := virtualwebauthn.CreateAssertionResponse(
+		setup.rp, setup.authenticator, setup.credential, *assertionOptions,
+	)
+
+	// Parse the assertion to get the raw components
+	parsedResp, err := protocol.ParseCredentialRequestResponseBody(
+		strings.NewReader(assertionResponse),
+	)
+	require.NoError(t, err)
+
+	rawAuthData := parsedResp.Raw.AssertionResponse.AuthenticatorData
+	require.True(t, len(rawAuthData) >= 37)
+
+	// Look up the stored credential public key
+	user, err := setup.store.Users().GetByID(setup.ctx, userID)
+	require.NoError(t, err)
+	require.NotEmpty(t, user.WebauthnCredentials)
+	storedPubKey := user.WebauthnCredentials[0].PublicKey
+	require.NotEmpty(t, storedPubKey)
+
+	t.Run("verify_with_stripped_extensions_succeeds", func(t *testing.T) {
+		// Simulate YubiKit bug: append fake extension CBOR and set ED flag
+		fakeCBOR := []byte{
+			0xA1,                                                  // map(1)
+			0x6B,                                                  // text(11)
+			'h', 'm', 'a', 'c', '-', 's', 'e', 'c', 'r', 'e', 't', // "hmac-secret"
+			0x58, 0x20, // bytes(32)
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		}
+		corruptedAuthData := make([]byte, len(rawAuthData)+len(fakeCBOR))
+		copy(corruptedAuthData, rawAuthData)
+		corruptedAuthData[32] |= 0x80 // Set ED flag
+		copy(corruptedAuthData[len(rawAuthData):], fakeCBOR)
+
+		result := verifyAssertionWithoutExtensions(
+			corruptedAuthData,
+			parsedResp.Raw.AssertionResponse.ClientDataJSON,
+			parsedResp.Response.Signature,
+			storedPubKey,
+		)
+		assert.True(t, result, "Should verify successfully after stripping extensions")
+	})
+
+	t.Run("verify_with_extensions_present_fails", func(t *testing.T) {
+		// Build corrupted authData (same as above)
+		fakeCBOR := []byte{
+			0xA1, 0x6B,
+			'h', 'm', 'a', 'c', '-', 's', 'e', 'c', 'r', 'e', 't',
+			0x58, 0x20,
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		}
+		corruptedAuthData := make([]byte, len(rawAuthData)+len(fakeCBOR))
+		copy(corruptedAuthData, rawAuthData)
+		corruptedAuthData[32] |= 0x80
+		copy(corruptedAuthData[len(rawAuthData):], fakeCBOR)
+
+		// Signature should NOT verify over the corrupted authData
+		clientDataHash := sha256.Sum256(parsedResp.Raw.AssertionResponse.ClientDataJSON)
+		sigData := append(corruptedAuthData, clientDataHash[:]...) //nolint:gocritic
+		key, err := webauthncose.ParsePublicKey(storedPubKey)
+		require.NoError(t, err)
+		valid, _ := webauthncose.VerifySignature(key, sigData, parsedResp.Response.Signature)
+		assert.False(t, valid, "Signature should NOT verify with extension-appended authData")
+	})
+
+	t.Run("reject_short_authdata", func(t *testing.T) {
+		result := verifyAssertionWithoutExtensions(
+			[]byte{0x01, 0x02, 0x03},
+			parsedResp.Raw.AssertionResponse.ClientDataJSON,
+			parsedResp.Response.Signature,
+			storedPubKey,
+		)
+		assert.False(t, result, "Should reject authData shorter than 37 bytes")
+	})
+
+	t.Run("reject_empty_inputs", func(t *testing.T) {
+		corrupted := make([]byte, 38)
+		copy(corrupted, rawAuthData[:37])
+		corrupted[32] |= 0x80
+		corrupted[37] = 0xA0 // empty CBOR map
+
+		assert.False(t, verifyAssertionWithoutExtensions(corrupted, nil, parsedResp.Response.Signature, storedPubKey))
+		assert.False(t, verifyAssertionWithoutExtensions(corrupted, parsedResp.Raw.AssertionResponse.ClientDataJSON, nil, storedPubKey))
+		assert.False(t, verifyAssertionWithoutExtensions(corrupted, parsedResp.Raw.AssertionResponse.ClientDataJSON, parsedResp.Response.Signature, nil))
+	})
 }


### PR DESCRIPTION
## Problem

Intermittent WebAuthn assertion signature verification failures when logging in with YubiKeys via the native iOS wrapper. The failure pattern from production logs:

- **All failed attempts**: `authenticatorData` contains `hmac-secret` extension CBOR, ED flag set (`0x85`)
- **All successful attempts**: `authenticatorData` has no extensions, ED flag clear (`0x05`)
- Same credential ID, same stored public key in every case
- **Not reproducible on Android** with the same YubiKey, ruling out a firmware-level defect

## Root Cause

The wallet-ios-wrapper depends on the **`jens/extensions` branch** of Yubico's yubikit-ios SDK (commit `c7fe639`) — an experimental/WIP branch that was never merged to `main`. This branch adds PRF/hmac-secret support but has a bug in its response-processing layer.

In `YKFFIDO2Session.m`, when extensions are requested, the SDK uses a different response initializer:

```objc
// WITH extensions — passes sharedSecret to enable hmac-secret decryption:
[[YKFFIDO2GetAssertionResponse alloc] initWithCBORData:cborData sharedSecret:sharedSecret]

// WITHOUT extensions — passes raw CTAP2 response only:
[[YKFFIDO2GetAssertionResponse alloc] initWithCBORData:cborData]
```

The `initWithCBORData:sharedSecret:` variant decrypts the hmac-secret output and **reconstructs the `authData` bytes** by injecting the decrypted extension result into the CBOR extensions map and setting the ED flag. The resulting `response.authData` no longer matches what the YubiKey actually signed over.

The wallet-ios-wrapper then naively passes this mutated value to the server:
```swift
authenticatorData = response.authData.webSafeBase64EncodedString()
```

Per CTAP2.1 §6.2.2 Step 13 and §12.5, the `authData` in the assertion response (key `0x02`) is defined as "the signed-over contextual bindings" — it must be passed through unmodified for signature verification. The SDK violates this by mutating authData client-side.

**The PRF extension cannot simply be omitted** — it is critical to the login flow because the hmac-secret output is used to derive the decryption key for the wallet's private data content. The correct fix in the SDK would be to preserve the raw signed `authData` bytes for the WebAuthn response while extracting the decrypted PRF output into a separate property (`extensionsOutput`).

## Fix (server-side workaround)

When `ValidateDiscoverableLogin` returns a **signature verification error** (specifically `protocol.Error` with Type `"invalid_signature"`) and the `authenticatorData` has the ED flag set:
1. Strip extension data (keep first 37 bytes)
2. Clear the ED flag
3. Retry signature verification manually using the stored COSE public key

If the retry succeeds, accept the login and log the workaround activation at INFO level.

**Security note**: The workaround only fires for signature errors. Challenge, origin, RP ID, and user verification are validated by the library *before* the signature check (steps 7–14 in the go-webauthn `Verify()` method) and return non-signature errors that are never intercepted.

## Testing

- `TestVerifyAssertionWithoutExtensions` — unit tests for the helper (4 sub-tests)
- `TestIsAssertionSignatureError` — verifies error-type guard (3 sub-tests)
- `TestFinishLogin_YubiKitExtensionWorkaround` — full FinishLogin integration test with mutated assertion JSON (2 sub-tests)

## Follow-up (client-side)

The proper fix belongs in the wallet-ios-wrapper's YubiKit dependency. Options:
1. Patch the `jens/extensions` branch to preserve raw authData from CTAP2 response key `0x02` while extracting PRF output separately
2. Upgrade to YubiKit 4.7.0 (`main`) if it handles PRF correctly
3. Fork and maintain a corrected version
