### PR TITLE
security: add top-level permissions for least-privilege workflow tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 8 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   server:
     uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,6 +10,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sbom:
     uses: sirosfoundation/.github/.github/workflows/sbom.yml@03160e376dbdeb9f2c904e7a9f45499b2f67e8fa # main


### PR DESCRIPTION
All workflows now declare explicit top-level `permissions: contents: read` for least-privilege. Addresses OpenSSF Scorecard **Token-Permissions** check.