### PR TITLE
feat: add SET audit trail for admin API operations

### DIFF
--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -932,7 +932,7 @@ func (h *AdminHandlers) CreateVerifier(c *gin.Context) {
 	h.logger.Info("Verifier created",
 		zap.String("tenant_id", string(tenantID)),
 		zap.String("name", req.Name))
-	h.emitAudit(set.EventVerifierCreated, req.Name, map[string]any{"tenant_id": string(tenantID)})
+	h.emitAudit(set.EventVerifierCreated, verifier.URL, map[string]any{"tenant_id": string(tenantID), "name": req.Name})
 	c.JSON(http.StatusCreated, verifierToResponse(verifier))
 }
 

--- a/internal/api/admin_handlers_test.go
+++ b/internal/api/admin_handlers_test.go
@@ -2,15 +2,23 @@ package api
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 
+	"github.com/sirosfoundation/go-siros-set/set"
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage/memory"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/audit"
 )
 
 func init() {
@@ -42,6 +50,52 @@ func TestNewAdminHandlers(t *testing.T) {
 	if handlers.logger == nil {
 		t.Error("Expected logger to be set")
 	}
+}
+
+func testAuditEmitter(t *testing.T) *audit.Emitter {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "audit-key-*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(f, &pem.Block{Type: "EC PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	e, err := audit.NewFromFile("https://test.example.com", f.Name(), "test-kid")
+	if err != nil {
+		t.Fatalf("audit.NewFromFile: %v", err)
+	}
+	return e
+}
+
+func TestEmitAudit_WithAuditorConfigured(t *testing.T) {
+	logger := zap.NewNop()
+	store := memory.NewStore()
+	handlers := NewAdminHandlers(store, logger, testAuditEmitter(t))
+
+	// Should not panic and should reach the emitter (the emitter itself is
+	// tested independently in pkg/audit; here we only need to exercise the
+	// non-nil branch of emitAudit).
+	handlers.emitAudit(set.EventTenantCreated, "tenant-1", map[string]any{"name": "test"})
+}
+
+func TestEmitAudit_NilAuditorIsNoOp(t *testing.T) {
+	logger := zap.NewNop()
+	store := memory.NewStore()
+	handlers := NewAdminHandlers(store, logger, nil)
+
+	// Should not panic when no auditor is configured.
+	handlers.emitAudit(set.EventTenantCreated, "tenant-1", nil)
 }
 
 func TestAdminHandlers_AdminStatus(t *testing.T) {

--- a/internal/api/admin_invite_handlers.go
+++ b/internal/api/admin_invite_handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/sirosfoundation/go-siros-set/set"
 	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 )
@@ -120,6 +121,7 @@ func (h *AdminHandlers) CreateInvite(c *gin.Context) {
 	h.logger.Info("Invite created",
 		zap.String("tenant_id", string(tenantID)),
 		zap.String("invite_id", invite.ID))
+	h.emitAudit(set.EventInviteCreated, invite.ID, map[string]any{"tenant_id": string(tenantID)})
 	c.JSON(http.StatusCreated, inviteToResponse(invite, true))
 }
 
@@ -249,6 +251,7 @@ func (h *AdminHandlers) UpdateInvite(c *gin.Context) {
 		zap.String("tenant_id", string(tenantID)),
 		zap.String("invite_id", inviteID),
 		zap.String("action", req.Action))
+	h.emitAudit(set.EventInviteUpdated, inviteID, map[string]any{"tenant_id": string(tenantID), "action": req.Action})
 	c.JSON(http.StatusOK, inviteToResponse(invite, false))
 }
 
@@ -284,5 +287,6 @@ func (h *AdminHandlers) DeleteInvite(c *gin.Context) {
 	h.logger.Info("Invite deleted",
 		zap.String("tenant_id", string(tenantID)),
 		zap.String("invite_id", inviteID))
+	h.emitAudit(set.EventInviteDeleted, inviteID, map[string]any{"tenant_id": string(tenantID)})
 	c.JSON(http.StatusOK, gin.H{"message": "Invite deleted"})
 }

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -384,11 +384,11 @@ type BackendProvider struct {
 	storage          *StorageProvider
 	store            backend.Backend
 	cfg              *config.Config
+	auditor          *audit.Emitter
 	authzenHandler   *api.AuthZENProxyHandler
 	metadataResolver *issuermetadata.Resolver
 	asModule         *as.ASModule
 	tokenValidator   *tokenvalidator.Validator
-	auditor          *audit.Emitter
 	logger           *zap.Logger
 }
 
