### PR TITLE
feat(registry): support mso_mdoc credentials, not just sd-jwt VCTM

### DIFF
--- a/internal/registry/document.go
+++ b/internal/registry/document.go
@@ -1,0 +1,71 @@
+package registry
+
+import "encoding/json"
+
+// documentHeader holds the fields we can extract generically from a
+// credential type metadata document, regardless of whether it's a VCTM
+// (sd-jwt, identified by "vct") or an MDDL (mso_mdoc, identified by
+// "doctype"). Both formats nest their human-readable name/description under
+// a locale-keyed "display" array rather than top-level fields; a few
+// top-level name/description/organization fields are also checked first for
+// forward compatibility with documents that do set them directly.
+type documentHeader struct {
+	VCT          string         `json:"vct"`
+	DocType      string         `json:"doctype"`
+	Name         string         `json:"name"`
+	Description  string         `json:"description"`
+	Organization string         `json:"organization"`
+	Display      []displayEntry `json:"display"`
+}
+
+// displayEntry is a single locale's display properties within a "display"
+// array, as used by both VCTM and MDDL documents.
+type displayEntry struct {
+	Locale      string `json:"locale"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// parseDocumentHeader best-effort parses the identifying fields out of a
+// credential type metadata document. Parse errors are ignored; callers get
+// the zero value, matching how header extraction has always been treated as
+// advisory rather than required (the caller decides what to do when fields
+// are missing).
+func parseDocumentHeader(body []byte) documentHeader {
+	var h documentHeader
+	_ = json.Unmarshal(body, &h)
+	return h
+}
+
+// identifier returns the document's identifier: its "vct" if present
+// (sd-jwt), otherwise its "doctype" (mso_mdoc). Returns "" if neither is set.
+func (h documentHeader) identifier() string {
+	if h.VCT != "" {
+		return h.VCT
+	}
+	return h.DocType
+}
+
+// displayName returns a top-level "name" if the document set one, otherwise
+// the first display[] entry's name.
+func (h documentHeader) displayName() string {
+	if h.Name != "" {
+		return h.Name
+	}
+	if len(h.Display) > 0 {
+		return h.Display[0].Name
+	}
+	return ""
+}
+
+// displayDescription returns a top-level "description" if the document set
+// one, otherwise the first display[] entry's description.
+func (h documentHeader) displayDescription() string {
+	if h.Description != "" {
+		return h.Description
+	}
+	if len(h.Display) > 0 {
+		return h.Display[0].Description
+	}
+	return ""
+}

--- a/internal/registry/document_test.go
+++ b/internal/registry/document_test.go
@@ -1,0 +1,87 @@
+package registry
+
+import "testing"
+
+func TestParseDocumentHeader_VCT(t *testing.T) {
+	body := []byte(`{"vct": "urn:eudi:pid:1", "name": "PID", "description": "desc"}`)
+	h := parseDocumentHeader(body)
+
+	if got := h.identifier(); got != "urn:eudi:pid:1" {
+		t.Errorf("identifier() = %q, want %q", got, "urn:eudi:pid:1")
+	}
+	if got := h.displayName(); got != "PID" {
+		t.Errorf("displayName() = %q, want %q", got, "PID")
+	}
+	if got := h.displayDescription(); got != "desc" {
+		t.Errorf("displayDescription() = %q, want %q", got, "desc")
+	}
+}
+
+func TestParseDocumentHeader_Doctype(t *testing.T) {
+	// mso_mdoc (MDDL) documents have no "vct" at all — "doctype" is the
+	// identifier, and name/description live under display[], not top-level.
+	body := []byte(`{
+		"format": "mso_mdoc",
+		"doctype": "org.iso.18013.5.1.mDL",
+		"display": [{"locale": "en-US", "name": "mDL", "description": "Mobile Driving Licence"}]
+	}`)
+	h := parseDocumentHeader(body)
+
+	if got := h.identifier(); got != "org.iso.18013.5.1.mDL" {
+		t.Errorf("identifier() = %q, want %q", got, "org.iso.18013.5.1.mDL")
+	}
+	if got := h.displayName(); got != "mDL" {
+		t.Errorf("displayName() = %q, want %q", got, "mDL")
+	}
+	if got := h.displayDescription(); got != "Mobile Driving Licence" {
+		t.Errorf("displayDescription() = %q, want %q", got, "Mobile Driving Licence")
+	}
+}
+
+func TestParseDocumentHeader_VCTPreferredOverDoctype(t *testing.T) {
+	// A document should never have both, but vct wins if it somehow does —
+	// sd-jwt credentials are the common case and vct is the more specific field.
+	body := []byte(`{"vct": "urn:eudi:pid:1", "doctype": "eu.europa.ec.eudi.pid.1"}`)
+	h := parseDocumentHeader(body)
+
+	if got := h.identifier(); got != "urn:eudi:pid:1" {
+		t.Errorf("identifier() = %q, want %q", got, "urn:eudi:pid:1")
+	}
+}
+
+func TestParseDocumentHeader_NoIdentifier(t *testing.T) {
+	h := parseDocumentHeader([]byte(`{"name": "no id"}`))
+	if got := h.identifier(); got != "" {
+		t.Errorf("identifier() = %q, want empty", got)
+	}
+}
+
+func TestParseDocumentHeader_TopLevelNameWinsOverDisplay(t *testing.T) {
+	body := []byte(`{
+		"vct": "urn:test:1",
+		"name": "Top Level Name",
+		"display": [{"locale": "en-US", "name": "Display Name"}]
+	}`)
+	h := parseDocumentHeader(body)
+
+	if got := h.displayName(); got != "Top Level Name" {
+		t.Errorf("displayName() = %q, want %q", got, "Top Level Name")
+	}
+}
+
+func TestParseDocumentHeader_NoDisplayNoTopLevel(t *testing.T) {
+	h := parseDocumentHeader([]byte(`{"vct": "urn:test:1"}`))
+	if got := h.displayName(); got != "" {
+		t.Errorf("displayName() = %q, want empty", got)
+	}
+	if got := h.displayDescription(); got != "" {
+		t.Errorf("displayDescription() = %q, want empty", got)
+	}
+}
+
+func TestParseDocumentHeader_InvalidJSON(t *testing.T) {
+	h := parseDocumentHeader([]byte(`not json`))
+	if got := h.identifier(); got != "" {
+		t.Errorf("identifier() = %q, want empty on invalid JSON", got)
+	}
+}

--- a/internal/registry/dynamic_fetcher.go
+++ b/internal/registry/dynamic_fetcher.go
@@ -124,20 +124,26 @@ func (f *DynamicFetcher) Fetch(ctx context.Context, vctURL string, existingEntry
 	}
 
 	// Validate JSON
-	var metadata map[string]interface{}
-	if err := json.Unmarshal(body, &metadata); err != nil {
-		return nil, fmt.Errorf("invalid JSON response: %w", err)
+	if !json.Valid(body) {
+		return nil, fmt.Errorf("invalid JSON response")
 	}
+	header := parseDocumentHeader(body)
 
 	// Calculate cache TTL
 	expiresAt := f.calculateExpiresAt(resp.Header)
 
-	// Build entry
+	// Build entry. Dynamic entries are always keyed by the URL that was
+	// fetched (not by any "vct"/"doctype" embedded in the document), since
+	// that's the same string the caller will look it up by again later.
+	name := header.displayName()
+	if name == "" {
+		name = vctURL
+	}
 	entry := &VCTMEntry{
 		VCT:          vctURL,
-		Name:         extractStringField(metadata, "name", vctURL),
-		Description:  extractStringField(metadata, "description", ""),
-		Organization: extractStringField(metadata, "organization", ""),
+		Name:         name,
+		Description:  header.displayDescription(),
+		Organization: header.Organization,
 		Metadata:     body,
 		FetchedAt:    time.Now(),
 		IsDynamic:    true,
@@ -197,16 +203,6 @@ func parseCacheControlMaxAge(cacheControl string) time.Duration {
 		}
 	}
 	return 0
-}
-
-// extractStringField extracts a string field from a map with a default value
-func extractStringField(m map[string]interface{}, key, defaultValue string) string {
-	if v, ok := m[key]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
-	}
-	return defaultValue
 }
 
 // IsURL checks if a string looks like a URL that could be fetched

--- a/internal/registry/dynamic_fetcher.go
+++ b/internal/registry/dynamic_fetcher.go
@@ -123,9 +123,12 @@ func (f *DynamicFetcher) Fetch(ctx context.Context, vctURL string, existingEntry
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Validate JSON
-	if !json.Valid(body) {
-		return nil, fmt.Errorf("invalid JSON response")
+	// Validate JSON. A credential type metadata document is always a JSON
+	// object; json.Valid alone would also accept top-level arrays/scalars,
+	// silently caching them as an entry with blank header fields.
+	var asObject map[string]json.RawMessage
+	if err := json.Unmarshal(body, &asObject); err != nil {
+		return nil, fmt.Errorf("invalid JSON response: expected a JSON object: %w", err)
 	}
 	header := parseDocumentHeader(body)
 

--- a/internal/registry/dynamic_fetcher_test.go
+++ b/internal/registry/dynamic_fetcher_test.go
@@ -357,6 +357,38 @@ func TestDynamicFetcher_Fetch_InvalidJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid JSON")
 }
 
+func TestDynamicFetcher_Fetch_RejectsNonObjectJSON(t *testing.T) {
+	// A credential type metadata document is always a JSON object. A
+	// top-level array or scalar is syntactically valid JSON but not a
+	// sensible document — it must be rejected, not cached as a blank entry.
+	for _, body := range []string{`[1, 2, 3]`, `"just a string"`, `42`} {
+		t.Run(body, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+
+			config := &DynamicCacheConfig{
+				Enabled:      true,
+				DefaultTTL:   1 * time.Hour,
+				MaxTTL:       24 * time.Hour,
+				MinTTL:       5 * time.Minute,
+				Timeout:      30 * time.Second,
+				AllowedHosts: []string{},
+			}
+			require.NoError(t, config.Compile())
+
+			fetcher := NewDynamicFetcher(config, testDynamicLogger(), nil)
+			fetcher.client = server.Client()
+
+			_, err := fetcher.Fetch(context.Background(), server.URL, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "expected a JSON object")
+		})
+	}
+}
+
 func TestParseCacheControlMaxAge(t *testing.T) {
 	tests := []struct {
 		cacheControl string

--- a/internal/registry/dynamic_fetcher_test.go
+++ b/internal/registry/dynamic_fetcher_test.go
@@ -175,6 +175,47 @@ func TestDynamicFetcher_Fetch_Success(t *testing.T) {
 	assert.False(t, entry.ExpiresAt.IsZero())
 }
 
+func TestDynamicFetcher_Fetch_MDocDocument(t *testing.T) {
+	// An MDDL (mso_mdoc) document has no top-level name/description at all —
+	// they live under display[]. The entry is still keyed by the fetch URL,
+	// matching sd-jwt dynamic-fetch behavior, but Name/Description must come
+	// from display[0] rather than being left blank.
+	mddlJSON := []byte(`{
+		"format": "mso_mdoc",
+		"doctype": "org.iso.18013.5.1.mDL",
+		"display": [{"locale": "en-US", "name": "mDL", "description": "Mobile Driving Licence"}]
+	}`)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(mddlJSON)
+	}))
+	defer server.Close()
+
+	config := &DynamicCacheConfig{
+		Enabled:      true,
+		DefaultTTL:   1 * time.Hour,
+		MaxTTL:       24 * time.Hour,
+		MinTTL:       5 * time.Minute,
+		Timeout:      30 * time.Second,
+		AllowedHosts: []string{},
+	}
+	require.NoError(t, config.Compile())
+
+	fetcher := NewDynamicFetcher(config, testDynamicLogger(), nil)
+	fetcher.client = server.Client()
+
+	result, err := fetcher.Fetch(context.Background(), server.URL, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	entry := result.Entry
+	require.NotNil(t, entry)
+	assert.Equal(t, server.URL, entry.VCT, "dynamic entries are keyed by the fetch URL, not the doctype")
+	assert.Equal(t, "mDL", entry.Name)
+	assert.Equal(t, "Mobile Driving Licence", entry.Description)
+}
+
 func TestDynamicFetcher_Fetch_304NotModified(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check for conditional request headers
@@ -436,17 +477,4 @@ func TestVCTMEntry_IsExpired(t *testing.T) {
 		}
 		assert.False(t, entry.IsExpired())
 	})
-}
-
-func TestExtractStringField(t *testing.T) {
-	m := map[string]interface{}{
-		"name":   "Test Name",
-		"count":  42,
-		"active": true,
-	}
-
-	assert.Equal(t, "Test Name", extractStringField(m, "name", "default"))
-	assert.Equal(t, "default", extractStringField(m, "missing", "default"))
-	assert.Equal(t, "default", extractStringField(m, "count", "default"))  // Non-string
-	assert.Equal(t, "default", extractStringField(m, "active", "default")) // Non-string
 }

--- a/internal/registry/fetcher.go
+++ b/internal/registry/fetcher.go
@@ -561,10 +561,17 @@ func (f *Fetcher) processRegistryResponse(ctx context.Context, source RemoteSour
 				for _, su := range schema.SchemaURIs {
 					entry, fetchErr := f.fetchSchemaDocument(ctx, schema, su.URI)
 					if fetchErr != nil {
+						errorCount++
 						f.logger.Debug("failed to fetch schema document from detail",
 							zap.String("id", cred.ID), zap.String("format", su.FormatIdentifier), zap.Error(fetchErr))
 						continue
 					}
+					// The document was fetched successfully — this credential
+					// has real TS11 detail, whether or not the filter admits
+					// it. Set fetchedAny before the filter check so a
+					// filtered-out credential doesn't fall through to the
+					// stub fallback below and reappear keyed by schema ID.
+					fetchedAny = true
 					if !f.config.Filter.Matches(entry.VCT) {
 						filteredCount++
 						continue
@@ -572,7 +579,6 @@ func (f *Fetcher) processRegistryResponse(ctx context.Context, source RemoteSour
 					entries[entry.VCT] = entry
 					fetchedCount++
 					detailCount++
-					fetchedAny = true
 				}
 			}
 		}
@@ -580,10 +586,10 @@ func (f *Fetcher) processRegistryResponse(ctx context.Context, source RemoteSour
 			continue
 		}
 
-		// Detail not available (non-TS11) or every format's fetch failed.
-		// Create a stub entry with the metadata we have from the registry list.
-		// Use the schema ID as a placeholder identifier (the real vct/doctype
-		// is unknown without the document).
+		// No TS11 detail available (non-TS11 entry) or every format's fetch
+		// failed outright. Create a stub entry with the metadata we have
+		// from the registry list. Use the schema ID as a placeholder
+		// identifier (the real vct/doctype is unknown without the document).
 		vct := cred.ID
 		if !f.config.Filter.Matches(vct) {
 			filteredCount++

--- a/internal/registry/fetcher.go
+++ b/internal/registry/fetcher.go
@@ -370,47 +370,43 @@ func (f *Fetcher) processTS11Response(ctx context.Context, source RemoteSourceCo
 		}
 
 		for _, schema := range page.Entries() {
-			// Determine which schemaURI to use as the VCTM fetch URL.
-			// Prefer the dc+sd-jwt entry; fall back to the first URI.
-			var vctmURI string
-			for _, su := range schema.SchemaURIs {
-				if su.FormatIdentifier == "dc+sd-jwt" {
-					vctmURI = su.URI
-					break
-				}
-			}
-			if vctmURI == "" && len(schema.SchemaURIs) > 0 {
-				vctmURI = schema.SchemaURIs[0].URI
-			}
-			if vctmURI == "" {
+			if len(schema.SchemaURIs) == 0 {
 				f.logger.Warn("TS11 schema has no schemaURIs, skipping", zap.String("id", schema.ID))
 				errorCount++
 				continue
 			}
 
-			// NOTE: we do not pre-derive the VCT from the schemaURI.
-			// The authoritative VCT identifier lives inside the fetched VCTM
-			// document itself ("vct" field) and may be a URN (e.g.
-			// "urn:eudi:diploma:1") rather than the HTTP URL of the document.
-			// We must fetch first, then apply the filter on the real VCT.
-			entry, err := f.fetchTS11VCTM(ctx, schema, vctmURI)
-			if err != nil {
-				errorCount++
-				f.logger.Warn("failed to fetch TS11 VCTM",
-					zap.String("schema_id", schema.ID),
-					zap.String("url", vctmURI),
-					zap.Error(err))
-				continue
-			}
+			// Fetch every format's document, not just one. A schema may
+			// offer both an sd-jwt (VCTM) and an mso_mdoc (MDDL) document
+			// for the same logical credential; each is cached under its own
+			// identifier ("vct" or "doctype") so both are queryable.
+			for _, su := range schema.SchemaURIs {
+				// NOTE: we do not pre-derive the identifier from the
+				// schemaURI. The authoritative identifier lives inside the
+				// fetched document itself ("vct" for sd-jwt, "doctype" for
+				// mso_mdoc) and may not match the HTTP URL used to fetch it
+				// (e.g. a "vct" that's a URN like "urn:eudi:diploma:1"). We
+				// must fetch first, then apply the filter on the real value.
+				entry, err := f.fetchSchemaDocument(ctx, schema, su.URI)
+				if err != nil {
+					errorCount++
+					f.logger.Warn("failed to fetch schema document",
+						zap.String("schema_id", schema.ID),
+						zap.String("format", su.FormatIdentifier),
+						zap.String("url", su.URI),
+						zap.Error(err))
+					continue
+				}
 
-			if !f.config.Filter.Matches(entry.VCT) {
-				filteredCount++
-				f.logger.Debug("filtered out credential", zap.String("vct", entry.VCT))
-				continue
-			}
+				if !f.config.Filter.Matches(entry.VCT) {
+					filteredCount++
+					f.logger.Debug("filtered out credential", zap.String("id", entry.VCT))
+					continue
+				}
 
-			entries[entry.VCT] = entry
-			fetchedCount++
+				entries[entry.VCT] = entry
+				fetchedCount++
+			}
 		}
 
 		// Follow pagination if more pages are available.
@@ -437,48 +433,38 @@ func (f *Fetcher) processTS11Response(ctx context.Context, source RemoteSourceCo
 	return entries, nil
 }
 
-// fetchTS11VCTM fetches the VCTM document for a TS11 schema and constructs a VCTMEntry.
-// The authoritative VCT identifier, name, and description are all extracted from the
-// fetched VCTM document.  The VCT field in the document takes precedence over the
-// schemaURI used to fetch it, because the VCT may be a URN (e.g. "urn:eudi:diploma:1")
-// rather than an HTTP URL.  If the document does not contain a "vct" field, vctmURI is
-// used as the fallback identifier.
-func (f *Fetcher) fetchTS11VCTM(ctx context.Context, schema TS11SchemaMeta, vctmURI string) (*VCTMEntry, error) {
-	f.logger.Debug("fetching TS11 VCTM", zap.String("url", vctmURI))
+// fetchSchemaDocument fetches a single format's document for a TS11 schema
+// (a VCTM for sd-jwt, or an MDDL for mso_mdoc) and constructs a VCTMEntry.
+// The authoritative identifier, name, and description are all extracted from
+// the fetched document itself, taking precedence over docURI: the identifier
+// may be a URN (e.g. "urn:eudi:diploma:1") or a doctype (e.g.
+// "org.iso.18013.5.1.mDL") rather than the HTTP URL used to fetch it. If the
+// document contains neither a "vct" nor a "doctype" field, docURI is used as
+// the fallback identifier.
+func (f *Fetcher) fetchSchemaDocument(ctx context.Context, schema TS11SchemaMeta, docURI string) (*VCTMEntry, error) {
+	f.logger.Debug("fetching schema document", zap.String("url", docURI))
 
-	body, err := f.fetchRaw(ctx, vctmURI)
+	body, err := f.fetchRaw(ctx, docURI)
 	if err != nil {
 		return nil, err
 	}
 
 	if !json.Valid(body) {
-		return nil, fmt.Errorf("invalid JSON in VCTM response")
+		return nil, fmt.Errorf("invalid JSON in schema document response")
 	}
 
-	// Extract the authoritative VCT identifier, name, and description from the
-	// VCTM document itself.
-	var vctmDoc struct {
-		VCT         string `json:"vct"`
-		Name        string `json:"name"`
-		Description string `json:"description,omitempty"`
-	}
-	if err := json.Unmarshal(body, &vctmDoc); err != nil {
-		f.logger.Debug("could not extract fields from VCTM document",
-			zap.String("url", vctmURI), zap.Error(err))
-	}
-
-	// Fall back to the schemaURI when the document does not carry a "vct" field.
-	vct := vctmDoc.VCT
-	if vct == "" {
-		f.logger.Debug("VCTM document has no 'vct' field, falling back to schemaURI",
-			zap.String("url", vctmURI))
-		vct = vctmURI
+	header := parseDocumentHeader(body)
+	id := header.identifier()
+	if id == "" {
+		f.logger.Debug("schema document has no 'vct' or 'doctype' field, falling back to its URI",
+			zap.String("url", docURI))
+		id = docURI
 	}
 
 	return &VCTMEntry{
-		VCT:              vct,
-		Name:             vctmDoc.Name,
-		Description:      vctmDoc.Description,
+		VCT:              id,
+		Name:             header.displayName(),
+		Description:      header.displayDescription(),
 		Metadata:         json.RawMessage(body),
 		AttestationLoS:   schema.AttestationLoS,
 		BindingType:      schema.BindingType,
@@ -565,24 +551,20 @@ func (f *Fetcher) processRegistryResponse(ctx context.Context, source RemoteSour
 		// Try to fetch TS11 detail for this credential (includes schemaURIs).
 		detailURL := baseURL + "/api/v1/schemas/" + cred.ID + ".json"
 		detailBody, err := f.fetchRaw(ctx, detailURL)
+		fetchedAny := false
 		if err == nil {
-			// Successfully fetched detail — process as TS11 schema with VCTM fetch.
+			// Successfully fetched detail — fetch every format's document,
+			// not just one, so an mso_mdoc variant alongside a dc+sd-jwt
+			// variant is also cached (see processTS11Response for why).
 			var schema TS11SchemaMeta
 			if jsonErr := json.Unmarshal(detailBody, &schema); jsonErr == nil && len(schema.SchemaURIs) > 0 {
-				// Pick the VCTM URI
-				var vctmURI string
 				for _, su := range schema.SchemaURIs {
-					if su.FormatIdentifier == "dc+sd-jwt" {
-						vctmURI = su.URI
-						break
+					entry, fetchErr := f.fetchSchemaDocument(ctx, schema, su.URI)
+					if fetchErr != nil {
+						f.logger.Debug("failed to fetch schema document from detail",
+							zap.String("id", cred.ID), zap.String("format", su.FormatIdentifier), zap.Error(fetchErr))
+						continue
 					}
-				}
-				if vctmURI == "" {
-					vctmURI = schema.SchemaURIs[0].URI
-				}
-
-				entry, fetchErr := f.fetchTS11VCTM(ctx, schema, vctmURI)
-				if fetchErr == nil {
 					if !f.config.Filter.Matches(entry.VCT) {
 						filteredCount++
 						continue
@@ -590,15 +572,18 @@ func (f *Fetcher) processRegistryResponse(ctx context.Context, source RemoteSour
 					entries[entry.VCT] = entry
 					fetchedCount++
 					detailCount++
-					continue
+					fetchedAny = true
 				}
-				f.logger.Debug("failed to fetch VCTM from detail", zap.String("id", cred.ID), zap.Error(fetchErr))
 			}
 		}
+		if fetchedAny {
+			continue
+		}
 
-		// Detail not available (non-TS11) or VCTM fetch failed.
+		// Detail not available (non-TS11) or every format's fetch failed.
 		// Create a stub entry with the metadata we have from the registry list.
-		// Use the schema ID as a placeholder VCT (the real VCT is unknown without VCTM).
+		// Use the schema ID as a placeholder identifier (the real vct/doctype
+		// is unknown without the document).
 		vct := cred.ID
 		if !f.config.Filter.Matches(vct) {
 			filteredCount++

--- a/internal/registry/fetcher_test.go
+++ b/internal/registry/fetcher_test.go
@@ -1360,6 +1360,55 @@ func TestFetcher_FetchFromSource_RegistryFormat_FetchesAllFormats(t *testing.T) 
 	assert.Equal(t, "PID mdoc", mdocEntry.Name)
 }
 
+func TestFetcher_FetchFromSource_RegistryFormat_FilteredNotStubbed(t *testing.T) {
+	// A credential whose document was successfully fetched but excluded by
+	// the filter must not reappear as a stub keyed by schema ID — that would
+	// reintroduce something the filter was configured to exclude.
+	vctmContent := `{"vct":"urn:eudi:pid:1","name":"PID SD-JWT"}`
+
+	docServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(vctmContent))
+	}))
+	defer docServer.Close()
+
+	registryMux := http.NewServeMux()
+	registryMux.HandleFunc("/api/v1/schemas/pid-id.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TS11SchemaMeta{
+			ID:               "pid-id",
+			Version:          "1.0.0",
+			SupportedFormats: []string{"dc+sd-jwt"},
+			SchemaURIs: []TS11SchemaURI{
+				{FormatIdentifier: "dc+sd-jwt", URI: docServer.URL + "/pid.vctm.json"},
+			},
+		})
+	})
+	registryMux.HandleFunc("/api/v1/registry.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RegistryResponse{
+			Total: 1,
+			Credentials: []RegistryListEntry{
+				{ID: "pid-id", Version: "1.0.0", SupportedFormats: []string{"dc+sd-jwt"}},
+			},
+		})
+	})
+	registryServer := httptest.NewServer(registryMux)
+	defer registryServer.Close()
+
+	config := DefaultConfig()
+	config.Filter.ExcludePatterns = []string{"^urn:eudi:pid:"}
+	require.NoError(t, config.Filter.Compile())
+	fetcher := NewFetcher(config, NewStore(""), testLogger(), nil)
+
+	src := RemoteSourceConfig{URL: registryServer.URL + "/api/v1/registry.json", Mode: APIModeRegistry}
+	entries, err := fetcher.fetchFromSource(context.Background(), src)
+	require.NoError(t, err)
+
+	// Neither the real (filtered) entry nor a schema-ID-keyed stub should be present.
+	assert.Empty(t, entries, "filtered-out credential must not reappear as a stub")
+}
+
 // TestConfig_Validate_InvalidMode verifies that invalid Mode values are rejected.
 func TestConfig_Validate_InvalidMode(t *testing.T) {
 	config := DefaultConfig()

--- a/internal/registry/fetcher_test.go
+++ b/internal/registry/fetcher_test.go
@@ -373,6 +373,64 @@ func TestFetcher_FetchFromSource_TS11_FallbackToFirstSchemaURI(t *testing.T) {
 	require.Len(t, entries, 1)
 }
 
+func TestFetcher_FetchFromSource_TS11_FetchesAllFormats(t *testing.T) {
+	// A schema offering both an sd-jwt (VCTM) and an mso_mdoc (MDDL) document
+	// for the same logical credential must cache both, each under its own
+	// identifier — not just the sd-jwt one.
+	vctmContent := `{"vct":"urn:eudi:pid:1","name":"PID SD-JWT"}`
+	mddlContent := `{"format":"mso_mdoc","doctype":"eu.europa.ec.eudi.pid.1","display":[{"locale":"en-US","name":"PID mdoc"}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/pid.vctm.json":
+			_, _ = w.Write([]byte(vctmContent))
+		case "/pid.mdoc.json":
+			_, _ = w.Write([]byte(mddlContent))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	schemas := TS11SchemasResponse{
+		Schemas: []TS11SchemaMeta{
+			{
+				ID:               "pid-id",
+				Version:          "1.0.0",
+				SupportedFormats: []string{"dc+sd-jwt", "mso_mdoc"},
+				SchemaURIs: []TS11SchemaURI{
+					{FormatIdentifier: "dc+sd-jwt", URI: server.URL + "/pid.vctm.json"},
+					{FormatIdentifier: "mso_mdoc", URI: server.URL + "/pid.mdoc.json"},
+				},
+			},
+		},
+	}
+
+	indexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(schemas)
+	}))
+	defer indexServer.Close()
+
+	config := DefaultConfig()
+	fetcher := NewFetcher(config, NewStore(""), testLogger(), nil)
+
+	src := RemoteSourceConfig{URL: indexServer.URL}
+	entries, err := fetcher.fetchFromSource(context.Background(), src)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	sdjwtEntry, ok := entries["urn:eudi:pid:1"]
+	require.True(t, ok, "sd-jwt entry should be keyed on its vct")
+	assert.Equal(t, "PID SD-JWT", sdjwtEntry.Name)
+
+	mdocEntry, ok := entries["eu.europa.ec.eudi.pid.1"]
+	require.True(t, ok, "mdoc entry should be keyed on its doctype")
+	assert.Equal(t, "PID mdoc", mdocEntry.Name)
+	assert.Equal(t, []string{"dc+sd-jwt", "mso_mdoc"}, mdocEntry.SupportedFormats)
+}
+
 func TestFetcher_FetchFromSource_TS11_SkipsSchemaWithNoURIs(t *testing.T) {
 	schemas := TS11SchemasResponse{
 		Schemas: []TS11SchemaMeta{
@@ -1239,6 +1297,67 @@ func TestFetcher_FetchFromSource_RegistryFormat(t *testing.T) {
 	require.True(t, ok, "non-TS11 entry should be keyed on schema ID")
 	assert.Equal(t, "iso_18045_moderate", nonTS11Entry.AttestationLoS)
 	assert.Equal(t, []string{"mso_mdoc", "dc+sd-jwt"}, nonTS11Entry.SupportedFormats)
+}
+
+func TestFetcher_FetchFromSource_RegistryFormat_FetchesAllFormats(t *testing.T) {
+	// Same as TestFetcher_FetchFromSource_RegistryFormat's TS11 detail path,
+	// but the detail schema offers both an sd-jwt and an mso_mdoc document —
+	// both must be cached, not just the sd-jwt one.
+	vctmContent := `{"vct":"urn:eudi:pid:1","name":"PID SD-JWT"}`
+	mddlContent := `{"format":"mso_mdoc","doctype":"eu.europa.ec.eudi.pid.1","display":[{"locale":"en-US","name":"PID mdoc"}]}`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/pid.vctm.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(vctmContent))
+	})
+	mux.HandleFunc("/pid.mdoc.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mddlContent))
+	})
+	docServer := httptest.NewServer(mux)
+	defer docServer.Close()
+
+	registryMux := http.NewServeMux()
+	registryMux.HandleFunc("/api/v1/schemas/pid-id.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TS11SchemaMeta{
+			ID:               "pid-id",
+			Version:          "1.0.0",
+			SupportedFormats: []string{"dc+sd-jwt", "mso_mdoc"},
+			SchemaURIs: []TS11SchemaURI{
+				{FormatIdentifier: "dc+sd-jwt", URI: docServer.URL + "/pid.vctm.json"},
+				{FormatIdentifier: "mso_mdoc", URI: docServer.URL + "/pid.mdoc.json"},
+			},
+		})
+	})
+	registryMux.HandleFunc("/api/v1/registry.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RegistryResponse{
+			Total: 1,
+			Credentials: []RegistryListEntry{
+				{ID: "pid-id", Version: "1.0.0", SupportedFormats: []string{"dc+sd-jwt", "mso_mdoc"}},
+			},
+		})
+	})
+	registryServer := httptest.NewServer(registryMux)
+	defer registryServer.Close()
+
+	config := DefaultConfig()
+	fetcher := NewFetcher(config, NewStore(""), testLogger(), nil)
+
+	src := RemoteSourceConfig{URL: registryServer.URL + "/api/v1/registry.json", Mode: APIModeRegistry}
+	entries, err := fetcher.fetchFromSource(context.Background(), src)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	sdjwtEntry, ok := entries["urn:eudi:pid:1"]
+	require.True(t, ok, "sd-jwt entry should be keyed on its vct")
+	assert.Equal(t, "PID SD-JWT", sdjwtEntry.Name)
+
+	mdocEntry, ok := entries["eu.europa.ec.eudi.pid.1"]
+	require.True(t, ok, "mdoc entry should be keyed on its doctype")
+	assert.Equal(t, "PID mdoc", mdocEntry.Name)
 }
 
 // TestConfig_Validate_InvalidMode verifies that invalid Mode values are rejected.

