### PR TITLE
feat: wallet-attestation-based AS client auth (no pre-registered client_id)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /app/server /app/server
 COPY --from=builder /app/configs /app/configs
+COPY --from=builder /app/rules /app/rules
 
 USER 65532:65532
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,12 +42,15 @@ func main() {
 	}
 	roleStrings := roles.Strings()
 
-	// Load backend configuration (needed for backend, engine, admin, and wallet-provider roles)
+	// Load backend configuration (needed for backend, engine, admin, auth, and wallet-provider roles)
 	var backendCfg *config.Config
-	if roles.Has(modes.RoleBackend) || roles.Has(modes.RoleEngine) || roles.Has(modes.RoleAdmin) || roles.Has(modes.RoleWalletProvider) {
+	if roles.Has(modes.RoleBackend) || roles.Has(modes.RoleEngine) || roles.Has(modes.RoleAdmin) || roles.Has(modes.RoleAuth) || roles.Has(modes.RoleWalletProvider) {
 		backendCfg, err = config.Load(*configFile)
 		if err != nil {
 			log.Fatalf("Failed to load backend configuration: %v", err)
+		}
+		if roles.Has(modes.RoleAuth) {
+			backendCfg.EnableForRole()
 		}
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,6 +51,14 @@ func main() {
 		}
 		if roles.Has(modes.RoleAuth) {
 			backendCfg.EnableForRole()
+			// EnableForRole mutates the already-validated config (e.g.
+			// falling back to WalletProvider's signing key for AS), so
+			// re-validate rather than let an invalid resulting state (say,
+			// AS enabled with no signing key anywhere) surface later as a
+			// less actionable failure during provider init.
+			if err := backendCfg.Validate(); err != nil {
+				log.Fatalf("Invalid backend configuration after enabling AS for role: %v", err)
+			}
 		}
 	}
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,6 +13,7 @@ Environment variables use the prefix `WALLET_` for the main backend and `REGISTR
 - [storage](#storage)
 - [logging](#logging)
 - [jwt](#jwt)
+- [as](#as)
 - [wallet_provider](#wallet_provider)
 - [trust](#trust)
 - [session_store](#session_store)
@@ -20,6 +21,7 @@ Environment variables use the prefix `WALLET_` for the main backend and `REGISTR
 - [security](#security)
 - [http_client](#http_client)
 - [authzen_proxy](#authzen_proxy)
+- [audit](#audit)
 - [Registry Server](#registry-server)
 - [registry.server](#registryserver)
 - [registry.source](#registrysource)
@@ -49,6 +51,8 @@ Environment prefix: `WALLET_SERVER`
 | `server.engine_port` | `WALLET_SERVER_ENGINE_PORT` | integer | WebSocket engine port (defaults to Port if 0) |
 | `server.registry_host` | `WALLET_SERVER_REGISTRY_HOST` | string | Registry bind address (defaults to Host) |
 | `server.registry_port` | `WALLET_SERVER_REGISTRY_PORT` | integer | VCTM registry port (defaults to 8097) |
+| `server.wp_host` | `WALLET_SERVER_WP_HOST` | string | Wallet-provider bind address (defaults to Host) |
+| `server.wp_port` | `WALLET_SERVER_WP_PORT` | integer | Wallet-provider port (0 = co-hosted with backend) |
 | `server.admin_token` | `WALLET_SERVER_ADMIN_TOKEN` | string | Bearer token for admin API (auto-generated if empty) |
 | `server.admin_token_path` | `WALLET_SERVER_ADMIN_TOKEN_PATH` | string | Path to file containing admin token |
 | `server.rp_id` | `WALLET_SERVER_RP_ID` | string |  |
@@ -114,6 +118,28 @@ Environment prefix: `WALLET_JWT`
 | `jwt.refresh_days` | `WALLET_JWT_REFRESH_DAYS` | integer |  |
 | `jwt.issuer` | `WALLET_JWT_ISSUER` | string |  |
 
+## as
+
+Environment prefix: `WALLET_AS`
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `as.enabled` | `WALLET_AS_ENABLED` | boolean | Enabled controls whether the new AS is active. |
+| `as.signing_key_path` | `WALLET_AS_SIGNING_KEY_PATH` | string | SigningKeyPath is the path to a PEM-encoded private key (ECDSA P-256, P-384, or Ed25519) used to sign access tokens. Mutually exclusive with SigningKeyPKCS11. |
+| `as.signing_key_pkcs11` | `WALLET_AS_SIGNING_KEY_PKCS11` | string | SigningKeyPKCS11 is a PKCS#11 URI for HSM-backed signing. Mutually exclusive with SigningKeyPath. |
+| `as.issuer` | `WALLET_AS_ISSUER` | string | Issuer is the value of the "iss" claim in issued access tokens. Defaults to JWT.Issuer if not set. |
+| `as.default_token_ttl` | `WALLET_AS_DEFAULT_TOKEN_TTL` | duration | DefaultTokenTTL is the default access token lifetime. Default: 2m |
+| `as.audience_ttls` | `WALLET_AS_AUDIENCE_TTLS` | map[string]time.Duration | AudienceTTLs allows per-audience TTL overrides. Keys are audience strings, values are durations. |
+| `as.audiences` | `WALLET_AS_AUDIENCES` | string list | Audiences lists the accepted audience values for token validation. Tokens must contain at least one of these in their "aud" claim. When empty, audience validation is skipped. Documented values: "wallet-backend", "wallet-engine", "wallet-registry". |
+| `as.rules_dir` | `WALLET_AS_RULES_DIR` | string | RulesDir is the path to a directory containing SPOCP policy rule files. |
+| `as.session_ttl` | `WALLET_AS_SESSION_TTL` | duration | SessionTTL is the maximum session lifetime before re-authentication. Default: 24h |
+| `as.default_max_tac` | `WALLET_AS_DEFAULT_MAX_TAC` | string | DefaultMaxTAC is the default maximum TAC for sessions created via passkey auth. Admin sessions (e.g. via OIDC) may get a different MaxTAC per policy. Default: "rwl" (read, write, list) |
+| `as.legacy.enabled` | `WALLET_AS_LEGACY_ENABLED` | boolean | Enabled controls whether legacy HMAC tokens are accepted. Default: true (for backward compatibility) |
+| `as.legacy.deprecation_header` | `WALLET_AS_LEGACY_DEPRECATION_HEADER` | boolean | DeprecationHeader controls whether Deprecation + Sunset headers are sent on legacy token responses. |
+| `as.legacy.sunset_date` | `WALLET_AS_LEGACY_SUNSET_DATE` | string | SunsetDate is the date after which legacy tokens will no longer be supported. Used in the Sunset HTTP header. Format: RFC 3339 date (e.g. "2027-10-01T00:00:00Z"). |
+| `as.external_url` | `WALLET_AS_EXTERNAL_URL` | string | ExternalURL is the public-facing base URL of the AS (e.g. "https://wallet.example.com"). Used to construct OIDC redirect URIs. Required when OIDC is used. |
+| `as.insecure_cookies` | `WALLET_AS_INSECURE_COOKIES` | boolean | InsecureCookies disables the __Host- prefix and Secure flag on session cookies. Required for local development over HTTP. NEVER enable in production. |
+
 ## wallet_provider
 
 Environment prefix: `WALLET_WALLET_PROVIDER`
@@ -123,6 +149,39 @@ Environment prefix: `WALLET_WALLET_PROVIDER`
 | `wallet_provider.private_key_path` | `WALLET_WALLET_PROVIDER_PRIVATE_KEY_PATH` | string |  |
 | `wallet_provider.certificate_path` | `WALLET_WALLET_PROVIDER_CERTIFICATE_PATH` | string |  |
 | `wallet_provider.ca_cert_path` | `WALLET_WALLET_PROVIDER_CA_CERT_PATH` | string |  |
+| `wallet_provider.pkcs11.module_path` | `WALLET_WALLET_PROVIDER_PKCS11_MODULE_PATH` | string |  |
+| `wallet_provider.pkcs11.slot_id` | `WALLET_WALLET_PROVIDER_PKCS11_SLOT_ID` | uint |  |
+| `wallet_provider.pkcs11.pin` | `WALLET_WALLET_PROVIDER_PKCS11_PIN` | string |  |
+| `wallet_provider.pkcs11.pin_path` | `WALLET_WALLET_PROVIDER_PKCS11_PIN_PATH` | string | Path to file containing PIN (preferred over inline PIN) |
+| `wallet_provider.pkcs11.key_label` | `WALLET_WALLET_PROVIDER_PKCS11_KEY_LABEL` | string |  |
+| `wallet_provider.pkcs11.pool_size` | `WALLET_WALLET_PROVIDER_PKCS11_POOL_SIZE` | integer | Session pool size (default 4) |
+| `wallet_provider.wia.enabled` | `WALLET_WALLET_PROVIDER_WIA_ENABLED` | boolean | Enabled controls whether WIA endpoints are registered |
+| `wallet_provider.wia.issuer` | `WALLET_WALLET_PROVIDER_WIA_ISSUER` | string | Issuer is the optional `iss` claim in WIA JWTs. Default is empty (omitted per TS03 §2.2.1, identity derived from x5c chain). Some national profiles require an explicit iss for interop. |
+| `wallet_provider.wia.omit_x5c` | `WALLET_WALLET_PROVIDER_WIA_OMIT_X5C` | boolean | OmitX5C skips attaching the wallet provider's certificate chain to the WIA JWT header, so relying parties resolve trust via the `iss` claim's JWKS (draft-ietf-oauth-attestation-based-client-auth, "iss-based IETF draft format") instead of TS03's x5c-derived identity. When x5c is present, consumers (e.g. SUNET/vc's parseAttestationIdentity) treat it as authoritative and iss as a secondary consistency check only — so this is the only way to actually exercise iss/JWKS-based trust when a certificate is configured. Requires Issuer to be set; the wallet provider's public key must be resolvable at "<issuer>/.well-known/jwks.json" (see RegisterWalletProviderJWKSRoute). |
+| `wallet_provider.wia.wallet_provider_uri` | `WALLET_WALLET_PROVIDER_WIA_WALLET_PROVIDER_URI` | string | WalletProviderURI is the expected `aud` in WIA-PoP JWTs (wallet provider identifier) |
+| `wallet_provider.wia.wallet_name` | `WALLET_WALLET_PROVIDER_WIA_WALLET_NAME` | string | WalletName is the wallet_name claim in WIA JWT |
+| `wallet_provider.wia.wallet_version` | `WALLET_WALLET_PROVIDER_WIA_WALLET_VERSION` | string | WalletVersion is the wallet_version claim |
+| `wallet_provider.wia.wallet_link` | `WALLET_WALLET_PROVIDER_WIA_WALLET_LINK` | string | WalletLink is the wallet download/info URI |
+| `wallet_provider.wia.certification_info` | `WALLET_WALLET_PROVIDER_WIA_CERTIFICATIONINFO` | map[string]interface{} | CertificationInfo is the wallet_solution_certification_information claim. Free-form map included as-is in the WIA JWT (Annex C §C.3.2). |
+| `wallet_provider.wia.max_expiry_seconds` | `WALLET_WALLET_PROVIDER_WIA_MAX_EXPIRY_SECONDS` | integer | MaxExpirySeconds is the maximum WIA lifetime in seconds (CS-04 requires < 24h) |
+| `wallet_provider.wia.challenge_ttl_seconds` | `WALLET_WALLET_PROVIDER_WIA_CHALLENGE_TTL_SECONDS` | integer | ChallengeTTLSeconds is the lifetime of WIA challenge nonces in seconds |
+| `wallet_provider.wia.rate_limit.enabled` | `WALLET_WALLET_PROVIDER_WIA_RATE_LIMIT_ENABLED` | boolean | Enabled controls whether rate limiting is active |
+| `wallet_provider.wia.rate_limit.max_attempts` | `WALLET_WALLET_PROVIDER_WIA_RATE_LIMIT_MAX_ATTEMPTS` | integer | MaxAttempts is the maximum number of login/registration attempts per window Default: 10 |
+| `wallet_provider.wia.rate_limit.window_seconds` | `WALLET_WALLET_PROVIDER_WIA_RATE_LIMIT_WINDOW_SECONDS` | integer | WindowSeconds is the time window for rate limiting (in seconds) Default: 60 (1 minute) |
+| `wallet_provider.wia.rate_limit.lockout_seconds` | `WALLET_WALLET_PROVIDER_WIA_RATE_LIMIT_LOCKOUT_SECONDS` | integer | LockoutSeconds is how long to lock out after exceeding the limit Default: 300 (5 minutes) |
+| `wallet_provider.attestation.lifetime_seconds` | `WALLET_WALLET_PROVIDER_ATTESTATION_LIFETIME_SECONDS` | integer | LifetimeSeconds is the global attestation lifetime (WIA + KA). CS-04 requires < 24h (86400). Default: 3600 (1 hour). |
+| `wallet_provider.attestation.ka_expiry_seconds` | `WALLET_WALLET_PROVIDER_ATTESTATION_KA_EXPIRY_SECONDS` | integer | KAExpirySeconds is the key attestation JWT expiry. Short-lived by default (15s) for single-use credential issuance. |
+| `wallet_provider.attestation.status_list_mode` | `WALLET_WALLET_PROVIDER_ATTESTATION_STATUS_LIST_MODE` | string | StatusListMode controls whether attestations include a status_list entry. Values: "always" (always include), "never" (omit for short-lived), "auto" (include only if lifetime > threshold). Default: "never". |
+| `wallet_provider.attestation.status_list_url` | `WALLET_WALLET_PROVIDER_ATTESTATION_STATUS_LIST_URL` | string | StatusListURL is the base URL for the Token Status List endpoint. |
+| `wallet_provider.attestation.status_list_expiry` | `WALLET_WALLET_PROVIDER_ATTESTATION_STATUS_LIST_EXPIRY` | integer | StatusListExpiry is the lifetime (seconds) of a status list entry. When > 0, the client_status object includes an "exp" field (Annex C §C.3.2). |
+| `wallet_provider.attestation.native_attestation.enabled` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_ENABLED` | boolean | Enabled controls whether native platform attestation is required. |
+| `wallet_provider.attestation.native_attestation.apple_app_attest_environment` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_APPLE_APP_ATTEST_ENVIRONMENT` | string | AppleAppAttestEnvironment: "production" or "development" |
+| `wallet_provider.attestation.native_attestation.apple_app_id` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_APPLE_APP_ID` | string | AppleAppID is the full App ID (TeamID.BundleID) for Apple App Attest. |
+| `wallet_provider.attestation.native_attestation.google_package_name` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PACKAGE_NAME` | string | GooglePackageName is the Android package name for Play Integrity. |
+| `wallet_provider.attestation.native_attestation.google_play_integrity_decryption_key` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PLAY_INTEGRITY_DECRYPTION_KEY` | string | GooglePlayIntegrityDecryptionKey is the base64-encoded decryption key. Prefer GooglePlayIntegrityDecryptionKeyPath for production deployments. |
+| `wallet_provider.attestation.native_attestation.google_play_integrity_decryption_key_path` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PLAY_INTEGRITY_DECRYPTION_KEY_PATH` | string | GooglePlayIntegrityDecryptionKeyPath is a path to a file containing the decryption key (preferred over the inline value — same pattern as PKCS11.PINPath / JWT.SecretPath, so this AES key material can be mounted from a secret store instead of living in plain env vars/YAML). |
+| `wallet_provider.attestation.native_attestation.google_play_integrity_verification_key` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PLAY_INTEGRITY_VERIFICATION_KEY` | string | GooglePlayIntegrityVerificationKey is the base64-encoded verification key. Prefer GooglePlayIntegrityVerificationKeyPath for production deployments. |
+| `wallet_provider.attestation.native_attestation.google_play_integrity_verification_key_path` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PLAY_INTEGRITY_VERIFICATION_KEY_PATH` | string | GooglePlayIntegrityVerificationKeyPath is a path to a file containing the verification key (preferred over the inline value). |
 
 ## trust
 
@@ -206,6 +265,17 @@ Environment prefix: `WALLET_AUTHZEN_PROXY`
 | `authzen_proxy.allow_resolution` | `WALLET_AUTHZEN_PROXY_ALLOW_RESOLUTION` | boolean | AllowResolution controls whether resolution-only requests are allowed. Resolution requests fetch metadata (DID documents, entity configs) without key validation. Default: true |
 | `authzen_proxy.fail_open_on_tenant_lookup_error` | `WALLET_AUTHZEN_PROXY_FAIL_OPEN_ON_TENANT_LOOKUP_ERROR` | boolean | FailOpenOnTenantLookupError controls behavior when per-tenant PDP lookup fails. If false (default), tenant lookup errors return an error to the client. If true, falls back to the global PDP URL on lookup errors. Security note: fail-closed (false) prevents bypassing per-tenant security policies. |
 
+## audit
+
+Environment prefix: `WALLET_AUDIT`
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `audit.enabled` | `WALLET_AUDIT_ENABLED` | boolean | Enabled enables SET audit event emission. |
+| `audit.issuer` | `WALLET_AUDIT_ISSUER` | string | Issuer is the iss claim in SET records (e.g. "https://wallet.siros.org"). |
+| `audit.key_path` | `WALLET_AUDIT_KEY_PATH` | string | KeyPath is the path to a PEM-encoded EC private key for signing SET records. |
+| `audit.key_id` | `WALLET_AUDIT_KEY_ID` | string | KeyID is the kid used in SET JWS headers. |
+
 ## Registry Server
 
 The registry server (`cmd/registry`) has its own configuration file. It serves VCTM (Verifiable Credential Type Metadata) fetched from upstream registries.
@@ -237,7 +307,8 @@ Environment prefix: `REGISTRY_SOURCE`
 
 | YAML Key | Env Variable | Type | Description |
 |----------|-------------|------|-------------|
-| `source.url` | `REGISTRY_SOURCE_URL` | string | URL of the upstream registry index. Supports both the legacy vctm-registry.json format and the TS11-compliant /api/v1/schemas.json endpoint – the format is auto-detected from the response. |
+| `source.url` | `REGISTRY_SOURCE_URL` | string | URL of the upstream registry. The actual endpoint is determined by the Mode setting. |
+| `source.mode` | `REGISTRY_SOURCE_MODE` | string (`ts11` or `registry`) | Mode selects which API endpoint to use: "ts11" (default) or "registry" (all credentials). |
 | `source.local_overrides` | `REGISTRY_SOURCE_LOCAL_OVERRIDES` | string list | LocalOverrides is a list of local file or directory paths containing VCTM JSON files. These are loaded at startup and take priority over entries fetched from the remote registry. Directories are scanned for *.json files. Entries are keyed by their "vct" field. |
 | `source.poll_interval` | `REGISTRY_SOURCE_POLL_INTERVAL` | duration | PollInterval is how often to poll the upstream registry for updates |
 | `source.timeout` | `REGISTRY_SOURCE_TIMEOUT` | duration | Timeout for HTTP requests to the upstream registry |
@@ -250,7 +321,8 @@ Environment prefix: `REGISTRY_SOURCES`
 
 | YAML Key | Env Variable | Type | Description |
 |----------|-------------|------|-------------|
-| `sources[*].url` | `REGISTRY_SOURCES_URL` | string | URL of the upstream registry index. Supports both the legacy vctm-registry.json format and the TS11-compliant /api/v1/schemas.json endpoint – the format is auto-detected from the response. |
+| `sources[*].url` | `REGISTRY_SOURCES_URL` | string | URL is the base URL of the registry (e.g. "https://registry.siros.org"). The actual endpoint path is determined by the Mode setting. For backward compatibility, if a full path to a specific endpoint is given (e.g. ending in schemas.json or registry.json), it is used as-is regardless of Mode. |
+| `sources[*].mode` | `REGISTRY_SOURCES_MODE` | string (`ts11` or `registry`) | Mode selects which API endpoint to use: "ts11" (default) for only TS11-compliant credentials, or "registry" for all credentials including non-TS11. |
 | `sources[*].timeout` | `REGISTRY_SOURCES_TIMEOUT` | duration | Timeout for HTTP requests to this source. Zero means no per-source timeout (the shared http.Client timeout applies). |
 
 ## registry.cache
@@ -325,6 +397,7 @@ Environment prefix: `REGISTRY_JWT`
 | YAML Key | Env Variable | Type | Description |
 |----------|-------------|------|-------------|
 | `jwt.secret` | `REGISTRY_JWT_SECRET` | string | Secret is the shared secret for validating JWT signatures (HMAC) |
+| `jwt.secret_path` | `REGISTRY_JWT_SECRET_PATH` | string | SecretPath is an alternative to Secret: path to a file containing the JWT secret. If both Secret and SecretPath are set, SecretPath takes precedence. |
 | `jwt.issuer` | `REGISTRY_JWT_ISSUER` | string | Issuer is the expected issuer claim in the JWT |
 | `jwt.require_auth` | `REGISTRY_JWT_REQUIRE_AUTH` | boolean | RequireAuth requires authentication for all requests (if false, unauthenticated access is allowed) |
 

--- a/docs/client-id-strategy.md
+++ b/docs/client-id-strategy.md
@@ -20,9 +20,9 @@ attestation-rooted identity.
 | 3 | Verifier attestation scheme | **Merged** | go-wallet-backend #238 |
 | 3a | SUNET/vc federation entity config | In progress | SUNET/vc (separate session) |
 | 3b | SUNET/vc DID-based identity | In progress | SUNET/vc (separate session) |
-| 3c | SUNET/vc eliminate static client map | **Implemented** (via WIA, see Phase 4) | SUNET/vc #556 |
+| 3c | SUNET/vc eliminate static client map | **Implemented** (via WIA, see Phase 4a) | SUNET/vc #556 |
 | 4 | Server-side issuer trust evaluation | **Merged** | go-wallet-backend #239 |
-| 4 | WIA + KA issuer auth (no pre-registration) | **Implemented, verified E2E against a live issuer** | go-wallet-backend #259, wallet-frontend #196, SUNET/vc #556 |
+| 4a | WIA + KA issuer auth (no pre-registration) | **Implemented, verified E2E against a live issuer** | go-wallet-backend #259, wallet-frontend #196, SUNET/vc #556 |
 | 5 | Deprecate pre-registration | Operational | go-trust config change only |
 | 6 | Native SDK typed TrustResult | **Merged** | Kotlin #46, Swift #44 |
 | 7 | ClientIdScheme parsing + audience validation | **Merged** | Kotlin #47/#48, Swift #45/#46 |

--- a/docs/client-id-strategy.md
+++ b/docs/client-id-strategy.md
@@ -20,8 +20,9 @@ attestation-rooted identity.
 | 3 | Verifier attestation scheme | **Merged** | go-wallet-backend #238 |
 | 3a | SUNET/vc federation entity config | In progress | SUNET/vc (separate session) |
 | 3b | SUNET/vc DID-based identity | In progress | SUNET/vc (separate session) |
-| 3c | SUNET/vc eliminate static client map | In progress | SUNET/vc (separate session) |
+| 3c | SUNET/vc eliminate static client map | **Implemented** (via WIA, see Phase 4) | SUNET/vc #556 |
 | 4 | Server-side issuer trust evaluation | **Merged** | go-wallet-backend #239 |
+| 4 | WIA + KA issuer auth (no pre-registration) | **Implemented, verified E2E against a live issuer** | go-wallet-backend #259, wallet-frontend #196, SUNET/vc #556 |
 | 5 | Deprecate pre-registration | Operational | go-trust config change only |
 | 6 | Native SDK typed TrustResult | **Merged** | Kotlin #46, Swift #44 |
 | 7 | ClientIdScheme parsing + audience validation | **Merged** | Kotlin #47/#48, Swift #45/#46 |
@@ -87,9 +88,13 @@ wire; OIDF determines how trust in that identity is evaluated.
 DPoP (RFC 9449) is always used. The `attestation` proof type is preferred when
 the issuer supports it (per `openid4vciProofTypePrecedence`).
 
-**In progress**: A PR on go-wallet-backend implements full WIA (Wallet Instance
-Attestation) + KA (Key Attestation) support. Corresponding code paths are being
-added to wallet-frontend (limited support) and the native SDKs.
+**Implemented and verified end-to-end**: go-wallet-backend #259 implements full
+WIA (Wallet Instance Attestation) + KA (Key Attestation) issuance, with a
+matching client-side path in wallet-frontend (#196) and issuer-side
+verification in SUNET/vc (#556). Verified against a live issuer with real
+Playwright browser tests, with no pre-registered `client_id` involved at any
+point. Native SDK support is still outstanding. See
+`docs/wallet-instance-attestation.md` for the implementation reference.
 
 ### SUNET/vc — Issuer and Verifier Service
 
@@ -400,7 +405,18 @@ addition to (or instead of) `x509_san_dns`.
 **Goal**: Replace `apigw.oauth_server.clients` YAML map with attestation-based
 wallet identification.
 
-**Components**:
+> **Update: implemented, differently from the sketch below.** The actual
+> mechanism (SUNET/vc #556, go-wallet-backend #259, wallet-frontend #196) uses
+> HTTP headers (`OAuth-Client-Attestation` / `OAuth-Client-Attestation-PoP`),
+> not a `client_assertion_type: jwt-bearer` body parameter, and config lives
+> under `apigw.trust.wallet_attestation` (delegating the trust *decision* to
+> the existing go-trust PDP whitelist/OIDF registries), not a separate
+> `wallet_provider_trust` map. See go-wallet-backend's
+> `docs/wallet-instance-attestation.md` and SUNET/vc's
+> `docs/TRUST_AND_IDENTITY.md` for what actually shipped; the components below
+> are left as the original planning sketch for context.
+
+**Components** (original plan, superseded — see note above):
 
 1. **Accept wallet attestation in token requests**:
    - Add `client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"`
@@ -460,11 +476,14 @@ trust dynamically.
    - The wallet-provider key attestation (`attestation` proof type) is the primary
      proof of wallet identity — no `client_id` needed beyond the spec-mandated
      parameter
-   - When `client_id` must be sent (spec compliance): use the wallet instance's
-     DID or the redirect_uri as a stable identifier derived from attestation
-   - **Note**: WIA (Wallet Instance Attestation) + KA (Key Attestation) support
-     is currently being implemented — PR in progress on go-wallet-backend with
-     corresponding paths being added to wallet-frontend (limited) and native SDKs
+   - When `client_id` must be sent (spec compliance): the wallet's own
+     `redirect_uri` (OID4VCI §7.1 unregistered-client convention) — this is
+     what actually shipped; see below, DID-based `client_id` for this purpose
+     was not pursued
+   - **Implemented**: WIA (Wallet Instance Attestation) + KA (Key Attestation)
+     support shipped in go-wallet-backend #259, wallet-frontend #196, and
+     SUNET/vc #556, verified end-to-end against a live issuer with no
+     pre-registered `client_id`. See `docs/wallet-instance-attestation.md`.
 
 3. **Issuer-side OpenID Federation**:
    - Wallet resolves `{issuer_url}/.well-known/openid-federation` to discover

--- a/docs/wallet-instance-attestation.md
+++ b/docs/wallet-instance-attestation.md
@@ -1,0 +1,43 @@
+# Wallet Instance Attestation (WIA)
+
+go-wallet-backend can act as a **wallet provider**: it issues Wallet Instance Attestations (WIAs) that let this wallet authenticate to credential issuers per [draft-ietf-oauth-attestation-based-client-auth](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html), without the issuer pre-registering an OAuth `client_id` for every wallet deployment.
+
+See `docs/CONFIGURATION.md`'s `wallet_provider.wia.*` section for the full field reference. This document explains the moving parts and the two supported identity formats.
+
+## Endpoints
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /wallet-provider/wia/challenge` | Issues a single-use nonce. The caller signs it into a PoP JWT to prove possession of the attestation key before a WIA is issued for it. |
+| `POST /wallet-provider/wia/generate` | Verifies the challenge PoP, then issues a WIA (`wallet_instance_attestation`) bound to the caller's key. |
+| `GET /.well-known/jwks.json` | Serves the wallet provider's own signing public key (`RegisterWalletProviderJWKSRoute`, `internal/service/wallet_provider_jwks.go`). Only registered when a wallet-provider signing key is configured. |
+| `GET /.well-known/oauth-authorization-server` | RFC 8414 metadata pointing at the JWKS above (`issuer` + `jwks_uri`). Only registered when `wallet_provider.wia.issuer` (or `wallet_provider_uri` as fallback) is set. |
+
+## Two identity formats: x5c vs. `iss`-based
+
+Controlled by `wallet_provider.wia.omit_x5c`:
+
+- **`omit_x5c: false` (default)** — the WIA's JOSE header carries the wallet provider's `x5c` certificate chain. Relying parties treat the embedded certificate as the authoritative key; `iss` (if set) is only a secondary consistency check against the cert.
+- **`omit_x5c: true`** — no certificate chain is attached. This is the *only* way to actually exercise `iss`/JWKS-based trust (per the IETF draft) when a certificate happens to be configured — with `omit_x5c: false`, consumers ignore `iss` in favor of the cert. Requires `wallet_provider.wia.issuer` to be set. Relying parties must then resolve the signing key themselves from `<issuer>/.well-known/jwks.json` (or the RFC 8414 document above), matched by the WIA's JOSE `kid` header — which is always set to `"wallet-provider"` in this mode, the same `KeyID` the JWKS route publishes.
+
+The IETF draft leaves key-resolution/trust-establishment mechanisms explicitly out of scope (§9.8) — `iss` + JWKS + `kid` is one of the draft's own suggested strategies, not a SIROS invention, but relying parties differ in *how* they discover the JWKS from `iss`. That's why both a bare `.well-known/jwks.json` and a wrapping RFC 8414 document are published: some discovery chains (e.g. SD-JWT VC §5.3-style resolvers) look for a metadata document with a `jwks_uri` field and never try a bare JWKS path directly.
+
+## `iss` vs. `wallet_provider_uri` — two different audiences
+
+These are easy to conflate but serve different JWTs:
+
+- **`wallet_provider.wia.issuer`** → the WIA's own `iss` claim, and (via `WalletProviderService.Issuer()`) the `issuer` field in the RFC 8414 metadata above. Identifies *this wallet provider* to whoever receives a WIA it issued.
+- **`wallet_provider.wia.wallet_provider_uri`** → the expected `aud` on the **WIA-request PoP** — the short-lived proof-of-possession JWT a caller sends to *this service's own* `/wallet-provider/wia/generate` endpoint when requesting a WIA. A completely different JWT, audience, and purpose from the WIA itself.
+
+In this deployment's config both happen to be the same URL (the wallet-proxy's public address), but that's a deployment choice, not a requirement — `Issuer()` and the PoP-audience check are independent code paths.
+
+## Client-side convention this depends on
+
+Nothing here constrains what OAuth `client_id` the wallet ultimately uses with the credential issuer — but whatever value it is, it becomes the WIA's `sub` claim (see `GenerateWIA` in `internal/service/wia.go`), and the issuer's PAR handler will reject the attestation if `sub` doesn't match the `client_id` it resolves for that request. For unregistered clients, this backend's own AS module (`internal/engine/oid4vci.go`) defaults `client_id` to the caller's `redirect_uri` (OID4VCI §7.1 convention) — client integrations (e.g. wallet-frontend) must pass that same value as the WIA's `client_id`, not, say, the credential issuer's URL.
+
+## Related
+
+- `docs/client-id-strategy.md` — the broader cross-repo plan this fits into (Phase 4).
+- SUNET/vc: `docs/TRUST_AND_IDENTITY.md`'s "Wallet Attestation" section — issuer-side verification and trust evaluation.
+- wallet-frontend: `docs/WALLET_ATTESTATION.md` — client-side generation and the client_id/aud pitfalls hit integrating against this backend.
+- developers.siros.org: [Wallet Attestation](https://developers.siros.org/docs/sirosid/trust/wallet-attestation) and the attestation-based authentication how-to guide.

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -519,6 +519,11 @@ func (p *BackendProvider) RegisterRoutes(router *gin.Engine) {
 		p.asModule.RegisterRoutes(authGroup)
 	}
 
+	// Register the wallet provider's own JWKS (distinct from the AS's),
+	// for relying parties resolving trust via an iss-based WIA. No-ops if
+	// WIA/the wallet provider signing key isn't configured.
+	service.RegisterWalletProviderJWKSRoute(router, p.Services().WalletProvider)
+
 	// Register AuthZEN proxy routes if enabled
 	if p.authzenHandler != nil {
 		protected := router.Group("/")
@@ -891,6 +896,14 @@ func (p *WalletProviderProvider) RegisterRoutes(router *gin.Engine) {
 			wp.POST("/wia/generate", wiaLimit, p.handlers.WIAGenerate)
 		}
 	}
+
+	// Register the wallet provider's own JWKS, same as BackendProvider does
+	// (see BackendProvider.RegisterRoutes) - deployments that run
+	// wallet-provider as its own standalone role (RoleWalletProvider without
+	// RoleBackend) still need this for relying parties resolving trust via
+	// an iss-based WIA. No-ops if WIA/the wallet provider signing key isn't
+	// configured.
+	service.RegisterWalletProviderJWKSRoute(router, p.Services().WalletProvider)
 }
 
 // Services returns the service aggregate.

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -432,6 +432,66 @@ func TestBackendProvider_RegisterRoutes_WithoutAuthZENHandler(t *testing.T) {
 	}
 }
 
+// TestBackendProvider_RegisterRoutes_RegistersJWKS is a regression test:
+// co-hosted (BackendProvider) mode must expose /.well-known/jwks.json when a
+// wallet-provider signing key is configured, so relying parties resolving
+// trust via an iss-based WIA (WalletProvider.WIA.OmitX5C) can fetch it.
+func TestBackendProvider_RegisterRoutes_RegistersJWKS(t *testing.T) {
+	dir := t.TempDir()
+	keyPath, certPath := writeTestECKeyAndCert(t, dir, "wallet-provider")
+
+	logger := zap.NewNop()
+	cfg := minimalTestConfig()
+	cfg.WalletProvider.PrivateKeyPath = keyPath
+	cfg.WalletProvider.CertificatePath = certPath
+	store := newTestMemoryBackend(t)
+
+	authProvider := NewAuthProvider(cfg, store, logger, nil)
+	storageProvider := NewStorageProvider(cfg, store, logger, nil)
+
+	provider := &BackendProvider{
+		auth:    authProvider,
+		storage: storageProvider,
+		store:   store,
+		cfg:     cfg,
+		logger:  logger,
+	}
+
+	router := gin.New()
+	provider.RegisterRoutes(router)
+
+	if !hasRoute(router.Routes(), http.MethodGet, "/.well-known/jwks.json") {
+		t.Error("expected GET /.well-known/jwks.json to be registered when a wallet-provider signing key is configured")
+	}
+}
+
+// TestBackendProvider_RegisterRoutes_NoJWKSWithoutSigningKey documents the
+// no-op counterpart: without a configured wallet-provider signing key, the
+// route must not be registered at all.
+func TestBackendProvider_RegisterRoutes_NoJWKSWithoutSigningKey(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := minimalTestConfig()
+	store := newTestMemoryBackend(t)
+
+	authProvider := NewAuthProvider(cfg, store, logger, nil)
+	storageProvider := NewStorageProvider(cfg, store, logger, nil)
+
+	provider := &BackendProvider{
+		auth:    authProvider,
+		storage: storageProvider,
+		store:   store,
+		cfg:     cfg,
+		logger:  logger,
+	}
+
+	router := gin.New()
+	provider.RegisterRoutes(router)
+
+	if hasRoute(router.Routes(), http.MethodGet, "/.well-known/jwks.json") {
+		t.Error("expected /.well-known/jwks.json NOT to be registered without a wallet-provider signing key")
+	}
+}
+
 func TestAuthProvider_RegisterRoutes_NoCacheCoverage(t *testing.T) {
 	logger := zap.NewNop()
 	cfg := minimalTestConfig()
@@ -596,6 +656,48 @@ func TestNewWalletProviderProvider_NoTokenValidatorWhenASDisabled(t *testing.T) 
 		t.Fatal("expected tokenValidator to be nil when cfg.AS.Enabled is false")
 	}
 }
+
+// TestWalletProviderProvider_RegisterRoutes_RegistersJWKS is a regression
+// test: standalone wallet-provider mode (RoleWalletProvider without
+// RoleBackend) must expose the same /.well-known/jwks.json as the co-hosted
+// BackendProvider does, or relying parties resolving trust via an iss-based
+// WIA (WalletProvider.WIA.OmitX5C) have nowhere to fetch the key when this
+// role runs as its own standalone microservice.
+func TestWalletProviderProvider_RegisterRoutes_RegistersJWKS(t *testing.T) {
+	dir := t.TempDir()
+	keyPath, certPath := writeTestECKeyAndCert(t, dir, "wallet-provider")
+
+	cfg := &config.Config{
+		Storage: config.StorageConfig{Type: "memory"},
+		Server:  config.ServerConfig{Host: "localhost", Port: 8080, RPID: "localhost", RPOrigin: "http://localhost:8080"},
+		JWT:     config.JWTConfig{Secret: "test-secret-that-is-at-least-32-bytes!", Issuer: "test-issuer"},
+	}
+	cfg.WalletProvider.PrivateKeyPath = keyPath
+	cfg.WalletProvider.CertificatePath = certPath
+	cfg.WalletProvider.WIA.RateLimit = config.AuthRateLimitConfig{Enabled: false}
+
+	p, err := NewWalletProviderProvider(cfg, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewWalletProviderProvider: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	router := gin.New()
+	p.RegisterRoutes(router)
+
+	if !hasRoute(router.Routes(), http.MethodGet, "/.well-known/jwks.json") {
+		t.Error("expected GET /.well-known/jwks.json to be registered in standalone wallet-provider mode")
+	}
+}
+
+// Unlike BackendProvider (see TestBackendProvider_RegisterRoutes_NoJWKSWithoutSigningKey),
+// there's no "standalone wallet-provider without a signing key" case to test
+// here: NewWalletProviderProvider itself refuses to construct without a
+// supported signing key (see its "wallet-provider signing keys not
+// configured or not supported" error), so the no-op path in
+// RegisterWalletProviderJWKSRoute is unreachable through this provider and
+// is already covered directly at the service level (see
+// TestRegisterWalletProviderJWKSRoute_NoOpWhenNoSigningKey).
 
 // TestAuthProvider_WIARoutes_NotRegisteredWhenServiceNilDespiteEnabled is a
 // regression test for a review finding: in co-hosted (AuthProvider) mode,

--- a/internal/service/wallet_provider.go
+++ b/internal/service/wallet_provider.go
@@ -223,6 +223,17 @@ func (s *WalletProviderService) IsSupported() bool {
 	return s.jwtSigner != nil && len(s.certChain) > 0
 }
 
+// PublicKey returns the wallet provider's signing public key, or nil if no
+// signing key is configured. Used to serve the wallet provider's own JWKS
+// (see RegisterWalletProviderJWKSRoute) for relying parties resolving trust
+// via an iss-based (WIA.OmitX5C) attestation instead of its x5c chain.
+func (s *WalletProviderService) PublicKey() crypto.PublicKey {
+	if s.signer == nil {
+		return nil
+	}
+	return s.signer.Public()
+}
+
 // Close releases resources held by the service.
 // For PKCS#11 signers, this closes the token session pool.
 func (s *WalletProviderService) Close() {

--- a/internal/service/wallet_provider.go
+++ b/internal/service/wallet_provider.go
@@ -234,6 +234,18 @@ func (s *WalletProviderService) PublicKey() crypto.PublicKey {
 	return s.signer.Public()
 }
 
+// Issuer returns the value used as the WIA's iss claim (see WIAService's
+// GenerateWIA), so relying parties' RFC 8414 metadata discovery
+// (RegisterWalletProviderJWKSRoute) advertises the exact issuer the WIA
+// itself claims.
+func (s *WalletProviderService) Issuer() string {
+	issuer := s.cfg.WalletProvider.WIA.Issuer
+	if issuer == "" {
+		issuer = s.cfg.WalletProvider.WIA.WalletProviderURI
+	}
+	return issuer
+}
+
 // Close releases resources held by the service.
 // For PKCS#11 signers, this closes the token session pool.
 func (s *WalletProviderService) Close() {

--- a/internal/service/wallet_provider_jwks.go
+++ b/internal/service/wallet_provider_jwks.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-jose/go-jose/v4"
@@ -47,8 +48,14 @@ func RegisterWalletProviderJWKSRoute(router gin.IRoutes, wp *WalletProviderServi
 	router.GET("/.well-known/oauth-authorization-server", func(c *gin.Context) {
 		c.Header("Cache-Control", "public, max-age=300")
 		c.JSON(http.StatusOK, gin.H{
+			// issuer must be byte-identical to wp.Issuer() (the WIA's own iss
+			// claim) - relying parties (e.g. vc's JWKSKeyResolver) reject the
+			// metadata if this doesn't exactly match the issuer they looked
+			// it up by. jwks_uri has no such constraint, so trim there only,
+			// to avoid a double slash when issuer is configured with a
+			// trailing one.
 			"issuer":   issuer,
-			"jwks_uri": issuer + "/.well-known/jwks.json",
+			"jwks_uri": strings.TrimRight(issuer, "/") + "/.well-known/jwks.json",
 		})
 	})
 }

--- a/internal/service/wallet_provider_jwks.go
+++ b/internal/service/wallet_provider_jwks.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-jose/go-jose/v4"
+)
+
+// RegisterWalletProviderJWKSRoute registers a bare-root /.well-known/jwks.json
+// endpoint serving the wallet provider's own signing public key. Distinct
+// from the AS module's JWKS (mounted at /auth/.well-known/jwks.json, a
+// different key for a different purpose): relying parties that receive an
+// iss-based WIA (WalletProvider.WIA.OmitX5C enabled) resolve trust by
+// fetching this endpoint at the WIA's iss URL, per the well-known-endpoint
+// discovery patterns trust registries use for JWK-identified issuers.
+//
+// No-ops (never registers the route) when the wallet provider has no
+// signing key configured, so environments without WIA enabled see a plain
+// 404 rather than a route that always errors.
+func RegisterWalletProviderJWKSRoute(router gin.IRoutes, wp *WalletProviderService) {
+	if wp == nil {
+		return
+	}
+	pub := wp.PublicKey()
+	if pub == nil {
+		return
+	}
+	router.GET("/.well-known/jwks.json", func(c *gin.Context) {
+		jwk := jose.JSONWebKey{
+			Key:       pub,
+			KeyID:     "wallet-provider",
+			Algorithm: string(jose.ES256),
+			Use:       "sig",
+		}
+		c.Header("Cache-Control", "public, max-age=300")
+		c.JSON(http.StatusOK, jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
+	})
+}

--- a/internal/service/wallet_provider_jwks.go
+++ b/internal/service/wallet_provider_jwks.go
@@ -8,14 +8,17 @@ import (
 )
 
 // RegisterWalletProviderJWKSRoute registers a bare-root /.well-known/jwks.json
-// endpoint serving the wallet provider's own signing public key. Distinct
-// from the AS module's JWKS (mounted at /auth/.well-known/jwks.json, a
-// different key for a different purpose): relying parties that receive an
+// endpoint serving the wallet provider's own signing public key, plus RFC
+// 8414 OAuth 2.0 Authorization Server Metadata at
+// /.well-known/oauth-authorization-server pointing to it via jwks_uri.
+// Distinct from the AS module's JWKS (mounted at /auth/.well-known/jwks.json,
+// a different key for a different purpose): relying parties that receive an
 // iss-based WIA (WalletProvider.WIA.OmitX5C enabled) resolve trust by
-// fetching this endpoint at the WIA's iss URL, per the well-known-endpoint
-// discovery patterns trust registries use for JWK-identified issuers.
+// discovering this metadata at the WIA's iss URL - the RFC 8414 document is
+// what lets standards-compliant JWKS discovery chains (e.g. SD-JWT VC §5.3
+// clients) find the key without any wallet-provider-specific knowledge.
 //
-// No-ops (never registers the route) when the wallet provider has no
+// No-ops (never registers the routes) when the wallet provider has no
 // signing key configured, so environments without WIA enabled see a plain
 // 404 rather than a route that always errors.
 func RegisterWalletProviderJWKSRoute(router gin.IRoutes, wp *WalletProviderService) {
@@ -35,5 +38,17 @@ func RegisterWalletProviderJWKSRoute(router gin.IRoutes, wp *WalletProviderServi
 		}
 		c.Header("Cache-Control", "public, max-age=300")
 		c.JSON(http.StatusOK, jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
+	})
+
+	issuer := wp.Issuer()
+	if issuer == "" {
+		return
+	}
+	router.GET("/.well-known/oauth-authorization-server", func(c *gin.Context) {
+		c.Header("Cache-Control", "public, max-age=300")
+		c.JSON(http.StatusOK, gin.H{
+			"issuer":   issuer,
+			"jwks_uri": issuer + "/.well-known/jwks.json",
+		})
 	})
 }

--- a/internal/service/wallet_provider_jwks_test.go
+++ b/internal/service/wallet_provider_jwks_test.go
@@ -83,6 +83,43 @@ func TestRegisterWalletProviderJWKSRoute_OAuthMetadata(t *testing.T) {
 	}
 }
 
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_TrailingSlashIssuer(t *testing.T) {
+	// Regression test: a configured issuer with a trailing slash must not
+	// produce a double slash in jwks_uri ("https://host//.well-known/..."),
+	// which strict metadata consumers reject. The issuer field itself must
+	// stay byte-identical to the configured value though - relying parties
+	// (e.g. vc's JWKSKeyResolver) match it exactly against the WIA's own iss
+	// claim, which also uses the untrimmed configured value.
+	svc := newTestWalletProviderService(t)
+	svc.cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example.com/"
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var meta struct {
+		Issuer  string `json:"issuer"`
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta.Issuer != "https://wallet-provider.example.com/" {
+		t.Errorf("issuer = %q, want byte-identical to configured value %q", meta.Issuer, "https://wallet-provider.example.com/")
+	}
+	if meta.JWKSURI != "https://wallet-provider.example.com/.well-known/jwks.json" {
+		t.Errorf("jwks_uri = %q, want no double slash", meta.JWKSURI)
+	}
+}
+
 func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_FallsBackToWalletProviderURI(t *testing.T) {
 	svc := newTestWalletProviderService(t)
 	svc.cfg.WalletProvider.WIA.WalletProviderURI = "https://fallback.example.com"

--- a/internal/service/wallet_provider_jwks_test.go
+++ b/internal/service/wallet_provider_jwks_test.go
@@ -49,6 +49,84 @@ func TestRegisterWalletProviderJWKSRoute_Success(t *testing.T) {
 	}
 }
 
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+	svc.cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example.com"
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=300")
+	}
+
+	var meta struct {
+		Issuer  string `json:"issuer"`
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta.Issuer != "https://wallet-provider.example.com" {
+		t.Errorf("issuer = %q, want %q", meta.Issuer, "https://wallet-provider.example.com")
+	}
+	if want := meta.Issuer + "/.well-known/jwks.json"; meta.JWKSURI != want {
+		t.Errorf("jwks_uri = %q, want %q", meta.JWKSURI, want)
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_FallsBackToWalletProviderURI(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+	svc.cfg.WalletProvider.WIA.WalletProviderURI = "https://fallback.example.com"
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var meta struct {
+		Issuer string `json:"issuer"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta.Issuer != "https://fallback.example.com" {
+		t.Errorf("issuer = %q, want %q", meta.Issuer, "https://fallback.example.com")
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_NoOpWhenNoIssuerConfigured(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+	// Neither WIA.Issuer nor WIA.WalletProviderURI set.
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (route should not be registered)", w.Code, http.StatusNotFound)
+	}
+}
+
 func TestRegisterWalletProviderJWKSRoute_NoOpWhenNoSigningKey(t *testing.T) {
 	svc := &WalletProviderService{
 		cfg: &config.Config{},

--- a/internal/service/wallet_provider_jwks_test.go
+++ b/internal/service/wallet_provider_jwks_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-jose/go-jose/v4"
+
+	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+)
+
+func TestRegisterWalletProviderJWKSRoute_Success(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=300")
+	}
+
+	var jwks jose.JSONWebKeySet
+	if err := json.Unmarshal(w.Body.Bytes(), &jwks); err != nil {
+		t.Fatalf("unmarshal jwks: %v", err)
+	}
+	if len(jwks.Keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(jwks.Keys))
+	}
+	key := jwks.Keys[0]
+	if key.KeyID != "wallet-provider" {
+		t.Errorf("KeyID = %q, want %q", key.KeyID, "wallet-provider")
+	}
+	if key.Algorithm != string(jose.ES256) {
+		t.Errorf("Algorithm = %q, want %q", key.Algorithm, jose.ES256)
+	}
+	if key.Use != "sig" {
+		t.Errorf("Use = %q, want %q", key.Use, "sig")
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_NoOpWhenNoSigningKey(t *testing.T) {
+	svc := &WalletProviderService{
+		cfg: &config.Config{},
+		// No signer configured.
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (route should not be registered)", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_NoOpWhenNilService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (route should not be registered)", w.Code, http.StatusNotFound)
+	}
+}

--- a/internal/service/wallet_provider_test.go
+++ b/internal/service/wallet_provider_test.go
@@ -755,6 +755,33 @@ func TestNewWalletProviderService_NoKeys(t *testing.T) {
 	}
 }
 
+func TestWalletProviderService_PublicKey(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+
+	pub := svc.PublicKey()
+	if pub == nil {
+		t.Fatal("expected non-nil public key when a signer is configured")
+	}
+	ecPub, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("expected *ecdsa.PublicKey, got %T", pub)
+	}
+	signerKey, ok := svc.signer.(*ecdsa.PrivateKey)
+	if !ok {
+		t.Fatalf("expected signer to be *ecdsa.PrivateKey, got %T", svc.signer)
+	}
+	if !ecPub.Equal(&signerKey.PublicKey) {
+		t.Error("PublicKey() should return the signer's public key")
+	}
+}
+
+func TestWalletProviderService_PublicKey_NilWithoutSigner(t *testing.T) {
+	svc := &WalletProviderService{cfg: &config.Config{}}
+	if pub := svc.PublicKey(); pub != nil {
+		t.Errorf("expected nil PublicKey() without a configured signer, got %v", pub)
+	}
+}
+
 // TestRandomStatusIndexSeed_NotZeroAndVaries is a regression test: the seed
 // used to initialize statusIndexCounter must be randomized per process, not a
 // constant zero. Without this, every replica in a horizontally-scaled

--- a/internal/service/wia.go
+++ b/internal/service/wia.go
@@ -546,7 +546,9 @@ func (s *WIAService) signWIA(cnfJWK map[string]interface{}, jkt string, tenantID
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
 	token.Header["typ"] = "oauth-client-attestation+jwt"
-	token.Header["x5c"] = s.certChain
+	if !s.cfg.WalletProvider.WIA.OmitX5C {
+		token.Header["x5c"] = s.certChain
+	}
 
 	tokenString, err := s.jwtSigner.SignToken(token)
 	if err != nil {

--- a/internal/service/wia.go
+++ b/internal/service/wia.go
@@ -548,6 +548,18 @@ func (s *WIAService) signWIA(cnfJWK map[string]interface{}, jkt string, tenantID
 	token.Header["typ"] = "oauth-client-attestation+jwt"
 	if !s.cfg.WalletProvider.WIA.OmitX5C {
 		token.Header["x5c"] = s.certChain
+	} else {
+		// No x5c means no embedded key material - relying parties must
+		// resolve the wallet provider's signing key from its own JWKS
+		// (RegisterWalletProviderJWKSRoute, served at the WIA's own iss
+		// URL). That resolution is kid-keyed (standard practice for
+		// multi-key JWKS, and what existing JWT trust-verification code
+		// elsewhere already expects), so the WIA itself must carry a kid
+		// header matching the JWKS entry's KeyID ("wallet-provider",
+		// hardcoded there since this deployment publishes exactly one
+		// signing key) - without it, a relying party has no way to know
+		// which of the issuer's published keys to use.
+		token.Header["kid"] = "wallet-provider"
 	}
 
 	tokenString, err := s.jwtSigner.SignToken(token)

--- a/internal/service/wia_test.go
+++ b/internal/service/wia_test.go
@@ -253,6 +253,45 @@ func TestWIAService_GenerateWIA_Success(t *testing.T) {
 	}
 }
 
+// OmitX5C lets a deployment opt into the IETF-draft iss/JWKS identity format
+// instead of TS03's x5c-derived identity - needed when relying parties can't
+// resolve trust via a self-signed x5c chain but can fetch a JWKS from a real
+// iss URL (see RegisterWalletProviderJWKSRoute).
+func TestWIAService_GenerateWIA_OmitX5C(t *testing.T) {
+	svc, _ := newTestWIAService(t)
+	svc.cfg.WalletProvider.WIA.OmitX5C = true
+	svc.cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example"
+
+	challenge, _, err := svc.CreateChallenge(context.Background(), domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("CreateChallenge: %v", err)
+	}
+	pop, _ := createTestPop(t, challenge)
+
+	wiaJWT, err := svc.GenerateWIA(context.Background(), domain.DefaultTenantID, nil, &WIARequest{
+		Pop:       pop,
+		Challenge: challenge,
+	})
+	if err != nil {
+		t.Fatalf("GenerateWIA: %v", err)
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(wiaJWT, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("Parse WIA: %v", err)
+	}
+
+	if token.Header["x5c"] != nil {
+		t.Error("x5c header should be omitted when OmitX5C is set")
+	}
+
+	claims := token.Claims.(jwt.MapClaims)
+	if claims["iss"] != "https://wallet-provider.example" {
+		t.Errorf("iss = %v, want https://wallet-provider.example", claims["iss"])
+	}
+}
+
 // draft-ietf-oauth-attestation-based-client-auth-10: "the sub claim MUST
 // specify client_id value of the OAuth Client" - when the caller (the OID4VCI
 // engine, via BackendApiClient.generateWIA) supplies its client_id, the WIA's

--- a/internal/service/wia_test.go
+++ b/internal/service/wia_test.go
@@ -286,6 +286,16 @@ func TestWIAService_GenerateWIA_OmitX5C(t *testing.T) {
 		t.Error("x5c header should be omitted when OmitX5C is set")
 	}
 
+	// Regression: without a kid header, a relying party has no self-contained
+	// key material (no x5c, no embedded jwk) and no way to know which of the
+	// wallet provider's published JWKS keys to use for signature
+	// verification (confirmed against a real relying party: SUNET/vc's
+	// pkg/trust JWT verification requires kid to resolve via JWKS). Must
+	// match RegisterWalletProviderJWKSRoute's hardcoded KeyID.
+	if token.Header["kid"] != "wallet-provider" {
+		t.Errorf("kid = %v, want %q (must match RegisterWalletProviderJWKSRoute's KeyID)", token.Header["kid"], "wallet-provider")
+	}
+
 	claims := token.Claims.(jwt.MapClaims)
 	if claims["iss"] != "https://wallet-provider.example" {
 		t.Errorf("iss = %v, want https://wallet-provider.example", claims["iss"])

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -154,13 +154,20 @@ func (c *Config) EnableForRole() {
 		return
 	}
 	c.AS.Enabled = true
-	// Auto-enable can only supply a signing key when the wallet provider
-	// itself is file-based (WalletProvider.PrivateKeyPath). A PKCS11-backed
-	// wallet provider has no equivalent here - AS's own PKCS11 signing is
-	// not implemented (see Validate()) - so this leaves SigningKeyPath
-	// empty and Validate() will reject with a clear, actionable error
-	// rather than silently limping along with AS enabled but unusable.
-	if c.AS.SigningKeyPath == "" && c.AS.SigningKeyPKCS11 == "" {
+	// Auto-enable can only inherit the wallet provider's signing key when
+	// the wallet provider is purely file-based - never when PKCS11 is
+	// configured for it, even if PrivateKeyPath is ALSO set as a runtime
+	// fallback (WalletProviderService tries PKCS11 first, independently of
+	// whether a file key is also configured). Inheriting the file path
+	// there would silently sign AS tokens with the weaker on-disk key while
+	// the wallet provider itself actually signs WIA/KA with the HSM key -
+	// a real, silent security downgrade, not just an unsupported
+	// configuration. AS's own PKCS11 signing is not implemented (see
+	// Validate()), so this deliberately leaves SigningKeyPath empty in that
+	// case; Validate() then rejects with a clear, actionable error rather
+	// than silently limping along with AS enabled on the wrong key.
+	walletProviderUsesPKCS11 := c.WalletProvider.PKCS11 != nil && c.WalletProvider.PKCS11.ModulePath != ""
+	if c.AS.SigningKeyPath == "" && c.AS.SigningKeyPKCS11 == "" && !walletProviderUsesPKCS11 {
 		c.AS.SigningKeyPath = c.WalletProvider.PrivateKeyPath
 	}
 	if c.AS.RulesDir == "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,28 +124,34 @@ func (c *ASConfig) SetDefaults() {
 	}
 }
 
-// EnableForRole turns on the AS (if not already explicitly configured) for
-// deployments that request the "auth" role (including via --mode=all).
-// There is no separate AS-specific key or policy to configure: it reuses the
-// wallet provider's own signing key, since every deployment already
-// configures one for WIA/Key Attestation, and falls back to the baseline
-// policy bundled in the image (see rules/, copied to /app/rules by the
-// Dockerfile) rather than requiring a deployment-specific RulesDir - a role
-// flag alone should be enough to turn AS on, matching how every other role
-// works.
+// EnableForRole turns on the AS for deployments that request the "auth" role
+// (including via --mode=all), and fills in defaults for anything left
+// unconfigured. There is no separate AS-specific key or policy to configure:
+// it reuses the wallet provider's own signing key (when file-based - see the
+// PKCS11 note below), since every deployment already configures one for
+// WIA/Key Attestation, and falls back to the baseline policy bundled in the
+// image (see rules/, copied to /app/rules by the Dockerfile) rather than
+// requiring a deployment-specific RulesDir - a role flag alone should be
+// enough to turn AS on, matching how every other role works.
 //
-// A caller-supplied c.AS.Enabled (explicitly set false or true in config)
-// always wins - this only fills in what an unconfigured AS section would
-// otherwise leave empty. Relies on Config.asEnabledExplicit (set by Load())
-// rather than c.AS.Enabled itself, since a plain bool can't distinguish
-// "explicitly set to false" from "never configured" (both are the zero
-// value) - without that, an operator's explicit as.enabled: false would be
-// silently overridden to true here.
+// An operator's explicit as.enabled: false always wins and skips all of the
+// above - relies on Config.asEnabledExplicit (set by Load()) rather than
+// c.AS.Enabled itself, since a plain bool can't distinguish "explicitly set
+// to false" from "never configured" (both are the zero value). An explicit
+// as.enabled: true does NOT skip defaulting - it's treated the same as
+// "unconfigured" for the fields below, so `as: {enabled: true}` alone
+// (without also configuring signing_key_path/rules_dir) still works.
 func (c *Config) EnableForRole() {
-	if c.asEnabledExplicit {
+	if c.asEnabledExplicit && !c.AS.Enabled {
 		return
 	}
 	c.AS.Enabled = true
+	// Auto-enable can only supply a signing key when the wallet provider
+	// itself is file-based (WalletProvider.PrivateKeyPath). A PKCS11-backed
+	// wallet provider has no equivalent here - AS's own PKCS11 signing is
+	// not implemented (see Validate()) - so this leaves SigningKeyPath
+	// empty and Validate() will reject with a clear, actionable error
+	// rather than silently limping along with AS enabled but unusable.
 	if c.AS.SigningKeyPath == "" && c.AS.SigningKeyPKCS11 == "" {
 		c.AS.SigningKeyPath = c.WalletProvider.PrivateKeyPath
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,14 @@ type Config struct {
 	HTTPClient     HTTPClientConfig     `yaml:"http_client" envconfig:"HTTP_CLIENT"`
 	AuthZENProxy   AuthZENProxyConfig   `yaml:"authzen_proxy" envconfig:"AUTHZEN_PROXY"`
 	Audit          AuditConfig          `yaml:"audit" envconfig:"AUDIT"`
+
+	// asEnabledExplicit records whether as.enabled was explicitly present in
+	// the YAML file or environment (as opposed to defaulting to its bool
+	// zero-value, false) - set by Load(), consumed by EnableForRole() so it
+	// can tell "operator explicitly disabled AS" apart from "AS section
+	// never configured". Unexported: never (un)marshaled, so it can't leak
+	// into YAML output or be set by config files/env itself.
+	asEnabledExplicit bool
 }
 
 // ASConfig contains the new Authorization Server configuration.
@@ -128,9 +136,13 @@ func (c *ASConfig) SetDefaults() {
 //
 // A caller-supplied c.AS.Enabled (explicitly set false or true in config)
 // always wins - this only fills in what an unconfigured AS section would
-// otherwise leave empty.
+// otherwise leave empty. Relies on Config.asEnabledExplicit (set by Load())
+// rather than c.AS.Enabled itself, since a plain bool can't distinguish
+// "explicitly set to false" from "never configured" (both are the zero
+// value) - without that, an operator's explicit as.enabled: false would be
+// silently overridden to true here.
 func (c *Config) EnableForRole() {
-	if c.AS.Enabled {
+	if c.asEnabledExplicit {
 		return
 	}
 	c.AS.Enabled = true
@@ -976,11 +988,15 @@ func Load(configFile string) (*Config, error) {
 			if err := yaml.Unmarshal(data, cfg); err != nil {
 				return nil, fmt.Errorf("failed to parse config file: %w", err)
 			}
+			cfg.asEnabledExplicit = yamlHasASEnabledKey(data)
 		}
 	}
 
 	// Override with environment variables (highest priority)
 	// Since we removed `default:` tags, this only applies actual env vars
+	if _, ok := os.LookupEnv("WALLET_AS_ENABLED"); ok {
+		cfg.asEnabledExplicit = true
+	}
 	if err := envconfig.Process("WALLET", cfg); err != nil {
 		return nil, fmt.Errorf("failed to process environment variables: %w", err)
 	}
@@ -1004,6 +1020,23 @@ func Load(configFile string) (*Config, error) {
 	cfg.Server.CORS.SetDefaults()
 
 	return cfg, nil
+}
+
+// yamlHasASEnabledKey reports whether the raw YAML explicitly sets an
+// `as.enabled` key, regardless of its value - used to distinguish "operator
+// explicitly configured as.enabled" from "AS section absent/defaulted",
+// which a plain bool field can't express on its own (see EnableForRole).
+func yamlHasASEnabledKey(data []byte) bool {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	as, ok := raw["as"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, ok = as["enabled"]
+	return ok
 }
 
 // loadSecretsFromFiles loads secrets from file paths.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -565,6 +565,17 @@ type WIAConfig struct {
 	// Default is empty (omitted per TS03 §2.2.1, identity derived from x5c chain).
 	// Some national profiles require an explicit iss for interop.
 	Issuer string `yaml:"issuer" envconfig:"ISSUER"`
+	// OmitX5C skips attaching the wallet provider's certificate chain to the
+	// WIA JWT header, so relying parties resolve trust via the `iss` claim's
+	// JWKS (draft-ietf-oauth-attestation-based-client-auth, "iss-based IETF
+	// draft format") instead of TS03's x5c-derived identity. When x5c is
+	// present, consumers (e.g. SUNET/vc's parseAttestationIdentity) treat it
+	// as authoritative and iss as a secondary consistency check only — so
+	// this is the only way to actually exercise iss/JWKS-based trust when a
+	// certificate is configured. Requires Issuer to be set; the wallet
+	// provider's public key must be resolvable at
+	// "<issuer>/.well-known/jwks.json" (see RegisterWalletProviderJWKSRoute).
+	OmitX5C bool `yaml:"omit_x5c" envconfig:"OMIT_X5C"`
 	// WalletProviderURI is the expected `aud` in WIA-PoP JWTs (wallet provider identifier)
 	WalletProviderURI string `yaml:"wallet_provider_uri" envconfig:"WALLET_PROVIDER_URI"`
 	// WalletName is the wallet_name claim in WIA JWT
@@ -1344,6 +1355,15 @@ func (c *Config) Validate() error {
 			(c.WalletProvider.PKCS11 != nil && c.WalletProvider.PKCS11.ModulePath != "")
 		if walletProviderKeysConfigured && c.WalletProvider.WIA.WalletProviderURI == "" {
 			return fmt.Errorf("wallet_provider.wia.wallet_provider_uri is required when WIA is enabled with signing keys configured (used to validate the WIA-PoP aud claim)")
+		}
+
+		// OmitX5C means the iss claim (not the x5c chain) is the only way a
+		// relying party can identify the wallet provider and resolve its
+		// JWKS - falling back to wallet_provider_uri here (as signWIA does
+		// when issuer is unset) would silently repurpose an aud identifier
+		// as an iss/JWKS-discovery URL that was never configured for that.
+		if c.WalletProvider.WIA.OmitX5C && c.WalletProvider.WIA.Issuer == "" {
+			return fmt.Errorf("wallet_provider.wia.issuer is required when wallet_provider.wia.omit_x5c is set (relying parties need it to resolve the JWKS)")
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,6 +116,39 @@ func (c *ASConfig) SetDefaults() {
 	}
 }
 
+// EnableForRole turns on the AS (if not already explicitly configured) for
+// deployments that request the "auth" role (including via --mode=all).
+// There is no separate AS-specific key or policy to configure: it reuses the
+// wallet provider's own signing key, since every deployment already
+// configures one for WIA/Key Attestation, and falls back to the baseline
+// policy bundled in the image (see rules/, copied to /app/rules by the
+// Dockerfile) rather than requiring a deployment-specific RulesDir - a role
+// flag alone should be enough to turn AS on, matching how every other role
+// works.
+//
+// A caller-supplied c.AS.Enabled (explicitly set false or true in config)
+// always wins - this only fills in what an unconfigured AS section would
+// otherwise leave empty.
+func (c *Config) EnableForRole() {
+	if c.AS.Enabled {
+		return
+	}
+	c.AS.Enabled = true
+	if c.AS.SigningKeyPath == "" && c.AS.SigningKeyPKCS11 == "" {
+		c.AS.SigningKeyPath = c.WalletProvider.PrivateKeyPath
+	}
+	if c.AS.RulesDir == "" {
+		// Ships in the image alongside the binary (see Dockerfile) - the
+		// baseline policy (read-only always allowed, own-tenant access for
+		// any tac) every deployment gets unless it configures its own.
+		c.AS.RulesDir = "/app/rules"
+	}
+	c.AS.SetDefaults()
+	if c.AS.Issuer == "" {
+		c.AS.Issuer = c.JWT.Issuer
+	}
+}
+
 // GetTokenTTL returns the TTL for a given audience, falling back to the default.
 func (c *ASConfig) GetTokenTTL(audience string) time.Duration {
 	if ttl, ok := c.AudienceTTLs[audience]; ok {
@@ -337,7 +370,7 @@ func (c *CORSConfig) SetDefaults() {
 	}
 	if len(c.AllowedHeaders) == 0 {
 		c.AllowedHeaders = []string{
-			"Authorization", "Content-Type", "X-Tenant-ID",
+			"Authorization", "Content-Type", "X-Tenant-ID", "X-Token-Mode",
 			"If-None-Match", "X-Private-Data-If-Match", "X-Private-Data-If-None-Match",
 			"Upgrade", "Connection", "Sec-WebSocket-Key",
 			"Sec-WebSocket-Version", "Sec-WebSocket-Protocol",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,9 +138,17 @@ func (c *ASConfig) SetDefaults() {
 // above - relies on Config.asEnabledExplicit (set by Load()) rather than
 // c.AS.Enabled itself, since a plain bool can't distinguish "explicitly set
 // to false" from "never configured" (both are the zero value). An explicit
-// as.enabled: true does NOT skip defaulting - it's treated the same as
-// "unconfigured" for the fields below, so `as: {enabled: true}` alone
-// (without also configuring signing_key_path/rules_dir) still works.
+// as.enabled: true does NOT skip defaulting here - it's treated the same as
+// "unconfigured" by this function's own logic.
+//
+// That said, `as: {enabled: true}` alone in a YAML file does NOT actually
+// work end-to-end via the normal startup path: Load() calls Validate()
+// before cmd/server/main.go ever calls EnableForRole(), and Validate()
+// unconditionally requires signing_key_path/rules_dir whenever AS.Enabled is
+// true - so Load() itself rejects that YAML before this function gets a
+// chance to fill in the defaults. This function's explicit-true handling
+// only matters for callers that construct/mutate a Config without going
+// through Load()'s validation first.
 func (c *Config) EnableForRole() {
 	if c.asEnabledExplicit && !c.AS.Enabled {
 		return

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,6 +124,15 @@ func (c *ASConfig) SetDefaults() {
 	}
 }
 
+// defaultASRulesDir is where EnableForRole expects the baseline SPOCP
+// policy to ship inside the container image (see rules/, copied here by
+// the Dockerfile). It's a var, not a const, so a packager whose filesystem
+// layout doesn't match the container's (e.g. a .deb following FHS) can
+// override it at build time without patching this file:
+//
+//	go build -ldflags "-X github.com/sirosfoundation/go-wallet-backend/pkg/config.defaultASRulesDir=/usr/share/go-wallet-backend/rules"
+var defaultASRulesDir = "/app/rules"
+
 // EnableForRole turns on the AS for deployments that request the "auth" role
 // (including via --mode=all), and fills in defaults for anything left
 // unconfigured. There is no separate AS-specific key or policy to configure:
@@ -171,10 +180,9 @@ func (c *Config) EnableForRole() {
 		c.AS.SigningKeyPath = c.WalletProvider.PrivateKeyPath
 	}
 	if c.AS.RulesDir == "" {
-		// Ships in the image alongside the binary (see Dockerfile) - the
-		// baseline policy (read-only always allowed, own-tenant access for
+		// Baseline policy (read-only always allowed, own-tenant access for
 		// any tac) every deployment gets unless it configures its own.
-		c.AS.RulesDir = "/app/rules"
+		c.AS.RulesDir = defaultASRulesDir
 	}
 	c.AS.SetDefaults()
 	if c.AS.Issuer == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1451,6 +1451,41 @@ as:
 	}
 }
 
+func TestConfig_EnableForRole_FillsDefaultsWhenExplicitlyEnabledInYAML(t *testing.T) {
+	// Regression test for EnableForRole()'s own logic: an explicit
+	// as.enabled: true must still get defaults filled in for whatever
+	// fields are empty - only an explicit as.enabled: false should skip
+	// defaulting entirely. Before this fix, EnableForRole() treated ANY
+	// explicit as.enabled (true or false) identically ("fully configured,
+	// don't touch it").
+	//
+	// Constructs Config directly (asEnabledExplicit set as Load() would)
+	// rather than going through Load() itself: Load()'s own Validate() call
+	// requires as.signing_key_path/rules_dir whenever as.enabled: true is
+	// present in YAML, regardless of role - so a YAML fixture reproducing
+	// this scenario would fail at Load() before EnableForRole() ever runs.
+	// That's a separate, pre-existing validation-ordering property (AS
+	// config is validated unconditionally on AS.Enabled, not gated on
+	// whether the auth role was even requested) - out of scope for this fix,
+	// which is specifically about EnableForRole()'s own explicit-true-vs-
+	// false handling.
+	cfg := &Config{asEnabledExplicit: true}
+	cfg.AS.Enabled = true
+	cfg.WalletProvider.PrivateKeyPath = "/wp/key.pem"
+
+	cfg.EnableForRole()
+
+	if !cfg.AS.Enabled {
+		t.Error("expected AS.Enabled to stay true")
+	}
+	if cfg.AS.SigningKeyPath != "/wp/key.pem" {
+		t.Errorf("expected SigningKeyPath to default to wallet provider's key, got %q", cfg.AS.SigningKeyPath)
+	}
+	if cfg.AS.RulesDir != "/app/rules" {
+		t.Errorf("expected RulesDir default of /app/rules, got %q", cfg.AS.RulesDir)
+	}
+}
+
 func TestConfig_EnableForRole_FillsInWhenYAMLOmitsASEntirely(t *testing.T) {
 	// Contrast with the test above: when the `as:` section is absent
 	// entirely (not just enabled: false), EnableForRole should still turn

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1368,6 +1368,32 @@ func TestConfig_EnableForRole_FillsDefaults(t *testing.T) {
 	}
 }
 
+func TestConfig_EnableForRole_DoesNotInheritFileKeyWhenWalletProviderUsesPKCS11(t *testing.T) {
+	// Regression test for a real Copilot review finding: a wallet provider
+	// configured with PKCS11 (which WalletProviderService tries first,
+	// independently of whether a file key is ALSO configured as a runtime
+	// fallback) actually signs WIA/KA with the HSM key. If EnableForRole()
+	// still inherited PrivateKeyPath here, AS would silently sign its own
+	// tokens with the weaker on-disk key instead - a security downgrade,
+	// not just an unsupported configuration. SigningKeyPath must stay empty
+	// so Validate() rejects with an actionable error instead.
+	cfg := &Config{}
+	cfg.WalletProvider.PrivateKeyPath = "/wp/fallback-key.pem"
+	cfg.WalletProvider.PKCS11 = &PKCS11SigningConfig{ModulePath: "/usr/lib/softhsm/libsofthsm2.so"}
+
+	cfg.EnableForRole()
+
+	if !cfg.AS.Enabled {
+		t.Error("expected AS.Enabled = true")
+	}
+	if cfg.AS.SigningKeyPath != "" {
+		t.Errorf("expected SigningKeyPath to stay empty (not inherit the file fallback key), got %q", cfg.AS.SigningKeyPath)
+	}
+	if cfg.AS.SigningKeyPKCS11 != "" {
+		t.Errorf("expected SigningKeyPKCS11 to stay empty (AS PKCS11 signing isn't implemented), got %q", cfg.AS.SigningKeyPKCS11)
+	}
+}
+
 func TestConfig_EnableForRole_NoOpWhenAlreadyEnabled(t *testing.T) {
 	cfg := &Config{}
 	cfg.AS.Enabled = true

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1343,6 +1343,77 @@ func TestASConfig_GetTokenTTL(t *testing.T) {
 	}
 }
 
+func TestConfig_EnableForRole_FillsDefaults(t *testing.T) {
+	cfg := &Config{}
+	cfg.WalletProvider.PrivateKeyPath = "/wp/key.pem"
+	cfg.JWT.Issuer = "https://issuer.example"
+
+	cfg.EnableForRole()
+
+	if !cfg.AS.Enabled {
+		t.Error("expected AS.Enabled = true")
+	}
+	if cfg.AS.SigningKeyPath != "/wp/key.pem" {
+		t.Errorf("expected SigningKeyPath to default to wallet provider's key, got %q", cfg.AS.SigningKeyPath)
+	}
+	if cfg.AS.RulesDir != "/app/rules" {
+		t.Errorf("expected RulesDir default of /app/rules, got %q", cfg.AS.RulesDir)
+	}
+	if cfg.AS.Issuer != "https://issuer.example" {
+		t.Errorf("expected Issuer to fall back to JWT.Issuer, got %q", cfg.AS.Issuer)
+	}
+	// SetDefaults should still run (TTLs, DefaultMaxTAC etc.)
+	if cfg.AS.DefaultTokenTTL == 0 {
+		t.Error("expected EnableForRole to also apply ASConfig.SetDefaults defaults")
+	}
+}
+
+func TestConfig_EnableForRole_NoOpWhenAlreadyEnabled(t *testing.T) {
+	cfg := &Config{}
+	cfg.AS.Enabled = true
+	cfg.AS.SigningKeyPath = "/custom/key.pem"
+	cfg.AS.RulesDir = "/custom/rules"
+	cfg.AS.Issuer = "https://custom-issuer.example"
+
+	cfg.EnableForRole()
+
+	if cfg.AS.SigningKeyPath != "/custom/key.pem" {
+		t.Errorf("expected explicit SigningKeyPath to be preserved, got %q", cfg.AS.SigningKeyPath)
+	}
+	if cfg.AS.RulesDir != "/custom/rules" {
+		t.Errorf("expected explicit RulesDir to be preserved, got %q", cfg.AS.RulesDir)
+	}
+	if cfg.AS.Issuer != "https://custom-issuer.example" {
+		t.Errorf("expected explicit Issuer to be preserved, got %q", cfg.AS.Issuer)
+	}
+}
+
+func TestConfig_EnableForRole_PreservesExplicitSigningKeyPKCS11(t *testing.T) {
+	cfg := &Config{}
+	cfg.AS.SigningKeyPKCS11 = "pkcs11:token=as-key"
+	cfg.WalletProvider.PrivateKeyPath = "/wp/key.pem"
+
+	cfg.EnableForRole()
+
+	if cfg.AS.SigningKeyPath != "" {
+		t.Errorf("expected SigningKeyPath to stay empty when SigningKeyPKCS11 is set, got %q", cfg.AS.SigningKeyPath)
+	}
+	if cfg.AS.SigningKeyPKCS11 != "pkcs11:token=as-key" {
+		t.Errorf("expected explicit SigningKeyPKCS11 to be preserved, got %q", cfg.AS.SigningKeyPKCS11)
+	}
+}
+
+func TestConfig_EnableForRole_ExplicitRulesDirPreserved(t *testing.T) {
+	cfg := &Config{}
+	cfg.AS.RulesDir = "/custom/rules"
+
+	cfg.EnableForRole()
+
+	if cfg.AS.RulesDir != "/custom/rules" {
+		t.Errorf("expected explicit RulesDir to be preserved, got %q", cfg.AS.RulesDir)
+	}
+}
+
 func TestConfig_Validate_AS_MissingSigningKey(t *testing.T) {
 	cfg := validBaseConfig()
 	cfg.AS.Enabled = true

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1414,6 +1414,78 @@ func TestConfig_EnableForRole_ExplicitRulesDirPreserved(t *testing.T) {
 	}
 }
 
+func TestConfig_EnableForRole_RespectsExplicitFalseInYAML(t *testing.T) {
+	// Regression test: EnableForRole must not override an operator's
+	// explicit `as.enabled: false` - a plain bool can't distinguish that
+	// from "as section never configured" (both are the zero value), which
+	// is why this goes through Load() (the only path that can observe the
+	// raw YAML) rather than constructing a Config{} directly.
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `
+server:
+  host: localhost
+  port: 8080
+  rp_id: localhost
+  rp_origin: http://localhost:8080
+storage:
+  type: memory
+jwt:
+  secret: test-secret-that-is-at-least-32-bytes-long
+as:
+  enabled: false
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	cfg.EnableForRole()
+
+	if cfg.AS.Enabled {
+		t.Error("expected explicit as.enabled: false in YAML to be preserved, but EnableForRole() overrode it to true")
+	}
+}
+
+func TestConfig_EnableForRole_FillsInWhenYAMLOmitsASEntirely(t *testing.T) {
+	// Contrast with the test above: when the `as:` section is absent
+	// entirely (not just enabled: false), EnableForRole should still turn
+	// it on for the auth role.
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `
+server:
+  host: localhost
+  port: 8080
+  rp_id: localhost
+  rp_origin: http://localhost:8080
+storage:
+  type: memory
+jwt:
+  secret: test-secret-that-is-at-least-32-bytes-long
+wallet_provider:
+  private_key_path: /wp/key.pem
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	cfg.EnableForRole()
+
+	if !cfg.AS.Enabled {
+		t.Error("expected AS.Enabled = true when as: section is absent entirely")
+	}
+}
+
 func TestConfig_Validate_AS_MissingSigningKey(t *testing.T) {
 	cfg := validBaseConfig()
 	cfg.AS.Enabled = true

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1780,6 +1780,46 @@ func TestConfig_Validate_WIA_PassesWithWalletProviderURI(t *testing.T) {
 	}
 }
 
+// TestConfig_Validate_WIA_OmitX5CRequiresIssuer is a regression test: when
+// OmitX5C is set, the iss claim (not the x5c chain) is the only way a
+// relying party can identify the wallet provider and resolve its JWKS.
+// Without this check, an operator could enable OmitX5C without setting
+// Issuer and get a WIA with neither x5c nor a usable iss - an attestation
+// nobody can resolve trust for.
+func TestConfig_Validate_WIA_OmitX5CRequiresIssuer(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.WalletProvider.WIA.Enabled = true
+	cfg.WalletProvider.WIA.MaxExpirySeconds = 86400
+	cfg.WalletProvider.WIA.WalletProviderURI = "https://wallet.example.com"
+	cfg.WalletProvider.WIA.OmitX5C = true
+	cfg.WalletProvider.PrivateKeyPath = "/path/to/key.pem"
+	cfg.WalletProvider.CertificatePath = "/path/to/cert.pem"
+	// Issuer intentionally left unset.
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error when omit_x5c is set without issuer")
+	}
+	if !strings.Contains(err.Error(), "wallet_provider.wia.issuer is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestConfig_Validate_WIA_OmitX5CPassesWithIssuer(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.WalletProvider.WIA.Enabled = true
+	cfg.WalletProvider.WIA.MaxExpirySeconds = 86400
+	cfg.WalletProvider.WIA.WalletProviderURI = "https://wallet.example.com"
+	cfg.WalletProvider.WIA.OmitX5C = true
+	cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example"
+	cfg.WalletProvider.PrivateKeyPath = "/path/to/key.pem"
+	cfg.WalletProvider.CertificatePath = "/path/to/cert.pem"
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // TestConfig_Validate_Audit_* are regression tests for a review finding:
 // Config.Validate() didn't check AuditConfig at all, so audit.enabled=true
 // with a missing issuer/key_path/key_id silently disabled the SET audit


### PR DESCRIPTION
## Summary

Enables wallet-attestation-based (WIA/Key Attestation) OAuth client authentication against the Authorization Server, per [draft-ietf-oauth-attestation-based-client-auth](https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/) — a client authenticates with a self-attested WIA instead of a pre-registered `client_id`/secret.

- **Auto-enable AS for the `auth` role.** `Config.EnableForRole()` turns the AS on when `--mode` includes `auth` (including `--mode=all`), without a separate AS-specific signing key or policy: it reuses the wallet provider's own signing key and falls back to the baseline SPOCP policy already bundled in the image (`rules/`, now copied into the container by the Dockerfile) unless the deployment configures its own `signing_key_path`/`rules_dir`. An explicitly configured `as.enabled` (either way) always wins.
- **iss/JWKS-based trust as an alternative to x5c.** `wallet_provider.wia.omit_x5c` lets a deployment skip the `x5c` certificate chain in the WIA JWT header, so a relying party resolves the wallet provider's identity via the `iss` claim's JWKS instead — the format the IETF draft expects, versus TS03 §2.2.1's x5c-derived identity. A new bare-root `/.well-known/jwks.json` route (`RegisterWalletProviderJWKSRoute`, distinct from the AS module's own JWKS at `/auth/.well-known/jwks.json`) serves the wallet provider's public key so that `iss` is actually resolvable, wired into both co-hosted (`BackendProvider`) and standalone (`WalletProviderProvider`) deployment modes.
- Adds `X-Token-Mode` to the default CORS allowed-headers list so AS session-mode clients aren't blocked by CORS preflight.

This pairs with corresponding changes in the `vc` and `sirosid-dev` repos (not part of this PR) that consume iss/JWKS-based attestation identity.

## Notable fixes made while completing this work

- **Nil-pointer panic on `--mode=auth`**: `backendCfg` was only loaded for `RoleBackend`/`RoleEngine`/`RoleAdmin`/`RoleWalletProvider`, but the new `EnableForRole()` call is gated on `RoleAuth` alone. `RoleAuth` is a documented, independently selectable role (`internal/modes.ValidRoles`), so running the server with `--mode=auth` by itself would have called `EnableForRole()` on a nil `*config.Config` and panicked at startup. `RoleAuth` is now included in the config-load condition.
- **Missing validation**: `wallet_provider.wia.omit_x5c` documented that it "requires Issuer to be set" but nothing enforced it — `Config.Validate()` now rejects `omit_x5c: true` with no `wia.issuer`, since falling back to `wallet_provider_uri` (as `signWIA` does when `issuer` is otherwise unset) would silently repurpose an `aud` identifier as a JWKS-discovery URL that was never configured for that purpose.
- **Missing JWKS wiring for standalone wallet-provider mode**: the JWKS route was only wired into `BackendProvider`, not `WalletProviderProvider` — meaning a deployment running `--mode=wallet-provider` as its own microservice (a real, supported split) would have no way to serve its JWKS at all. Wired into both.
- Fixed a stale doc comment on `EnableForRole` claiming it defaults to an "allow all" policy with no `rules_dir` — the code actually falls back to the bundled baseline policy at `/app/rules`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` all clean
- [x] New/updated tests: `EnableForRole` (no-op when already enabled, defaults filled in, explicit values preserved), `omit_x5c` WIA generation and config validation, `PublicKey()`, the new JWKS route (present/absent based on signing-key config), and its wiring into both `BackendProvider` and `WalletProviderProvider`