### PR TITLE
fix(authzen): resource_type=oauth-authorization-server unreachable in /v1/resolve

### DIFF
--- a/internal/api/authzen_proxy.go
+++ b/internal/api/authzen_proxy.go
@@ -435,10 +435,21 @@ func (h *AuthZENProxyHandler) Resolve(c *gin.Context) {
 			h.resolveCredentialOfferURI(c, ctx, req.SubjectID)
 			return
 		}
-		// Allowlist: only credential_issuer is valid beyond this point.
-		// An unknown resource_type would silently fall through to credential-issuer
-		// resolution, creating a policy-bypass surface if SPOCP rules are permissive.
-		if resourceType != "credential_issuer" {
+		// Allowlist: only credential_issuer and oauth-authorization-server are
+		// valid beyond this point. An unknown resource_type would silently
+		// fall through to credential-issuer resolution, creating a
+		// policy-bypass surface if SPOCP rules are permissive.
+		//
+		// oauth-authorization-server was added below (the switch case calling
+		// resolveAuthorizationServerMetadata) without updating this allowlist,
+		// making that case dead code - every oauth-authorization-server
+		// request 400ed here first. Confirmed live: OpenID4VCIHelper's
+		// getAuthorizationServerMetadata (used to decide whether to PAR a
+		// credential-issuance flow) always got this 400, so
+		// pushed_authorization_request_endpoint was never seen even when the
+		// issuer's real discovery document advertised one and required PAR -
+		// the wallet fell back to an un-PARed authorize redirect instead.
+		if resourceType != "credential_issuer" && resourceType != "oauth-authorization-server" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("unsupported resource_type for URL subjects: %s", resourceType)})
 			return
 		}

--- a/internal/api/authzen_proxy_test.go
+++ b/internal/api/authzen_proxy_test.go
@@ -1156,6 +1156,74 @@ func TestResolve_UnknownResourceTypeURL_Rejected(t *testing.T) {
 	}
 }
 
+// Regression test: resource_type="oauth-authorization-server" must actually
+// reach resolveAuthorizationServerMetadata, not get rejected by the
+// allowlist above it. Before the fix, this always 400ed, so
+// OpenID4VCIHelper.getAuthorizationServerMetadata (used by wallet-frontend
+// to decide whether to PAR a credential-issuance flow) could never see a
+// real issuer's pushed_authorization_request_endpoint - the wallet fell
+// back to an un-PARed authorize redirect even against a PAR-only AS.
+func TestResolve_URLSubject_OAuthAuthorizationServer_Success(t *testing.T) {
+	asServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			t.Errorf("unexpected well-known path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                                "https://as.example.com",
+			"token_endpoint":                        "https://as.example.com/token",
+			"pushed_authorization_request_endpoint": "https://as.example.com/par",
+			"require_pushed_authorization_requests": true,
+		})
+	}))
+	defer asServer.Close()
+
+	cfg := &config.AuthZENProxyConfig{
+		Enabled:         true,
+		Timeout:         30,
+		AllowResolution: true,
+	}
+	logger := zap.NewNop()
+	resolver := &mockMetadataResolver{
+		result: &issuermetadata.ResolveResult{Metadata: map[string]interface{}{}},
+	}
+	handler := NewAuthZENProxyHandler(cfg, &mockAuthorizer{allowAll: true}, nil, nil, resolver, asServer.Client(), asServer.Client(), logger)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "test-tenant")
+		c.Next()
+	})
+	router.POST("/v1/resolve", handler.Resolve)
+
+	body, _ := json.Marshal(map[string]string{
+		"subject_id":    asServer.URL,
+		"subject_type":  "url",
+		"resource_type": "oauth-authorization-server",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Context struct {
+			TrustMetadata map[string]interface{} `json:"trust_metadata"`
+		} `json:"context"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v: %s", err, w.Body.String())
+	}
+	if resp.Context.TrustMetadata["pushed_authorization_request_endpoint"] != "https://as.example.com/par" {
+		t.Errorf("expected pushed_authorization_request_endpoint in trust_metadata, got: %v", resp.Context.TrustMetadata)
+	}
+}
+
 // ============================================================================
 // Helper Function Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- `AuthZENProxyHandler.Resolve`'s URL-subject allowlist rejected any `resource_type` other than `credential_issuer` with a 400 - before ever reaching the `switch` statement immediately below it that explicitly handles `resource_type=oauth-authorization-server` via `resolveAuthorizationServerMetadata`. That `switch` case has been dead code since it was added (in the AS feature branch, #229) without the allowlist above it being updated to match.
- Confirmed live against a real deployment: `OpenID4VCIHelper.getAuthorizationServerMetadata` (wallet-frontend's own helper for deciding whether a credential-issuance flow must use PAR) always got this 400, for every issuer - so `pushed_authorization_request_endpoint` was never visible to the wallet even when an issuer's real discovery document advertised one and mandated it (`require_pushed_authorization_requests: true`). The wallet fell back to a bare, un-PARed `/authorize` redirect, which the issuer then correctly rejected with `request_uri required`.
- Fix: extend the allowlist to include `oauth-authorization-server`.

## Test plan
- [x] New regression test exercising the actual success path: a real `oauth-authorization-server` well-known fetch via `httptest.NewTLSServer` (not just the mocked `credential_issuer` resolver, which wouldn't have exercised this code path at all) - fails without the fix, passes with it
- [x] Verified the existing `TestResolve_UnknownResourceTypeURL_Rejected` (uses a made-up type name, not `oauth-authorization-server`) still passes - the allowlist still correctly rejects genuinely unknown types
- [x] `go build ./...`, `go vet ./...`, `go test ./internal/api/...`, `golangci-lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeEupvuqtP2XX2G1Wnnt3i