--- a/internal/registry/local.go
+++ b/internal/registry/local.go
@@ -10,10 +10,11 @@ import (
 	"go.uber.org/zap"
 )
 
-// LoadLocalOverrides reads VCTM JSON files from the configured paths and
-// inserts them into the store with IsLocal=true. Each path may be a regular
-// file or a directory; directories are scanned for *.json files (non-recursive).
-// The "vct" field in each JSON document is used as the store key.
+// LoadLocalOverrides reads credential type metadata JSON files (VCTM or
+// MDDL) from the configured paths and inserts them into the store with
+// IsLocal=true. Each path may be a regular file or a directory; directories
+// are scanned for *.json files (non-recursive). The "vct" field (sd-jwt) or
+// "doctype" field (mso_mdoc) in each JSON document is used as the store key.
 func LoadLocalOverrides(store *Store, paths []string, logger *zap.Logger) error {
 	var loaded int
 	for _, p := range paths {
@@ -64,8 +65,9 @@ func loadPath(store *Store, p string, logger *zap.Logger) (int, error) {
 	return count, nil
 }
 
-// loadFile reads a single VCTM JSON file, extracts the "vct" field, and puts
-// it into the store as a local override.
+// loadFile reads a single credential type metadata JSON file (VCTM or
+// MDDL), extracts its identifier ("vct" or "doctype"), and puts it into the
+// store as a local override.
 func loadFile(store *Store, path string, logger *zap.Logger) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -76,24 +78,16 @@ func loadFile(store *Store, path string, logger *zap.Logger) error {
 		return fmt.Errorf("invalid JSON")
 	}
 
-	// Extract the top-level "vct" and optional display fields.
-	var header struct {
-		VCT          string `json:"vct"`
-		Name         string `json:"name"`
-		Description  string `json:"description"`
-		Organization string `json:"organization"`
-	}
-	if err := json.Unmarshal(data, &header); err != nil {
-		return fmt.Errorf("unmarshal header: %w", err)
-	}
-	if header.VCT == "" {
-		return fmt.Errorf("missing or empty \"vct\" field")
+	header := parseDocumentHeader(data)
+	id := header.identifier()
+	if id == "" {
+		return fmt.Errorf("missing or empty \"vct\"/\"doctype\" field")
 	}
 
 	entry := &VCTMEntry{
-		VCT:          header.VCT,
-		Name:         header.Name,
-		Description:  header.Description,
+		VCT:          id,
+		Name:         header.displayName(),
+		Description:  header.displayDescription(),
 		Organization: header.Organization,
 		Metadata:     json.RawMessage(data),
 		FetchedAt:    time.Now(),
@@ -101,8 +95,8 @@ func loadFile(store *Store, path string, logger *zap.Logger) error {
 	}
 
 	store.Put(entry)
-	logger.Debug("Loaded local VCTM override",
-		zap.String("vct", header.VCT),
+	logger.Debug("Loaded local credential type override",
+		zap.String("id", id),
 		zap.String("path", path))
 	return nil
 }

--- a/internal/registry/local_test.go
+++ b/internal/registry/local_test.go
@@ -120,6 +120,42 @@ func TestLoadLocalOverrides_MissingVCT(t *testing.T) {
 	}
 }
 
+func TestLoadLocalOverrides_MDocOnly(t *testing.T) {
+	// An mdoc-only override has no "vct" at all — "doctype" plus display[]
+	// name/description must still be recognized.
+	dir := t.TempDir()
+	mddl := []byte(`{
+		"format": "mso_mdoc",
+		"doctype": "org.iso.18013.5.1.mDL",
+		"display": [{"locale": "en-US", "name": "mDL", "description": "Mobile Driving Licence"}]
+	}`)
+	fp := filepath.Join(dir, "mdl.json")
+	if err := os.WriteFile(fp, mddl, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	if err := LoadLocalOverrides(store, []string{fp}, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entry, ok := store.Get("org.iso.18013.5.1.mDL")
+	if !ok {
+		t.Fatal("entry not found in store, keyed by doctype")
+	}
+	if !entry.IsLocal {
+		t.Error("expected IsLocal=true")
+	}
+	if entry.Name != "mDL" {
+		t.Errorf("Name = %q, want %q", entry.Name, "mDL")
+	}
+	if entry.Description != "Mobile Driving Licence" {
+		t.Errorf("Description = %q, want %q", entry.Description, "Mobile Driving Licence")
+	}
+}
+
 func TestLoadLocalOverrides_FileError(t *testing.T) {
 	store := NewStore(filepath.Join(t.TempDir(), "cache.json"))
 	logger := zap.NewNop()


### PR DESCRIPTION
## Summary

`internal/registry`'s ingestion paths all assumed a fetched/loaded document was VCTM-shaped: identified by a top-level `"vct"` field, with `name`/`description` also expected at the top level (though in practice both VCTM *and* MDDL documents nest those under a locale-keyed `display` array). An MDDL (`mso_mdoc`) document has no `"vct"` at all — it's identified by `"doctype"` — so it was either rejected outright or silently degraded, in four places:

- `local.go` `loadFile()`: hard-errored `"missing or empty \"vct\" field"` for any mdoc-only local override file, rejecting it entirely.
- `fetcher.go` `fetchTS11VCTM()`: fell back to using the raw fetch URL as the identifier for any document with no `vct` (losing the real doctype), and left `Name`/`Description` permanently blank for any document that nests them under `display[]` instead of at the top level — true for both formats, just only visibly broken for mdoc.
- `fetcher.go` `processTS11Response()`/`processRegistryResponse()`: when a TS11 schema declared multiple `schemaURIs`, only the `dc+sd-jwt` one was ever fetched — an `mso_mdoc` variant offered alongside it was silently dropped, with no way to also retrieve or serve it.
- `dynamic_fetcher.go` `Fetch()`: same top-level-only `Name`/`Description`/`Organization` extraction, via a bespoke helper.

## What changed

New `internal/registry/document.go` — a `documentHeader` shared by all four ingestion paths: `identifier()` falls back from `"vct"` to `"doctype"`, and `displayName()`/`displayDescription()` fall back from top-level fields to the first `display[]` entry.

`fetchTS11VCTM` is renamed `fetchSchemaDocument` and now called **once per schemaURI** instead of once per schema (picking a single preferred format) — so a schema offering both an sd-jwt and an mso_mdoc document now caches both, each under its own identifier. The now-dead `extractStringField` helper (and its test) is removed in favor of `documentHeader`.

**No changes needed to `Store`/`Handler`/`FilterConfig`** — `VCTMEntry.Metadata` is already raw bytes, the store is already keyed by an arbitrary string, and `SupportedFormats` already accepts `"mso_mdoc"` as a valid TS11 value. Every actual gap was in the ingestion layer's assumption about document shape, not the storage/serving core.

## Test plan

- New `document_test.go`: identifier/displayName/displayDescription fallback behavior (vct vs doctype, top-level vs display[], invalid JSON).
- New `TestFetcher_FetchFromSource_TS11_FetchesAllFormats` / `..._RegistryFormat_FetchesAllFormats`: a schema with both a `dc+sd-jwt` and an `mso_mdoc` schemaURI now yields two cached entries, keyed by `vct` and `doctype` respectively.
- New `TestLoadLocalOverrides_MDocOnly`, `TestDynamicFetcher_Fetch_MDocDocument`: mdoc-only documents load/fetch correctly with the right identifier and display fields.
- All pre-existing tests pass unchanged (every existing fixture only ever declared a single `schemaURI`, so the "iterate all" change doesn't alter their behavior).
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean; repo's pre-commit hook (fmt + lint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)