### PR TITLE
fix(engine): accept haip:// scheme and fetch bare reference-URL requests

### DIFF
--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -201,7 +201,9 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 func (h *OID4VPHandler) parseRequest(ctx context.Context, msg *FlowStartMessage) (*AuthorizationRequest, error) {
 	_ = h.ProgressMessage(StepParsingRequest, "Parsing authorization request")
 
-	h.Logger.Debug("parsing authorization request", zap.String("request_uri", msg.RequestURI), zap.String("request_uri_ref", msg.RequestURIRef))
+	h.Logger.Debug("parsing authorization request",
+		zap.String("request_uri", redactURIForLogging(msg.RequestURI)),
+		zap.String("request_uri_ref", redactURIForLogging(msg.RequestURIRef)))
 
 	var authReq AuthorizationRequest
 
@@ -223,6 +225,19 @@ func (h *OID4VPHandler) parseRequest(ctx context.Context, msg *FlowStartMessage)
 			}
 			// Parse inline parameters
 			return h.parseRequestFromURL(u)
+		}
+		// requestStr may be a raw query string with no scheme at all (e.g.
+		// "client_id=foo&nonce=bar", as validateResponseURIOrigin already
+		// anticipates) rather than a URL. Anything that doesn't itself start
+		// with a URL scheme is a raw query string - parse it as inline
+		// params directly, the same as before this fix. This check must
+		// come before ever calling url.Parse on requestStr: a raw query
+		// string can contain a "://" inside a parameter value (e.g.
+		// client_id=https://verifier...), which url.Parse rejects with
+		// "first path segment ... cannot contain colon" since the string
+		// itself has no leading scheme.
+		if !hasURLScheme(requestStr) {
+			return h.parseRequestFromURL(&url.URL{RawQuery: requestStr})
 		}
 		// Direct https:// URL: either a by-value request with inline query
 		// parameters, or a bare reference URL (no query at all) that must be
@@ -246,6 +261,48 @@ func (h *OID4VPHandler) parseRequest(ctx context.Context, msg *FlowStartMessage)
 	}
 
 	return &authReq, errors.New("no request provided")
