### PR TITLE
fix: clamp self-reported KA security_properties, normalize ISO 18045 vocabulary

### DIFF
--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -41,7 +41,7 @@ func NewServices(store storage.Store, cfg *config.Config, logger *zap.Logger) *S
 		// Continue without WebAuthn - it will be nil
 	}
 
-	wpSvc := NewWalletProviderService(cfg, logger)
+	wpSvc := NewWalletProviderService(cfg, logger, store.WalletInstances())
 
 	// WIA shares the same signing key as the wallet provider
 	var wiaSvc *WIAService

--- a/internal/service/wallet_provider.go
+++ b/internal/service/wallet_provider.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/signing"
 )
@@ -63,13 +65,19 @@ type WalletProviderService struct {
 	signer    crypto.Signer
 	jwtSigner *signing.CryptoSignerES256
 	certChain []string
+	instances storage.WalletInstanceStore
 }
 
-// NewWalletProviderService creates a new WalletProviderService
-func NewWalletProviderService(cfg *config.Config, logger *zap.Logger) *WalletProviderService {
+// NewWalletProviderService creates a new WalletProviderService.
+// instances is used to corroborate a KA request's self-reported security
+// properties against a WIA that already proved native platform integrity
+// for the same wallet instance (see GenerateKeyAttestation) — may be nil in
+// tests that don't exercise that path.
+func NewWalletProviderService(cfg *config.Config, logger *zap.Logger, instances storage.WalletInstanceStore) *WalletProviderService {
 	svc := &WalletProviderService{
-		cfg:    cfg,
-		logger: logger.Named("wallet-provider-service"),
+		cfg:       cfg,
+		logger:    logger.Named("wallet-provider-service"),
+		instances: instances,
 	}
 
 	// Try PKCS#11 first, then fall back to file-based key loading if PKCS#11
@@ -281,16 +289,25 @@ func (s *WalletProviderService) GenerateKeyAttestation(ctx context.Context, jwks
 		claims["aud"] = audience
 	}
 
-	// Security properties are top-level KA claims (Annex C §C.3.1)
+	// Security properties are top-level KA claims (Annex C §C.3.1). These are
+	// self-reported by the client — trust them only when the same wallet
+	// instance already has a WIA proving native platform integrity
+	// (Tier 1: ios_app_attest / android_play_integrity). Otherwise clamp to
+	// the software/K3 floor: a client can always claim more than it can
+	// back up, and nothing here independently verifies a hardware or
+	// remote-HSM claim. See internal/service/wallet_provider_test.go for
+	// the regression tests this guards.
 	if secProps != nil {
-		if len(secProps.KeyStorage) > 0 {
-			claims["key_storage"] = secProps.KeyStorage
+		trusted := s.instanceHasNativeAttestation(ctx, walletInstanceID)
+		normalized := normalizeSecurityProperties(secProps, trusted)
+		if len(normalized.KeyStorage) > 0 {
+			claims["key_storage"] = normalized.KeyStorage
 		}
-		if len(secProps.UserAuthentication) > 0 {
-			claims["user_authentication"] = secProps.UserAuthentication
+		if len(normalized.UserAuthentication) > 0 {
+			claims["user_authentication"] = normalized.UserAuthentication
 		}
-		if secProps.Certification != nil {
-			claims["certification"] = secProps.Certification
+		if normalized.Certification != nil {
+			claims["certification"] = normalized.Certification
 		}
 	}
 
@@ -326,4 +343,102 @@ func (s *WalletProviderService) GenerateKeyAttestation(ctx context.Context, jwks
 
 	kaGeneratedTotal.Inc()
 	return tokenString, nil
+}
+
+// nativeAttestationSources are the WalletInstance.AttestationSource values
+// that indicate the wallet's Tier 1 WIA was backed by verified platform
+// attestation (iOS App Attest or Android Play Integrity) — i.e. an
+// independent signal that the instance's runtime integrity was checked,
+// which corroborates (though doesn't cryptographically prove) an elevated
+// key_storage/certification claim for that same instance.
+var nativeAttestationSources = map[string]bool{
+	"ios_app_attest":         true,
+	"android_play_integrity": true,
+}
+
+// instanceHasNativeAttestation reports whether walletInstanceID resolves to
+// a WalletInstance whose WIA was backed by verified native platform
+// attestation. Returns false on a missing ID, an unknown instance, a
+// lookup error, or a nil instance store (e.g. in tests that construct
+// WalletProviderService directly) — all of which mean there's no evidence
+// to corroborate an elevated claim, not that one should be granted.
+func (s *WalletProviderService) instanceHasNativeAttestation(ctx context.Context, walletInstanceID string) bool {
+	if s.instances == nil || walletInstanceID == "" {
+		return false
+	}
+	instance, err := s.instances.GetByID(ctx, walletInstanceID)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			s.logger.Warn("failed to look up wallet instance for KA trust check", zap.Error(err))
+		}
+		return false
+	}
+	return nativeAttestationSources[instance.AttestationSource]
+}
+
+// isoAttackPotential maps SIROS's internal WSCD key-storage/user-auth
+// vocabulary onto the OID4VCI Key Attestation JWT's registered
+// `iso_18045_*` attack-potential-resistance values. Mirrors the mapping
+// already used client-side in the Kotlin/Swift SDKs' self-signed fallback
+// path (WscdKeystoreAdapter.toIso18045AttackPotential) — kept in sync so
+// the same raw value maps the same way regardless of which side does it.
+// Mappings are necessarily approximate; conservative/lower tiers are
+// preferred over overclaiming resistance that hasn't been verified.
+func isoAttackPotential(raw string, omitIfNone bool) (string, bool) {
+	if strings.HasPrefix(raw, "iso_18045_") {
+		return raw, true // already spec-compliant, pass through
+	}
+	switch strings.ToLower(raw) {
+	case "none":
+		if omitIfNone {
+			return "", false
+		}
+		return "iso_18045_basic", true
+	case "software":
+		return "iso_18045_basic", true
+	case "hardware":
+		return "iso_18045_moderate", true
+	case "trusted_execution":
+		return "iso_18045_enhanced-basic", true
+	case "remote_hsm":
+		return "iso_18045_high", true
+	default:
+		return "iso_18045_basic", true
+	}
+}
+
+// normalizeSecurityProperties maps secProps onto the registered
+// `iso_18045_*` vocabulary and, when trusted is false, clamps every claim
+// down to the software/K3 floor regardless of what the client asserted.
+func normalizeSecurityProperties(secProps *SecurityProperties, trusted bool) *SecurityProperties {
+	if !trusted {
+		return &SecurityProperties{
+			KeyStorage:    []string{"iso_18045_basic"},
+			Certification: "none",
+		}
+	}
+
+	out := &SecurityProperties{Certification: secProps.Certification}
+	out.KeyStorage = mapDistinct(secProps.KeyStorage, false)
+	if len(out.KeyStorage) == 0 {
+		out.KeyStorage = []string{"iso_18045_basic"}
+	}
+	out.UserAuthentication = mapDistinct(secProps.UserAuthentication, true)
+	return out
+}
+
+// mapDistinct applies isoAttackPotential to each value, dropping omitted
+// entries and de-duplicating (matching the Kotlin/Swift SDKs' .distinct()).
+func mapDistinct(raw []string, omitIfNone bool) []string {
+	seen := make(map[string]bool, len(raw))
+	var out []string
+	for _, v := range raw {
+		mapped, ok := isoAttackPotential(v, omitIfNone)
+		if !ok || seen[mapped] {
+			continue
+		}
+		seen[mapped] = true
+		out = append(out, mapped)
+	}
+	return out
 }

--- a/internal/service/wallet_provider_test.go
+++ b/internal/service/wallet_provider_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"go.uber.org/zap"
 
+	"github.com/sirosfoundation/go-wallet-backend/internal/domain"
+	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
+	"github.com/sirosfoundation/go-wallet-backend/internal/storage/memory"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/signing"
 )
@@ -56,8 +59,31 @@ func newTestWalletProviderService(t *testing.T) *WalletProviderService {
 	}
 }
 
-func TestGenerateKeyAttestation_TopLevelSecurityProperties(t *testing.T) {
+// newTestWalletProviderServiceWithInstances is like newTestWalletProviderService
+// but wires a real (in-memory) wallet instance store, needed for tests that
+// exercise the security-properties trust gate in GenerateKeyAttestation.
+func newTestWalletProviderServiceWithInstances(t *testing.T) (*WalletProviderService, storage.WalletInstanceStore) {
+	t.Helper()
 	svc := newTestWalletProviderService(t)
+	instances := memory.NewStore().WalletInstances()
+	svc.instances = instances
+	return svc, instances
+}
+
+// TestGenerateKeyAttestation_TopLevelSecurityProperties exercises the
+// trusted path: the wallet instance already has a WIA proving native
+// platform integrity, so the client's security_properties claim is
+// honored (after normalization — already-prefixed iso_18045_* values pass
+// through unchanged).
+func TestGenerateKeyAttestation_TopLevelSecurityProperties(t *testing.T) {
+	svc, instances := newTestWalletProviderServiceWithInstances(t)
+	instanceID := "test-instance-native"
+	if err := instances.Upsert(context.Background(), &domain.WalletInstance{
+		ID:                instanceID,
+		AttestationSource: "ios_app_attest",
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	jwks := []map[string]interface{}{
 		{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"},
@@ -72,7 +98,7 @@ func TestGenerateKeyAttestation_TopLevelSecurityProperties(t *testing.T) {
 		},
 	}
 
-	ka, err := svc.GenerateKeyAttestation(context.Background(), jwks, "test-nonce", secProps, "", "")
+	ka, err := svc.GenerateKeyAttestation(context.Background(), jwks, "test-nonce", secProps, instanceID, "")
 	if err != nil {
 		t.Fatalf("GenerateKeyAttestation: %v", err)
 	}
@@ -158,6 +184,159 @@ func TestGenerateKeyAttestation_CertificationStringNone(t *testing.T) {
 	}
 	if cert != "none" {
 		t.Errorf("certification = %v, want \"none\"", cert)
+	}
+}
+
+// TestGenerateKeyAttestation_SecurityProperties_ClampedWithoutInstance is a
+// regression test for a review finding: without this, any caller could
+// self-assert an arbitrary key_storage/certification claim (e.g.
+// iso_18045_high) with no wallet_instance_id and no verification at all,
+// and have it signed straight into the KA JWT. With no walletInstanceID to
+// even attempt a lookup against, the claim must be clamped to the
+// software/K3 floor.
+func TestGenerateKeyAttestation_SecurityProperties_ClampedWithoutInstance(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+
+	jwks := []map[string]interface{}{
+		{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"},
+	}
+	secProps := &SecurityProperties{
+		KeyStorage:         []string{"iso_18045_high"},
+		UserAuthentication: []string{"iso_18045_high"},
+		Certification: map[string]interface{}{
+			"scheme": "EUCC",
+		},
+	}
+
+	ka, err := svc.GenerateKeyAttestation(context.Background(), jwks, "test-nonce", secProps, "", "")
+	if err != nil {
+		t.Fatalf("GenerateKeyAttestation: %v", err)
+	}
+
+	claims := parseKAClaims(t, ka)
+	assertKeyStorage(t, claims, "iso_18045_basic")
+	if cert := claims["certification"]; cert != "none" {
+		t.Errorf("certification = %v, want \"none\"", cert)
+	}
+	if _, ok := claims["user_authentication"]; ok {
+		t.Error("user_authentication should be clamped away, not passed through")
+	}
+}
+
+// TestGenerateKeyAttestation_SecurityProperties_ClampedForBackendAttestedInstance
+// covers the Tier 3 case: the wallet instance exists but its WIA was
+// backend-attested only (no native platform integrity proof), so an
+// elevated claim still must not be honored.
+func TestGenerateKeyAttestation_SecurityProperties_ClampedForBackendAttestedInstance(t *testing.T) {
+	svc, instances := newTestWalletProviderServiceWithInstances(t)
+	instanceID := "test-instance-backend-attested"
+	if err := instances.Upsert(context.Background(), &domain.WalletInstance{
+		ID:                instanceID,
+		AttestationSource: "backend_attested",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	jwks := []map[string]interface{}{{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"}}
+	secProps := &SecurityProperties{KeyStorage: []string{"iso_18045_high"}}
+
+	ka, err := svc.GenerateKeyAttestation(context.Background(), jwks, "test-nonce", secProps, instanceID, "")
+	if err != nil {
+		t.Fatalf("GenerateKeyAttestation: %v", err)
+	}
+	assertKeyStorage(t, parseKAClaims(t, ka), "iso_18045_basic")
+}
+
+// TestGenerateKeyAttestation_SecurityProperties_ClampedForUnknownInstance
+// covers a wallet_instance_id that doesn't resolve to any known instance
+// (storage.ErrNotFound) — must fail closed (clamp), not fail open.
+func TestGenerateKeyAttestation_SecurityProperties_ClampedForUnknownInstance(t *testing.T) {
+	svc, _ := newTestWalletProviderServiceWithInstances(t)
+
+	jwks := []map[string]interface{}{{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"}}
+	secProps := &SecurityProperties{KeyStorage: []string{"iso_18045_high"}}
+
+	ka, err := svc.GenerateKeyAttestation(context.Background(), jwks, "test-nonce", secProps, "does-not-exist", "")
+	if err != nil {
+		t.Fatalf("GenerateKeyAttestation: %v", err)
+	}
+	assertKeyStorage(t, parseKAClaims(t, ka), "iso_18045_basic")
+}
+
+// TestGenerateKeyAttestation_SecurityProperties_NormalizesRawVocabulary is a
+// regression test for the other half of the same finding: the SDKs send
+// their raw internal WSCD vocabulary ("software"/"hardware"/
+// "trusted_execution"/"remote_hsm"), not the iso_18045_* enum the KA spec
+// requires, and nothing was mapping it before this fix — even for a
+// trusted (natively-attested) instance.
+func TestGenerateKeyAttestation_SecurityProperties_NormalizesRawVocabulary(t *testing.T) {
+	svc, instances := newTestWalletProviderServiceWithInstances(t)
+	instanceID := "test-instance-native-2"
+	if err := instances.Upsert(context.Background(), &domain.WalletInstance{
+		ID:                instanceID,
+		AttestationSource: "android_play_integrity",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	jwks := []map[string]interface{}{{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"}}
+	secProps := &SecurityProperties{
+		KeyStorage:         []string{"hardware"},
+		UserAuthentication: []string{"none"},
+	}
+
+	ka, err := svc.GenerateKeyAttestation(context.Background(), jwks, "test-nonce", secProps, instanceID, "")
+	if err != nil {
+		t.Fatalf("GenerateKeyAttestation: %v", err)
+	}
+	claims := parseKAClaims(t, ka)
+	assertKeyStorage(t, claims, "iso_18045_moderate")
+	// omitIfNone: a "none" user_authentication claim is dropped, not mapped
+	// to a placeholder value.
+	if _, ok := claims["user_authentication"]; ok {
+		t.Errorf("user_authentication = %v, want omitted for \"none\"", claims["user_authentication"])
+	}
+}
+
+// TestGenerateKeyAttestation_SecurityProperties_UnrecognizedValueDefaultsToBasic
+// covers an unrecognized raw value (not already iso_18045_*, not a known
+// internal vocabulary word) — must default to the safe floor rather than
+// erroring or passing an invalid enum value through into the signed JWT.
+func TestGenerateKeyAttestation_SecurityProperties_UnrecognizedValueDefaultsToBasic(t *testing.T) {
+	svc, instances := newTestWalletProviderServiceWithInstances(t)
+	instanceID := "test-instance-native-3"
+	if err := instances.Upsert(context.Background(), &domain.WalletInstance{
+		ID:                instanceID,
+		AttestationSource: "ios_app_attest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	jwks := []map[string]interface{}{{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"}}
+	secProps := &SecurityProperties{KeyStorage: []string{"quantum_vault"}}
+
+	ka, err := svc.GenerateKeyAttestation(context.Background(), jwks, "test-nonce", secProps, instanceID, "")
+	if err != nil {
+		t.Fatalf("GenerateKeyAttestation: %v", err)
+	}
+	assertKeyStorage(t, parseKAClaims(t, ka), "iso_18045_basic")
+}
+
+func parseKAClaims(t *testing.T, ka string) jwt.MapClaims {
+	t.Helper()
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(ka, jwt.MapClaims{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token.Claims.(jwt.MapClaims)
+}
+
+func assertKeyStorage(t *testing.T, claims jwt.MapClaims, want string) {
+	t.Helper()
+	ks, ok := claims["key_storage"].([]interface{})
+	if !ok || len(ks) != 1 || ks[0] != want {
+		t.Errorf("key_storage = %v, want [%s]", claims["key_storage"], want)
 	}
 }
 
@@ -525,7 +704,7 @@ func TestNewWalletProviderService_FileKeys(t *testing.T) {
 	cfg.WalletProvider.PrivateKeyPath = keyPath
 	cfg.WalletProvider.CertificatePath = certPath
 
-	svc := NewWalletProviderService(cfg, zap.NewNop())
+	svc := NewWalletProviderService(cfg, zap.NewNop(), nil)
 	if !svc.IsSupported() {
 		t.Error("service should be supported with valid keys")
 	}
@@ -562,7 +741,7 @@ func TestNewWalletProviderService_PKCS11FailureFallsBackToFileKeys(t *testing.T)
 		ModulePath: "/nonexistent/pkcs11.so", // fails to load regardless of build tags
 	}
 
-	svc := NewWalletProviderService(cfg, zap.NewNop())
+	svc := NewWalletProviderService(cfg, zap.NewNop(), nil)
 	if !svc.IsSupported() {
 		t.Error("service should fall back to file-based keys when PKCS#11 fails to load")
 	}
@@ -570,7 +749,7 @@ func TestNewWalletProviderService_PKCS11FailureFallsBackToFileKeys(t *testing.T)
 
 func TestNewWalletProviderService_NoKeys(t *testing.T) {
 	cfg := &config.Config{}
-	svc := NewWalletProviderService(cfg, zap.NewNop())
+	svc := NewWalletProviderService(cfg, zap.NewNop(), nil)
 	if svc.IsSupported() {
 		t.Error("service should not be supported without keys")
 	}


### PR DESCRIPTION
## Summary

`GenerateKeyAttestation` copied client-submitted `key_storage`/`certification`/
`user_authentication` claims verbatim into the signed `keyattestation+jwt`,
with **zero server-side verification**. Any caller could self-assert
`key_storage: ["iso_18045_high"]` and have it signed straight through into
a legally-relevant attestation issuers rely on for LoA decisions (Annex C
§C.3.1).

## Changes

- Clamp `key_storage`/`user_authentication`/`certification` to the
  software/K3 floor (`iso_18045_basic` / `"none"`) unless the request's
  `wallet_instance_id` resolves to a `WalletInstance` whose WIA was backed
  by verified native platform attestation (Tier 1: `ios_app_attest` /
  `android_play_integrity`). That join was already possible — WIA issuance
  already persists `AttestationSource` keyed by the same JWK-thumbprint ID
  KA's `wallet_instance_id` refers to — nothing used it until now.
- Normalize the SDKs' raw internal WSCD vocabulary (`software`/`hardware`/
  `trusted_execution`/`remote_hsm`) onto the registered `iso_18045_*` enum
  before signing. Nothing did this before, so real (non-test) KA requests
  were almost certainly already producing non-compliant claim values.
  Mirrors the mapping that already exists client-side in the Kotlin/Swift
  SDKs' self-signed fallback path (`WscdKeystoreAdapter.toIso18045AttackPotential`),
  kept in sync so the same raw value maps the same way on both sides.

## Known follow-up (tracked separately, not in scope here)

No current SDK call site sends `wallet_instance_id` with the KA request,
so this clamps existing hardware-level (FIDO2 rawSign) claims to
software-level until the SDKs are updated to send it. Accepted as the
safe direction — it only prevents over-claiming, never creates
under-verification — and matches the SDKs' own documented preference for
conservative tiers over unbacked claims. Spec for the SDK-side follow-up:
`prompts/ka-wallet-instance-id-threading.prompt.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` all clean
- [x] Full `go test ./...` green
- [x] New regression tests confirmed to fail without the fix (reverted the
      trust-gate call locally, confirmed 3 clamp tests fail with the old
      passthrough values, restored)
- [x] Existing `TestGenerateKeyAttestation_TopLevelSecurityProperties`
      updated to exercise the trusted path explicitly rather than bare
      passthrough