@@ -492,11 +492,11 @@ func NewBackendProvider(cfg *config.Config, logger *zap.Logger, roles []string) 
 		storage:          storageProvider,
 		store:            store,
 		cfg:              cfg,
+		auditor:          newAuditEmitter(cfg, logger),
 		authzenHandler:   authzenHandler,
 		metadataResolver: metadataResolver,
 		asModule:         asModule,
 		tokenValidator:   tv,
-		auditor:          newAuditEmitter(cfg, logger),
 		logger:           logger,
 	}, nil
 }

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -109,12 +109,14 @@ func NewFromConfig(cfg *config.Config, logger *zap.Logger) *Emitter {
 	return emitter
 }
 
-// Emit emits an audit event.
+// Emit emits an audit event. Errors are logged but do not fail the operation.
 func (a *Emitter) Emit(event set.EventURI, data map[string]any) {
 	if a == nil {
 		return
 	}
-	_ = a.e.Emit(event, data)
+	if err := a.e.Emit(event, data); err != nil {
+		slog.Error("audit emit failed", "event", string(event), "error", err)
+	}
 }
 
 // EmitWithSubject emits an audit event with a subject identifier.
@@ -122,5 +124,7 @@ func (a *Emitter) EmitWithSubject(event set.EventURI, subject string, data map[s
 	if a == nil {
 		return
 	}
-	_ = a.e.EmitWithSubject(event, subject, data)
+	if err := a.e.EmitWithSubject(event, subject, data); err != nil {
+		slog.Error("audit emit failed", "event", string(event), "subject", subject, "error", err)
+	}
 }

--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -1,12 +1,14 @@
 package audit
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -192,4 +194,105 @@ func TestEmit_Success(t *testing.T) {
 	// Should not panic — just verify it runs without error.
 	e.Emit(set.EventWIAIssued, map[string]any{"test": true})
 	e.EmitWithSubject(set.EventWIAIssued, "test-subject", map[string]any{"test": true})
+}
+
+func TestNew_WithLogger(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	joseSigner, err := set.NewSigner(key, "ES256", "test-kid")
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	e := New("https://test.example.com", joseSigner, logger)
+	if e == nil {
+		t.Fatal("expected non-nil emitter")
+	}
+}
+
+func TestNewFromFile_PKCS8EC(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "audit-pkcs8-*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(f, &pem.Block{Type: "PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	e, err := NewFromFile("https://test.example.com", f.Name(), "test-kid")
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+	if e == nil {
+		t.Fatal("emitter should not be nil")
+	}
+}
+
+func TestNewFromFile_PKCS8UnsupportedKeyType(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "audit-rsa-*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(f, &pem.Block{Type: "PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	_, err = NewFromFile("https://test.example.com", f.Name(), "test-kid")
+	if err == nil {
+		t.Fatal("expected error for unsupported (non-ECDSA) key type")
+	}
+}
+
+func TestNewFromFile_P521(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	path := writeTestKey(t, key)
+
+	e, err := NewFromFile("https://test.example.com", path, "test-kid")
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+	if e == nil {
+		t.Fatal("emitter should not be nil")
+	}
+}
+
+func TestNewFromFile_UnsupportedCurveSize(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	path := writeTestKey(t, key)
+
+	_, err := NewFromFile("https://test.example.com", path, "test-kid")
+	if err == nil {
+		t.Fatal("expected error for unsupported EC curve size")
+	}
+}
+
+func TestEmit_MarshalError(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	path := writeTestKey(t, key)
+
+	e, err := NewFromFile("https://test.example.com", path, "test-kid")
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+
+	// A func value can't be JSON-marshaled, forcing the record-signing
+	// error path. Should be logged, not panic or propagate.
+	e.Emit(set.EventWIAIssued, map[string]any{"bad": func() {}})
+	e.EmitWithSubject(set.EventWIAIssued, "test-subject", map[string]any{"bad": func() {}})
 }


### PR DESCRIPTION
## Admin Audit Trail

Adds structured audit logging via Security Event Tokens (RFC 8417) for all admin API write operations.

### New package
- `pkg/audit`: SET event emitter with configurable ECDSA signing

### Audit events emitted for
- Tenant CRUD (create, update, delete)
- Issuer CRUD (create, update, delete)
- Verifier CRUD (create, update, delete)
- Invite lifecycle (create, update, delete)
- User management (remove from tenant)

### Configuration
```yaml
audit:
  issuer: "https://wallet.example.com"
  private_key_path: "/path/to/audit-key.pem"
  key_id: "audit-key-1"
```

The emitter is nil-safe — when audit is not configured, all emit calls are no-ops.

---
*Extracted from #221 (WIA service PR) to keep PRs focused.*