+}
+
+// hasURLScheme reports whether s begins with a URL scheme ("scheme://...",
+// per RFC 3986: a letter followed by letters/digits/+/-/. up to "://").
+// Used to tell an actual URL apart from a raw query string that happens to
+// contain "://" inside a parameter value.
+func hasURLScheme(s string) bool {
+	idx := strings.Index(s, "://")
+	if idx <= 0 {
+		return false
+	}
+	scheme := s[:idx]
+	for i := 0; i < len(scheme); i++ {
+		c := scheme[i]
+		isLetter := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+		if i == 0 {
+			if !isLetter {
+				return false
+			}
+			continue
+		}
+		isDigit := c >= '0' && c <= '9'
+		if !isLetter && !isDigit && c != '+' && c != '-' && c != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+// redactURIForLogging returns a form of uri safe to log: scheme and host
+// only. The query string (and, for a bare raw-query value, the entire
+// string) may carry sensitive material - nonces, reference tokens, embedded
+// JWTs - so neither is ever included.
+func redactURIForLogging(uri string) string {
+	if uri == "" {
+		return ""
+	}
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "<non-url>"
+	}
+	return u.Scheme + "://" + u.Host
 }
 
 func (h *OID4VPHandler) parseRequestFromURL(u *url.URL) (*AuthorizationRequest, error) {
@@ -314,7 +371,7 @@ func (h *OID4VPHandler) parseRequestJWT(jwtStr string) (*AuthorizationRequest, e
 }
 
 func (h *OID4VPHandler) fetchRequestFromURI(ctx context.Context, uri string) (*AuthorizationRequest, error) {
-	h.Logger.Debug("fetching authorization request object", zap.String("uri", uri))
+	h.Logger.Debug("fetching authorization request object", zap.String("uri", redactURIForLogging(uri)))
 	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 	if err != nil {
 		return nil, err

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -299,9 +299,13 @@ func redactURIForLogging(uri string) string {
 		return ""
 	}
 	u, err := url.Parse(uri)
-	if err != nil || u.Scheme == "" || u.Host == "" {
+	if err != nil || u.Scheme == "" {
 		return "<non-url>"
 	}
+	// Host is legitimately empty for some valid, non-sensitive requests -
+	// e.g. "haip://?client_id=..." (no callback/authority segment) parses
+	// with an empty Host. Requiring a non-empty Host here would misclassify
+	// those as "<non-url>" instead of the more informative "haip://".
 	return u.Scheme + "://" + u.Host
 }
 

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -201,12 +201,17 @@ func (h *OID4VPHandler) Execute(ctx context.Context, msg *FlowStartMessage) erro
 func (h *OID4VPHandler) parseRequest(ctx context.Context, msg *FlowStartMessage) (*AuthorizationRequest, error) {
 	_ = h.ProgressMessage(StepParsingRequest, "Parsing authorization request")
 
+	h.Logger.Debug("parsing authorization request", zap.String("request_uri", msg.RequestURI), zap.String("request_uri_ref", msg.RequestURIRef))
+
 	var authReq AuthorizationRequest
 
 	if msg.RequestURI != "" {
-		// Parse from openid4vp:// URL or direct URL
+		// Parse from openid4vp://, haip://, or a direct https:// URL. HAIP
+		// (OpenID4VC High Assurance Interoperability Profile) uses the same
+		// openid4vp://?client_id=...&request_uri=... wire shape as plain
+		// OID4VP, just under its own scheme - treat both identically.
 		requestStr := msg.RequestURI
-		if strings.HasPrefix(requestStr, "openid4vp://") {
+		if strings.HasPrefix(requestStr, "openid4vp://") || strings.HasPrefix(requestStr, "haip://") {
 			u, err := url.Parse(requestStr)
 			if err != nil {
 				return nil, fmt.Errorf("invalid request URL: %w", err)
@@ -219,8 +224,23 @@ func (h *OID4VPHandler) parseRequest(ctx context.Context, msg *FlowStartMessage)
 			// Parse inline parameters
 			return h.parseRequestFromURL(u)
 		}
-		// Direct URL
-		return h.parseRequestFromURL(&url.URL{RawQuery: requestStr})
+		// Direct https:// URL: either a by-value request with inline query
+		// parameters, or a bare reference URL (no query at all) that must be
+		// fetched to obtain the actual request object - e.g. a QR/link that
+		// itself IS the request_uri, with no openid4vp://... wrapper. A
+		// query-less URL can't carry inline params, so treating requestStr as
+		// a literal RawQuery in that case silently yields every field empty
+		// (this is exactly what broke: a bare https://.../haip-vp link with
+		// no "=" characters parsed to nonce="" and failed on "missing
+		// required 'nonce' parameter", never even attempting to fetch it).
+		u, err := url.Parse(requestStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid request URL: %w", err)
+		}
+		if u.RawQuery == "" {
+			return h.fetchRequestFromURI(ctx, requestStr)
+		}
+		return h.parseRequestFromURL(u)
 	} else if msg.RequestURIRef != "" {
 		return h.fetchRequestFromURI(ctx, msg.RequestURIRef)
 	}
@@ -294,6 +314,7 @@ func (h *OID4VPHandler) parseRequestJWT(jwtStr string) (*AuthorizationRequest, e
 }
 
 func (h *OID4VPHandler) fetchRequestFromURI(ctx context.Context, uri string) (*AuthorizationRequest, error) {
+	h.Logger.Debug("fetching authorization request object", zap.String("uri", uri))
 	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 	if err != nil {
 		return nil, err

--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -1298,7 +1298,7 @@ func validateResponseURIOrigin(authReq *AuthorizationRequest, msg *FlowStartMess
 		return nil
 	}
 	requestURL := msg.RequestURI
-	if strings.HasPrefix(requestURL, "openid4vp://") {
+	if strings.HasPrefix(requestURL, "openid4vp://") || strings.HasPrefix(requestURL, "haip://") {
 		if u, err := url.Parse(requestURL); err == nil {
 			requestURL = u.Query().Get("request_uri")
 		}

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -396,6 +396,20 @@ func TestParseRequest(t *testing.T) {
 		assert.Equal(t, "fetched-nonce", authReq.Nonce)
 	})
 
+	// Regression test: a raw query string with no scheme/host at all (as
+	// validateResponseURIOrigin already anticipates) must be parsed as
+	// inline params, not misidentified as a reference URL to fetch - it has
+	// an empty RawQuery too (the whole string lands in url.URL.Path), so
+	// scheme/host presence, not RawQuery, has to be the discriminator.
+	t.Run("raw query string with no scheme is parsed directly", func(t *testing.T) {
+		msg := &FlowStartMessage{
+			RequestURI: "response_type=vp_token&client_id=https://verifier.example.com&nonce=raw-nonce",
+		}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "raw-nonce", authReq.Nonce)
+	})
+
 	t.Run("bare https URL with inline query params is parsed directly", func(t *testing.T) {
 		msg := &FlowStartMessage{
 			RequestURI: "https://wallet.example.com/present?response_type=vp_token&client_id=https://verifier.example.com&nonce=inline-nonce",
@@ -410,6 +424,41 @@ func TestParseRequest(t *testing.T) {
 		_, err := h.parseRequest(context.Background(), msg)
 		require.Error(t, err)
 	})
+}
+
+func TestHasURLScheme(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"https://verifier.example.com", true},
+		{"http://127.0.0.1:8080", true},
+		{"openid4vp://?client_id=foo", true},
+		{"haip://?client_id=foo", true},
+		{"", false},
+		{"client_id=foo&nonce=bar", false},
+		{"response_type=vp_token&client_id=https://verifier.example.com", false},
+		{"://missing-scheme", false},
+		{"1https://bad-first-char", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, hasURLScheme(tc.in), "hasURLScheme(%q)", tc.in)
+	}
+}
+
+func TestRedactURIForLogging(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"https://verifier.example.com/req?nonce=secret&client_id=foo", "https://verifier.example.com"},
+		{"client_id=foo&nonce=secret", "<non-url>"},
+		{"not a url at all", "<non-url>"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, redactURIForLogging(tc.in), "redactURIForLogging(%q)", tc.in)
+	}
 }
 
 // ===== DCQL query tests =====

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -301,7 +302,7 @@ func TestFetchRequestFromURI(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			h := &OID4VPHandler{httpClient: srv.Client()}
+			h := &OID4VPHandler{BaseHandler: BaseHandler{Logger: zap.NewNop()}, httpClient: srv.Client()}
 
 			authReq, err := h.fetchRequestFromURI(context.Background(), srv.URL)
 			if tt.wantErr {
@@ -315,6 +316,100 @@ func TestFetchRequestFromURI(t *testing.T) {
 			assert.Equal(t, tt.wantClientID, authReq.ClientID)
 		})
 	}
+}
+
+func TestParseRequest(t *testing.T) {
+	// A minimal by-value authorization request served by a reference URL,
+	// reused by every "fetch" case below.
+	referencedRequest := `{"client_id":"did:web:verifier","response_type":"vp_token","nonce":"fetched-nonce"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, referencedRequest)
+	}))
+	defer srv.Close()
+
+	// parseRequest calls h.ProgressMessage() unconditionally, which needs a
+	// real Flow/Session/conn behind it (see testSession/wsTestServer in
+	// match_test.go) or it panics on a nil websocket connection.
+	conn, cleanup := wsTestServer(t, func(srvConn *websocket.Conn) {
+		for {
+			if _, _, err := srvConn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+	defer cleanup()
+	session := testSession(conn)
+	flow := &Flow{ID: "test-flow", Session: session, Data: make(map[string]interface{})}
+
+	h := &OID4VPHandler{BaseHandler: BaseHandler{Flow: flow, Logger: zap.NewNop()}, httpClient: srv.Client()}
+
+	t.Run("openid4vp scheme with inline params", func(t *testing.T) {
+		msg := &FlowStartMessage{
+			RequestURI: "openid4vp://?response_type=vp_token&client_id=https://verifier.example.com&nonce=inline-nonce",
+		}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "inline-nonce", authReq.Nonce)
+	})
+
+	t.Run("openid4vp scheme with request_uri reference", func(t *testing.T) {
+		msg := &FlowStartMessage{
+			RequestURI: "openid4vp://?client_id=did:web:verifier&request_uri=" + url.QueryEscape(srv.URL),
+		}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "fetched-nonce", authReq.Nonce)
+	})
+
+	// HAIP (OpenID4VC High Assurance Interoperability Profile) uses the same
+	// wire shape as plain OID4VP under its own scheme - regression test for a
+	// bug where haip:// fell through to the "direct URL" branch instead of
+	// being recognized and unwrapped the same way as openid4vp://.
+	t.Run("haip scheme with request_uri reference", func(t *testing.T) {
+		msg := &FlowStartMessage{
+			RequestURI: "haip://?client_id=did:web:verifier&request_uri=" + url.QueryEscape(srv.URL),
+		}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "fetched-nonce", authReq.Nonce)
+	})
+
+	t.Run("haip scheme with inline params", func(t *testing.T) {
+		msg := &FlowStartMessage{
+			RequestURI: "haip://?response_type=vp_token&client_id=https://verifier.example.com&nonce=inline-nonce",
+		}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "inline-nonce", authReq.Nonce)
+	})
+
+	// Regression test for a bug where a bare reference URL with no query
+	// string (e.g. a QR/link that IS itself the request_uri, no
+	// openid4vp://...&request_uri= wrapper at all) was parsed as if the
+	// entire URL string were a raw query string - silently yielding every
+	// field empty instead of being fetched.
+	t.Run("bare https URL with no query is fetched as a reference", func(t *testing.T) {
+		msg := &FlowStartMessage{RequestURI: srv.URL}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "fetched-nonce", authReq.Nonce)
+	})
+
+	t.Run("bare https URL with inline query params is parsed directly", func(t *testing.T) {
+		msg := &FlowStartMessage{
+			RequestURI: "https://wallet.example.com/present?response_type=vp_token&client_id=https://verifier.example.com&nonce=inline-nonce",
+		}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "inline-nonce", authReq.Nonce)
+	})
+
+	t.Run("no request provided", func(t *testing.T) {
+		msg := &FlowStartMessage{}
+		_, err := h.parseRequest(context.Background(), msg)
+		require.Error(t, err)
+	})
 }
 
 // ===== DCQL query tests =====

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -1238,6 +1238,36 @@ func TestValidateResponseURIOrigin_OpenID4VPScheme(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// Regression test: parseRequest treats haip:// the same as openid4vp://,
+// but validateResponseURIOrigin only unwrapped openid4vp:// to find the
+// embedded request_uri. A HAIP request_uri parsed to an empty host and was
+// silently treated as "not a proper URL", skipping the origin check
+// entirely instead of enforcing it.
+func TestValidateResponseURIOrigin_HAIPScheme(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "haip://?request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	assert.NoError(t, err)
+}
+
+func TestValidateResponseURIOrigin_HAIPScheme_Mismatch(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ResponseURI:    "https://evil.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "haip://?request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match request_uri origin")
+}
+
 func TestValidateResponseURIOrigin_SkipsNonX509Scheme(t *testing.T) {
 	// Origin check should be skipped for non-x509_san_dns schemes.
 	authReq := &AuthorizationRequest{

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -455,6 +455,11 @@ func TestRedactURIForLogging(t *testing.T) {
 		{"https://verifier.example.com/req?nonce=secret&client_id=foo", "https://verifier.example.com"},
 		{"client_id=foo&nonce=secret", "<non-url>"},
 		{"not a url at all", "<non-url>"},
+		// haip:// (and openid4vp://) requests with no callback/authority
+		// segment are common and not malformed - Host is legitimately
+		// empty. Must still report the scheme, not "<non-url>".
+		{"haip://?client_id=foo&nonce=secret", "haip://"},
+		{"openid4vp://?client_id=foo&nonce=secret", "openid4vp://"},
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.want, redactURIForLogging(tc.in), "redactURIForLogging(%q)", tc.in)


### PR DESCRIPTION
## Summary
- `parseRequest` now treats `haip://` (OpenID4VC High Assurance Interoperability Profile) identically to `openid4vp://`, since HAIP uses the same wire shape under its own scheme.
- Fixes a real bug: a bare `https://` `request_uri` with no query string (a pure reference link, not a by-value request - e.g. a `.../haip-vp` link) was parsed as a literal empty `RawQuery` instead of being fetched, silently yielding an empty `nonce` and failing with "missing required 'nonce' parameter" instead of ever attempting the fetch.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/engine/...` (includes new coverage for the haip:// scheme and bare-reference-URL fetch path)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>