### PR TITLE
ci: add workflow_dispatch trigger for manual builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,16 @@ on:
     tags: ['v[0-9]+.[0-9]+.[0-9]+*']
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+      image_tag:
+        description: 'Custom image tag (leave empty for standard policy)'
+        required: false
+        default: ''
 
 jobs:
   server:
@@ -17,6 +27,8 @@ jobs:
     with:
       image-name: sirosfoundation/go-wallet-backend
       dockerfile: ./Dockerfile
+      custom-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.git_ref || '' }}
+      custom-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
 
   registry:
     uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main
@@ -27,6 +39,8 @@ jobs:
     with:
       image-name: sirosfoundation/go-wallet-registry
       dockerfile: ./Dockerfile.registry
+      custom-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.git_ref || '' }}
+      custom-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
 
   wallet-admin:
     uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main
@@ -37,3 +51,5 @@ jobs:
     with:
       image-name: sirosfoundation/go-wallet-admin
       dockerfile: ./Dockerfile.wallet-admin
+      custom-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.git_ref || '' }}
+      custom-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}


### PR DESCRIPTION
Adds `workflow_dispatch` to `ci.yml` and `docker-publish.yml` so GitHub renders the **Run workflow** button on the Actions tab.

Also passes `custom-ref`/`custom-tag` inputs through to the reusable `docker-build-push` workflow for ad-hoc builds from any ref.

**Problem:** Without `workflow_dispatch`, there's no way to manually trigger builds from the Actions UI — GitHub simply doesn't render the button.

Part of a cross-repo fix applied to all sirosfoundation repos using Docker workflows.