### PR TITLE
feat(wia): align WIA/KA with EC TS03 v1.5.2 and ETSI TS 119 472-3, add ietf/etsi mode split

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,6 +13,7 @@ Environment variables use the prefix `WALLET_` for the main backend and `REGISTR
 - [storage](#storage)
 - [logging](#logging)
 - [jwt](#jwt)
+- [as](#as)
 - [wallet_provider](#wallet_provider)
 - [trust](#trust)
 - [session_store](#session_store)
@@ -20,6 +21,7 @@ Environment variables use the prefix `WALLET_` for the main backend and `REGISTR
 - [security](#security)
 - [http_client](#http_client)
 - [authzen_proxy](#authzen_proxy)
+- [audit](#audit)
 - [Registry Server](#registry-server)
 - [registry.server](#registryserver)
 - [registry.source](#registrysource)
@@ -49,6 +51,8 @@ Environment prefix: `WALLET_SERVER`
 | `server.engine_port` | `WALLET_SERVER_ENGINE_PORT` | integer | WebSocket engine port (defaults to Port if 0) |
 | `server.registry_host` | `WALLET_SERVER_REGISTRY_HOST` | string | Registry bind address (defaults to Host) |
 | `server.registry_port` | `WALLET_SERVER_REGISTRY_PORT` | integer | VCTM registry port (defaults to 8097) |
+| `server.wp_host` | `WALLET_SERVER_WP_HOST` | string | Wallet-provider bind address (defaults to Host) |
+| `server.wp_port` | `WALLET_SERVER_WP_PORT` | integer | Wallet-provider port (0 = co-hosted with backend) |
 | `server.admin_token` | `WALLET_SERVER_ADMIN_TOKEN` | string | Bearer token for admin API (auto-generated if empty) |
 | `server.admin_token_path` | `WALLET_SERVER_ADMIN_TOKEN_PATH` | string | Path to file containing admin token |
 | `server.rp_id` | `WALLET_SERVER_RP_ID` | string |  |
@@ -114,6 +118,28 @@ Environment prefix: `WALLET_JWT`
 | `jwt.refresh_days` | `WALLET_JWT_REFRESH_DAYS` | integer |  |
 | `jwt.issuer` | `WALLET_JWT_ISSUER` | string |  |
 
+## as
+
+Environment prefix: `WALLET_AS`
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `as.enabled` | `WALLET_AS_ENABLED` | boolean | Enabled controls whether the new AS is active. |
+| `as.signing_key_path` | `WALLET_AS_SIGNING_KEY_PATH` | string | SigningKeyPath is the path to a PEM-encoded private key (ECDSA P-256, P-384, or Ed25519) used to sign access tokens. Mutually exclusive with SigningKeyPKCS11. |
+| `as.signing_key_pkcs11` | `WALLET_AS_SIGNING_KEY_PKCS11` | string | SigningKeyPKCS11 is a PKCS#11 URI for HSM-backed signing. Mutually exclusive with SigningKeyPath. |
+| `as.issuer` | `WALLET_AS_ISSUER` | string | Issuer is the value of the "iss" claim in issued access tokens. Defaults to JWT.Issuer if not set. |
+| `as.default_token_ttl` | `WALLET_AS_DEFAULT_TOKEN_TTL` | duration | DefaultTokenTTL is the default access token lifetime. Default: 2m |
+| `as.audience_ttls` | `WALLET_AS_AUDIENCE_TTLS` | map[string]time.Duration | AudienceTTLs allows per-audience TTL overrides. Keys are audience strings, values are durations. |
+| `as.audiences` | `WALLET_AS_AUDIENCES` | string list | Audiences lists the accepted audience values for token validation. Tokens must contain at least one of these in their "aud" claim. When empty, audience validation is skipped. Documented values: "wallet-backend", "wallet-engine", "wallet-registry". |
+| `as.rules_dir` | `WALLET_AS_RULES_DIR` | string | RulesDir is the path to a directory containing SPOCP policy rule files. |
+| `as.session_ttl` | `WALLET_AS_SESSION_TTL` | duration | SessionTTL is the maximum session lifetime before re-authentication. Default: 24h |
+| `as.default_max_tac` | `WALLET_AS_DEFAULT_MAX_TAC` | string | DefaultMaxTAC is the default maximum TAC for sessions created via passkey auth. Admin sessions (e.g. via OIDC) may get a different MaxTAC per policy. Default: "rwl" (read, write, list) |
+| `as.legacy.enabled` | `WALLET_AS_LEGACY_ENABLED` | boolean | Enabled controls whether legacy HMAC tokens are accepted. Default: true (for backward compatibility) |
+| `as.legacy.deprecation_header` | `WALLET_AS_LEGACY_DEPRECATION_HEADER` | boolean | DeprecationHeader controls whether Deprecation + Sunset headers are sent on legacy token responses. |
+| `as.legacy.sunset_date` | `WALLET_AS_LEGACY_SUNSET_DATE` | string | SunsetDate is the date after which legacy tokens will no longer be supported. Used in the Sunset HTTP header. Format: RFC 3339 date (e.g. "2027-10-01T00:00:00Z"). |
+| `as.external_url` | `WALLET_AS_EXTERNAL_URL` | string | ExternalURL is the public-facing base URL of the AS (e.g. "https://wallet.example.com"). Used to construct OIDC redirect URIs. Required when OIDC is used. |
+| `as.insecure_cookies` | `WALLET_AS_INSECURE_COOKIES` | boolean | InsecureCookies disables the __Host- prefix and Secure flag on session cookies. Required for local development over HTTP. NEVER enable in production. |
+
 ## wallet_provider
 
 Environment prefix: `WALLET_WALLET_PROVIDER`
@@ -123,6 +149,36 @@ Environment prefix: `WALLET_WALLET_PROVIDER`
 | `wallet_provider.private_key_path` | `WALLET_WALLET_PROVIDER_PRIVATE_KEY_PATH` | string |  |
 | `wallet_provider.certificate_path` | `WALLET_WALLET_PROVIDER_CERTIFICATE_PATH` | string |  |
 | `wallet_provider.ca_cert_path` | `WALLET_WALLET_PROVIDER_CA_CERT_PATH` | string |  |
+| `wallet_provider.pkcs11.module_path` | `WALLET_WALLET_PROVIDER_PKCS11_MODULE_PATH` | string |  |
+| `wallet_provider.pkcs11.slot_id` | `WALLET_WALLET_PROVIDER_PKCS11_SLOT_ID` | uint |  |
+| `wallet_provider.pkcs11.pin` | `WALLET_WALLET_PROVIDER_PKCS11_PIN` | string |  |
+| `wallet_provider.pkcs11.pin_path` | `WALLET_WALLET_PROVIDER_PKCS11_PIN_PATH` | string | Path to file containing PIN (preferred over inline PIN) |
+| `wallet_provider.pkcs11.key_label` | `WALLET_WALLET_PROVIDER_PKCS11_KEY_LABEL` | string |  |
+| `wallet_provider.pkcs11.pool_size` | `WALLET_WALLET_PROVIDER_PKCS11_POOL_SIZE` | integer | Session pool size (default 4) |
+| `wallet_provider.wia.enabled` | `WALLET_WALLET_PROVIDER_WIA_ENABLED` | boolean | Enabled controls whether WIA endpoints are registered |
+| `wallet_provider.wia.issuer` | `WALLET_WALLET_PROVIDER_WIA_ISSUER` | string | Issuer is the `iss` claim in WIA JWTs. Required when Mode is "ietf" (it's the only way a relying party can locate the JWKS to verify the WIA); unused/omitted when Mode is "etsi". |
+| `wallet_provider.wia.mode` | `WALLET_WALLET_PROVIDER_WIA_MODE` | string | Mode selects which WIA trust model this wallet provider issues:    - "etsi" (default): the EUDI ARF v3.0 / EC TS03 v1.5.2 / ETSI TS 119     472-3 V1.1.1 model. The WIA always carries the signing certificate     chain in the `x5c` JOSE header; relying parties verify it against     the Trusted List for Wallet Providers (ETSI TS 119 472-3     AUTH-REQ-PROC-4.4.3-01 / TOKEN-REQ-PROC-4.5.2-01). No `iss` or     `kid` is set — TS03 v1.5 explicitly removed `iss` from the WIA;     Wallet Provider identity is inferred solely from the x5c signing     certificate. This is the only mode with a defined trust path under     the current EUDI/ARF/ETSI specs; use it when interoperating with     ARF-conformant PID/EAA Providers.    - "ietf": the generic IETF draft-ietf-oauth-attestation-based-client-auth     model, with no ARF/ETSI counterpart. The WIA omits `x5c` and     instead carries a `kid` header plus the `iss` claim (required);     relying parties resolve trust via JWKS discovery at     "<issuer>/.well-known/jwks.json" (see     RegisterWalletProviderJWKSRoute). Only meaningful for non-EUDI,     generic-OAuth ecosystems — an ARF-conformant PID/EAA Provider has     no spec-defined way to resolve trust via this path.  Note SUNET/vc's parseAttestationIdentity treats x5c as authoritative and `iss` as a secondary consistency check only when both are present, so "etsi" mode (no iss) and "ietf" mode (no x5c) are both unambiguous to that consumer. |
+| `wallet_provider.wia.wallet_provider_uri` | `WALLET_WALLET_PROVIDER_WIA_WALLET_PROVIDER_URI` | string | WalletProviderURI is the expected `aud` in WIA-PoP JWTs (wallet provider identifier) |
+| `wallet_provider.wia.wallet_name` | `WALLET_WALLET_PROVIDER_WIA_WALLET_NAME` | string | WalletName is the wallet_name claim in WIA JWT. REQUIRED by EC TS03 v1.5.2 §2.3.1 when Mode is "etsi" — Validate() enforces this (defaults to "SIROS ID" so it's populated out of the box). |
+| `wallet_provider.wia.wallet_version` | `WALLET_WALLET_PROVIDER_WIA_WALLET_VERSION` | string | WalletVersion is the wallet_version claim. REQUIRED by EC TS03 v1.5.2 §2.3.1 ("Added `wallet_version` (REQUIRED) to the WIA") when Mode is "etsi" — Validate() enforces this; there is no sensible built-in default (it must reflect this deployment's actual released version). |
+| `wallet_provider.wia.wallet_link` | `WALLET_WALLET_PROVIDER_WIA_WALLET_LINK` | string | WalletLink is the wallet download/info URI. SHOULD per TS03 §2.3.1; not enforced by Validate(). |
+| `wallet_provider.wia.certification_info` | `WALLET_WALLET_PROVIDER_WIA_CERTIFICATIONINFO` | map[string]interface{} | CertificationInfo is the wallet_solution_certification_information claim. Free-form map included as-is in the WIA JWT. SHALL-required by TS03 §2.3.1 when Mode is "etsi", but TS03 itself notes the certification scheme is not yet finalized ("the exact content of wallet_solution_certification_information is undefined") — Validate() only warns (via the WIA service logger at startup) rather than hard failing, unlike WalletVersion. |
+| `wallet_provider.wia.max_expiry_seconds` | `WALLET_WALLET_PROVIDER_WIA_MAX_EXPIRY_SECONDS` | integer | MaxExpirySeconds is the maximum WIA lifetime in seconds (CS-04 requires < 24h) |
+| `wallet_provider.wia.challenge_ttl_seconds` | `WALLET_WALLET_PROVIDER_WIA_CHALLENGE_TTL_SECONDS` | integer | ChallengeTTLSeconds is the lifetime of WIA challenge nonces in seconds |
+| `wallet_provider.wia.rate_limit.enabled` | `WALLET_WALLET_PROVIDER_WIA_RATE_LIMIT_ENABLED` | boolean | Enabled controls whether rate limiting is active |
+| `wallet_provider.wia.rate_limit.max_attempts` | `WALLET_WALLET_PROVIDER_WIA_RATE_LIMIT_MAX_ATTEMPTS` | integer | MaxAttempts is the maximum number of login/registration attempts per window Default: 10 |
+| `wallet_provider.wia.rate_limit.window_seconds` | `WALLET_WALLET_PROVIDER_WIA_RATE_LIMIT_WINDOW_SECONDS` | integer | WindowSeconds is the time window for rate limiting (in seconds) Default: 60 (1 minute) |
+| `wallet_provider.wia.rate_limit.lockout_seconds` | `WALLET_WALLET_PROVIDER_WIA_RATE_LIMIT_LOCKOUT_SECONDS` | integer | LockoutSeconds is how long to lock out after exceeding the limit Default: 300 (5 minutes) |
+| `wallet_provider.attestation.lifetime_seconds` | `WALLET_WALLET_PROVIDER_ATTESTATION_LIFETIME_SECONDS` | integer | LifetimeSeconds is the WIA lifetime. TS03 v1.5.2 caps this at < 24h (86400); this wallet provider defaults far below that (300s / 5 min) specifically so that WIA lifetime — not revocation-list checking — is the mechanism that bounds exposure from a compromised/revoked wallet instance. See the type-level comment above. |
+| `wallet_provider.attestation.ka_expiry_seconds` | `WALLET_WALLET_PROVIDER_ATTESTATION_KA_EXPIRY_SECONDS` | integer | KAExpirySeconds is the key attestation JWT expiry. Short-lived by default (15s) for single-use credential issuance. |
+| `wallet_provider.attestation.native_attestation.enabled` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_ENABLED` | boolean | Enabled controls whether native platform attestation is required. |
+| `wallet_provider.attestation.native_attestation.apple_app_attest_environment` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_APPLE_APP_ATTEST_ENVIRONMENT` | string | AppleAppAttestEnvironment: "production" or "development" |
+| `wallet_provider.attestation.native_attestation.apple_app_id` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_APPLE_APP_ID` | string | AppleAppID is the full App ID (TeamID.BundleID) for Apple App Attest. |
+| `wallet_provider.attestation.native_attestation.google_package_name` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PACKAGE_NAME` | string | GooglePackageName is the Android package name for Play Integrity. |
+| `wallet_provider.attestation.native_attestation.google_play_integrity_decryption_key` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PLAY_INTEGRITY_DECRYPTION_KEY` | string | GooglePlayIntegrityDecryptionKey is the base64-encoded decryption key. Prefer GooglePlayIntegrityDecryptionKeyPath for production deployments. |
+| `wallet_provider.attestation.native_attestation.google_play_integrity_decryption_key_path` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PLAY_INTEGRITY_DECRYPTION_KEY_PATH` | string | GooglePlayIntegrityDecryptionKeyPath is a path to a file containing the decryption key (preferred over the inline value — same pattern as PKCS11.PINPath / JWT.SecretPath, so this AES key material can be mounted from a secret store instead of living in plain env vars/YAML). |
+| `wallet_provider.attestation.native_attestation.google_play_integrity_verification_key` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PLAY_INTEGRITY_VERIFICATION_KEY` | string | GooglePlayIntegrityVerificationKey is the base64-encoded verification key. Prefer GooglePlayIntegrityVerificationKeyPath for production deployments. |
+| `wallet_provider.attestation.native_attestation.google_play_integrity_verification_key_path` | `WALLET_WALLET_PROVIDER_ATTESTATION_NATIVE_ATTESTATION_GOOGLE_PLAY_INTEGRITY_VERIFICATION_KEY_PATH` | string | GooglePlayIntegrityVerificationKeyPath is a path to a file containing the verification key (preferred over the inline value). |
 
 ## trust
 
@@ -206,6 +262,17 @@ Environment prefix: `WALLET_AUTHZEN_PROXY`
 | `authzen_proxy.allow_resolution` | `WALLET_AUTHZEN_PROXY_ALLOW_RESOLUTION` | boolean | AllowResolution controls whether resolution-only requests are allowed. Resolution requests fetch metadata (DID documents, entity configs) without key validation. Default: true |
 | `authzen_proxy.fail_open_on_tenant_lookup_error` | `WALLET_AUTHZEN_PROXY_FAIL_OPEN_ON_TENANT_LOOKUP_ERROR` | boolean | FailOpenOnTenantLookupError controls behavior when per-tenant PDP lookup fails. If false (default), tenant lookup errors return an error to the client. If true, falls back to the global PDP URL on lookup errors. Security note: fail-closed (false) prevents bypassing per-tenant security policies. |
 
+## audit
+
+Environment prefix: `WALLET_AUDIT`
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `audit.enabled` | `WALLET_AUDIT_ENABLED` | boolean | Enabled enables SET audit event emission. |
+| `audit.issuer` | `WALLET_AUDIT_ISSUER` | string | Issuer is the iss claim in SET records (e.g. "https://wallet.siros.org"). |
+| `audit.key_path` | `WALLET_AUDIT_KEY_PATH` | string | KeyPath is the path to a PEM-encoded EC private key for signing SET records. |
+| `audit.key_id` | `WALLET_AUDIT_KEY_ID` | string | KeyID is the kid used in SET JWS headers. |
+
 ## Registry Server
 
 The registry server (`cmd/registry`) has its own configuration file. It serves VCTM (Verifiable Credential Type Metadata) fetched from upstream registries.
@@ -237,7 +304,8 @@ Environment prefix: `REGISTRY_SOURCE`
 
 | YAML Key | Env Variable | Type | Description |
 |----------|-------------|------|-------------|
-| `source.url` | `REGISTRY_SOURCE_URL` | string | URL of the upstream registry index. Supports both the legacy vctm-registry.json format and the TS11-compliant /api/v1/schemas.json endpoint – the format is auto-detected from the response. |
+| `source.url` | `REGISTRY_SOURCE_URL` | string | URL of the upstream registry. The actual endpoint is determined by the Mode setting. |
+| `source.mode` | `REGISTRY_SOURCE_MODE` | string (`ts11` or `registry`) | Mode selects which API endpoint to use: "ts11" (default) or "registry" (all credentials). |
 | `source.local_overrides` | `REGISTRY_SOURCE_LOCAL_OVERRIDES` | string list | LocalOverrides is a list of local file or directory paths containing VCTM JSON files. These are loaded at startup and take priority over entries fetched from the remote registry. Directories are scanned for *.json files. Entries are keyed by their "vct" field. |
 | `source.poll_interval` | `REGISTRY_SOURCE_POLL_INTERVAL` | duration | PollInterval is how often to poll the upstream registry for updates |
 | `source.timeout` | `REGISTRY_SOURCE_TIMEOUT` | duration | Timeout for HTTP requests to the upstream registry |
@@ -250,7 +318,8 @@ Environment prefix: `REGISTRY_SOURCES`
 
 | YAML Key | Env Variable | Type | Description |
 |----------|-------------|------|-------------|
-| `sources[*].url` | `REGISTRY_SOURCES_URL` | string | URL of the upstream registry index. Supports both the legacy vctm-registry.json format and the TS11-compliant /api/v1/schemas.json endpoint – the format is auto-detected from the response. |
+| `sources[*].url` | `REGISTRY_SOURCES_URL` | string | URL is the base URL of the registry (e.g. "https://registry.siros.org"). The actual endpoint path is determined by the Mode setting. For backward compatibility, if a full path to a specific endpoint is given (e.g. ending in schemas.json or registry.json), it is used as-is regardless of Mode. |
+| `sources[*].mode` | `REGISTRY_SOURCES_MODE` | string (`ts11` or `registry`) | Mode selects which API endpoint to use: "ts11" (default) for only TS11-compliant credentials, or "registry" for all credentials including non-TS11. |
 | `sources[*].timeout` | `REGISTRY_SOURCES_TIMEOUT` | duration | Timeout for HTTP requests to this source. Zero means no per-source timeout (the shared http.Client timeout applies). |
 
 ## registry.cache
@@ -325,6 +394,7 @@ Environment prefix: `REGISTRY_JWT`
 | YAML Key | Env Variable | Type | Description |
 |----------|-------------|------|-------------|
 | `jwt.secret` | `REGISTRY_JWT_SECRET` | string | Secret is the shared secret for validating JWT signatures (HMAC) |
+| `jwt.secret_path` | `REGISTRY_JWT_SECRET_PATH` | string | SecretPath is an alternative to Secret: path to a file containing the JWT secret. If both Secret and SecretPath are set, SecretPath takes precedence. |
 | `jwt.issuer` | `REGISTRY_JWT_ISSUER` | string | Issuer is the expected issuer claim in the JWT |
 | `jwt.require_auth` | `REGISTRY_JWT_REQUIRE_AUTH` | boolean | RequireAuth requires authentication for all requests (if false, unauthenticated access is allowed) |
 

--- a/docs/wallet-instance-attestation.md
+++ b/docs/wallet-instance-attestation.md
@@ -11,7 +11,7 @@ See `docs/CONFIGURATION.md`'s `wallet_provider.wia.*` section for the full field
 | `POST /wallet-provider/wia/challenge` | Issues a single-use nonce. The caller signs it into a PoP JWT to prove possession of the attestation key before a WIA is issued for it. |
 | `POST /wallet-provider/wia/generate` | Verifies the challenge PoP, then issues a WIA (`wallet_instance_attestation`) bound to the caller's key. |
 | `GET /.well-known/jwks.json` | Serves the wallet provider's own signing public key (`RegisterWalletProviderJWKSRoute`, `internal/service/wallet_provider_jwks.go`). Only registered when a wallet-provider signing key is configured. |
-| `GET /.well-known/oauth-authorization-server` | RFC 8414 metadata pointing at the JWKS above (`issuer` + `jwks_uri`). Only registered in `ietf` mode (see below) with `wallet_provider.wia.issuer` (or `wallet_provider_uri` as fallback) set. |
+| `GET /.well-known/oauth-authorization-server` | RFC 8414 metadata pointing at the JWKS above (`issuer` + `jwks_uri`). Only registered in `ietf` mode (see below) with `wallet_provider.wia.issuer` explicitly set - no fallback to `wallet_provider_uri` (see below). |
 | `GET /wallet-provider/status-list` | Always-empty (never revoked) Token Status List, for interop completeness only — no WIA/KA this wallet provider issues actually references it (`RegisterWalletProviderStatusListRoute`, `internal/service/wallet_provider_statuslist.go`). |
 
 ## Two identity formats: x5c vs. `iss`-based

--- a/internal/api/wia_handlers_test.go
+++ b/internal/api/wia_handlers_test.go
@@ -48,7 +48,6 @@ func setupWIATestHandlers(t *testing.T, wiaEnabled bool) (*Handlers, *gin.Engine
 	}
 	cfg.WalletProvider.Attestation = config.AttestationConfig{
 		LifetimeSeconds: 3600,
-		StatusListMode:  "never",
 	}
 
 	store := memory.NewStore()

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -519,6 +519,16 @@ func (p *BackendProvider) RegisterRoutes(router *gin.Engine) {
 		p.asModule.RegisterRoutes(authGroup)
 	}
 
+	// Register the wallet provider's own JWKS (distinct from the AS's),
+	// for relying parties resolving trust via an iss-based WIA. No-ops if
+	// WIA/the wallet provider signing key isn't configured.
+	service.RegisterWalletProviderJWKSRoute(router, p.Services().WalletProvider)
+
+	// Register an always-empty status list for interop completeness only —
+	// see RegisterWalletProviderStatusListRoute's doc comment. No WIA/KA
+	// this wallet provider issues references it.
+	service.RegisterWalletProviderStatusListRoute(router, p.Services().WalletProvider)
+
 	// Register AuthZEN proxy routes if enabled
 	if p.authzenHandler != nil {
 		protected := router.Group("/")
@@ -825,7 +835,12 @@ func NewWalletProviderProvider(cfg *config.Config, logger *zap.Logger) (*WalletP
 	}
 
 	services := service.NewServices(store, cfg, logger)
-	if services.WalletProvider == nil || !services.WalletProvider.IsSupported() {
+	// HasSigningKey (not IsSupported): a cert-less signing key is a valid
+	// standalone deployment when only "ietf"-mode WIA is needed. Key
+	// Attestation generation (registered unconditionally below) still
+	// individually gates on IsSupported() and fails gracefully per-request
+	// if no certificate is configured.
+	if services.WalletProvider == nil || !services.WalletProvider.HasSigningKey() {
 		return nil, fmt.Errorf("wallet-provider signing keys not configured or not supported")
 	}
 	services.Start()

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -67,6 +67,16 @@ func NewServices(store storage.Store, cfg *config.Config, logger *zap.Logger) *S
 		// audited whenever cfg.Audit is enabled, consistent with admin-API auditing.
 		wiaAuditor := audit.NewFromConfig(cfg, logger)
 		wiaSvc = NewWIAService(cfg, logger, wpSvc.jwtSigner, wpSvc.certChain, store.WalletInstances(), wiaAuditor, challengeStore)
+		// A signing key alone is enough to construct WIAService, but "etsi"
+		// mode additionally requires a certificate chain (see IsSupported).
+		// Leaving wiaSvc non-nil here would register the WIA routes, but
+		// every actual call would fail with ErrWIANotSupported, which the
+		// handlers map to a generic 500 rather than the clean 503
+		// WIA_NOT_SUPPORTED they already return for services.WIA == nil -
+		// nil it out here so that existing check covers this case too.
+		if !wiaSvc.IsSupported() {
+			wiaSvc = nil
+		}
 	}
 
 	return &Services{

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -43,9 +43,13 @@ func NewServices(store storage.Store, cfg *config.Config, logger *zap.Logger) *S
 
 	wpSvc := NewWalletProviderService(cfg, logger, store.WalletInstances())
 
-	// WIA shares the same signing key as the wallet provider
+	// WIA shares the same signing key as the wallet provider. Uses
+	// HasSigningKey (not IsSupported) because "ietf"-mode WIA only needs a
+	// signing key, not a certificate — IsSupported additionally requires a
+	// certificate chain, which is only mandatory for Key Attestation and
+	// "etsi"-mode WIA.
 	var wiaSvc *WIAService
-	if cfg.WalletProvider.WIA.Enabled && wpSvc.IsSupported() {
+	if cfg.WalletProvider.WIA.Enabled && wpSvc.HasSigningKey() {
 		var challengeStore WIAChallengeStore
 		// Use MongoDB-backed challenge store if the underlying storage is MongoDB.
 		type databaseProvider interface {

--- a/internal/service/services_test.go
+++ b/internal/service/services_test.go
@@ -199,3 +199,50 @@ func TestNewServices_WiresAuditEmitterIntoWIA(t *testing.T) {
 		t.Error("expected WIA service to receive a real audit emitter when cfg.Audit.Enabled is true")
 	}
 }
+
+// TestNewServices_WIANilWhenSigningKeyButNoCertInETSIMode is a regression
+// test: a signing key alone is enough to construct WIAService (HasSigningKey
+// gates construction, for "ietf" mode's sake), but "etsi" mode (the default)
+// additionally requires a certificate chain (WIAService.IsSupported). Without
+// this, services.WIA would be non-nil but permanently unsupported, so every
+// WIA route would 500 (ErrWIANotSupported falls through to the handlers'
+// generic error case) instead of the clean 503 WIA_NOT_SUPPORTED they already
+// return when services.WIA == nil.
+func TestNewServices_WIANilWhenSigningKeyButNoCertInETSIMode(t *testing.T) {
+	dir := t.TempDir()
+	wpKeyPath, _ := writeECKeyAndCert(t, dir, "wallet-provider")
+
+	store := memory.NewStore()
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Host:     "localhost",
+			Port:     8080,
+			RPID:     "localhost",
+			RPOrigin: "http://localhost:8080",
+			RPName:   "Test Wallet",
+		},
+		JWT: config.JWTConfig{
+			Secret:      "test-secret-that-is-at-least-32-bytes-long",
+			ExpiryHours: 24,
+			Issuer:      "test-wallet",
+		},
+	}
+	cfg.WalletProvider.PrivateKeyPath = wpKeyPath
+	// CertificatePath deliberately left unset - etsi mode (the zero-value
+	// default) requires it; ietf mode wouldn't.
+	cfg.WalletProvider.WIA = config.WIAConfig{
+		Enabled:             true,
+		MaxExpirySeconds:    86400,
+		ChallengeTTLSeconds: 300,
+	}
+	cfg.WalletProvider.Attestation = config.AttestationConfig{
+		LifetimeSeconds: 3600,
+	}
+
+	logger := zap.NewNop()
+	services := NewServices(store, cfg, logger)
+
+	if services.WIA != nil {
+		t.Error("expected WIA service to be nil when unsupported (etsi mode, signing key but no certificate)")
+	}
+}

--- a/internal/service/services_test.go
+++ b/internal/service/services_test.go
@@ -187,7 +187,6 @@ func TestNewServices_WiresAuditEmitterIntoWIA(t *testing.T) {
 	}
 	cfg.WalletProvider.Attestation = config.AttestationConfig{
 		LifetimeSeconds: 3600,
-		StatusListMode:  "never",
 	}
 
 	logger := zap.NewNop()

--- a/internal/service/wallet_provider.go
+++ b/internal/service/wallet_provider.go
@@ -233,13 +233,15 @@ func (s *WalletProviderService) PublicKey() crypto.PublicKey {
 // Issuer returns the value used as the WIA's iss claim (see WIAService's
 // GenerateWIA), so relying parties' RFC 8414 metadata discovery
 // (RegisterWalletProviderJWKSRoute) advertises the exact issuer the WIA
-// itself claims.
+// itself claims. No WalletProviderURI fallback: config.Validate() requires
+// WIA.Issuer to be explicitly set whenever Mode is "ietf" (the only mode
+// that calls this), so falling back here would only mask a config that
+// bypassed Validate() (e.g. constructed directly in tests) - and
+// WalletProviderURI is a different identifier for a different purpose (the
+// WIA-PoP's expected aud, not this wallet provider's own issuer identity;
+// see docs/wallet-instance-attestation.md).
 func (s *WalletProviderService) Issuer() string {
-	issuer := s.cfg.WalletProvider.WIA.Issuer
-	if issuer == "" {
-		issuer = s.cfg.WalletProvider.WIA.WalletProviderURI
-	}
-	return issuer
+	return s.cfg.WalletProvider.WIA.Issuer
 }
 
 // Close releases resources held by the service.

--- a/internal/service/wallet_provider.go
+++ b/internal/service/wallet_provider.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -28,31 +25,6 @@ import (
 var (
 	ErrKeyAttestationNotSupported = errors.New("key attestation not supported")
 )
-
-// statusIndexCounter is a process-scoped monotonic counter for status list indices.
-// Each attestation (WIA or KA) gets a unique index. In a multi-instance deployment,
-// uniqueness across instances is achieved by seeding each process with a random
-// starting offset (see init() below) rather than starting from zero — otherwise
-// every replica (and every restart of the same replica) would hand out colliding
-// indices on the same status_list URI once wallet_provider.attestation.status_list_mode
-// is "always".
-var statusIndexCounter atomic.Uint64
-
-func init() {
-	statusIndexCounter.Store(randomStatusIndexSeed())
-}
-
-// randomStatusIndexSeed returns a random 64-bit starting offset for
-// statusIndexCounter. Extracted for direct unit testing.
-func randomStatusIndexSeed() uint64 {
-	var seed [8]byte
-	if _, err := rand.Read(seed[:]); err != nil {
-		// Should never happen on any real platform; falling back to 0 is no
-		// worse than the counter's behavior before this fix.
-		return 0
-	}
-	return binary.BigEndian.Uint64(seed[:])
-}
 
 // MaxJWKSPerRequest is the hard upper bound on JWKs in a single KA request.
 // Prevents DoS via expensive JWT signing with excessively large arrays.
@@ -122,7 +94,7 @@ func NewWalletProviderService(cfg *config.Config, logger *zap.Logger, instances 
 			}
 		}
 	}
-	if !pkcs11Loaded && cfg.WalletProvider.PrivateKeyPath != "" && cfg.WalletProvider.CertificatePath != "" {
+	if !pkcs11Loaded && cfg.WalletProvider.PrivateKeyPath != "" {
 		if err := svc.loadKeys(); err != nil {
 			svc.logger.Warn("Failed to load wallet provider keys", zap.Error(err))
 		}
@@ -172,6 +144,18 @@ func (s *WalletProviderService) loadKeys() error {
 	}
 	s.jwtSigner = jwtSigner
 
+	// CertificatePath is optional: a signing key alone is enough for
+	// "ietf"-mode WIA issuance (JWKS-based trust, no x5c — see
+	// WIAConfig.Mode). Key Attestation (KA) and "etsi"-mode WIA always
+	// require x5c, which config.Validate() enforces by requiring a
+	// certificate whenever wallet_provider.wia.mode is "etsi"; without one,
+	// IsSupported() (KA) correctly reports unsupported and only WIAService's
+	// own ietf-mode IsSupported() can be true.
+	if s.cfg.WalletProvider.CertificatePath == "" {
+		s.logger.Info("Loaded wallet provider signing key (no certificate configured; x5c/KA unavailable)")
+		return nil
+	}
+
 	// Load certificate chain using proper PEM parsing
 	s.certChain, err = parsePEMCertChain(s.cfg.WalletProvider.CertificatePath)
 	if err != nil {
@@ -218,9 +202,43 @@ func parsePEMCertChain(path string) ([]string, error) {
 	return chain, nil
 }
 
-// IsSupported returns true if key attestation is supported
+// IsSupported returns true if Key Attestation (KA) generation is supported.
+// KA always requires x5c (there is no "ietf mode" for KA — see
+// GenerateKeyAttestation), so this deliberately requires a certificate chain,
+// unlike HasSigningKey.
 func (s *WalletProviderService) IsSupported() bool {
 	return s.jwtSigner != nil && len(s.certChain) > 0
+}
+
+// HasSigningKey returns true if a signing key (file or PKCS#11) is loaded,
+// regardless of whether a certificate/x5c chain is also configured. Used to
+// gate WIA-only ("ietf" mode) functionality, which doesn't need x5c — unlike
+// IsSupported, which additionally requires a certificate for KA.
+func (s *WalletProviderService) HasSigningKey() bool {
+	return s.jwtSigner != nil
+}
+
+// PublicKey returns the wallet provider's signing public key, or nil if no
+// signing key is configured. Used to serve the wallet provider's own JWKS
+// (see RegisterWalletProviderJWKSRoute) for relying parties resolving trust
+// via an iss-based (WIA.Mode == config.WIAModeIETF) attestation instead of
+// its x5c chain.
+func (s *WalletProviderService) PublicKey() crypto.PublicKey {
+	if s.signer == nil {
+		return nil
+	}
+	return s.signer.Public()
+}
+
+// Issuer returns the value used as the WIA's iss claim (see GenerateWIA),
+// so relying parties' RFC 8414 metadata discovery (RegisterWalletProviderJWKSRoute)
+// advertises the exact issuer the WIA itself claims.
+func (s *WalletProviderService) Issuer() string {
+	issuer := s.cfg.WalletProvider.WIA.Issuer
+	if issuer == "" {
+		issuer = s.cfg.WalletProvider.WIA.WalletProviderURI
+	}
+	return issuer
 }
 
 // Close releases resources held by the service.
@@ -271,12 +289,19 @@ func (s *WalletProviderService) GenerateKeyAttestation(ctx context.Context, jwks
 		kaExpiry = 15 * time.Second
 	}
 	claims := jwt.MapClaims{
-		"iss":           s.cfg.Server.BaseURL,
+		// No `iss`: EC TS03 v1.5.2 removed `iss` from the KA (as it did for
+		// the WIA) — Wallet Provider identity is inferred solely from the
+		// x5c signing certificate below.
 		"jti":           uuid.New().String(),
 		"attested_keys": attested,
-		"nonce":         nonce,
-		"iat":           now.Unix(),
-		"exp":           now.Add(kaExpiry).Unix(),
+		// c_nonce (not `nonce`): TS03 §2.3.2 requires a KA sent via the
+		// `attestation` proof type to carry `c_nonce`. When a KA is instead
+		// wrapped in the `jwt` proof type, the nonce belongs in the outer
+		// proof JWT's body (built client-side), not here — this claim is
+		// then unused by conformant verifiers but harmless to include.
+		"c_nonce": nonce,
+		"iat":     now.Unix(),
+		"exp":     now.Add(kaExpiry).Unix(),
 	}
 
 	// Bind KA to the wallet instance (CS-04 §7.1.3)
@@ -311,22 +336,9 @@ func (s *WalletProviderService) GenerateKeyAttestation(ctx context.Context, jwks
 		}
 	}
 
-	// key_storage_status: KA revocation via Token Status List (CS-04 §7.1.3)
-	if s.cfg.WalletProvider.Attestation.StatusListMode == "always" && s.cfg.WalletProvider.Attestation.StatusListURL != "" {
-		idx := statusIndexCounter.Add(1)
-		ksStatus := map[string]interface{}{
-			"status": map[string]interface{}{
-				"status_list": map[string]interface{}{
-					"uri": s.cfg.WalletProvider.Attestation.StatusListURL,
-					"idx": idx,
-				},
-			},
-		}
-		if s.cfg.WalletProvider.Attestation.StatusListExpiry > 0 {
-			ksStatus["exp"] = now.Add(time.Duration(s.cfg.WalletProvider.Attestation.StatusListExpiry) * time.Second).Unix()
-		}
-		claims["key_storage_status"] = ksStatus
-	}
+	// No `key_storage_status`: this wallet provider does not implement
+	// KA/WIA revocation-chaining. See AttestationConfig's type-level comment
+	// for the design rationale (short KA/WIA lifetime instead).
 
 	// Create the token with ES256 and x5c header
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)

--- a/internal/service/wallet_provider_jwks.go
+++ b/internal/service/wallet_provider_jwks.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-jose/go-jose/v4"
+)
+
+// RegisterWalletProviderJWKSRoute registers a bare-root /.well-known/jwks.json
+// endpoint serving the wallet provider's own signing public key, plus RFC
+// 8414 OAuth 2.0 Authorization Server Metadata at
+// /.well-known/oauth-authorization-server pointing to it via jwks_uri.
+// Distinct from the AS module's JWKS (mounted at /auth/.well-known/jwks.json,
+// a different key for a different purpose): relying parties that receive an
+// iss-based WIA (WalletProvider.WIA.Mode == config.WIAModeIETF) resolve
+// trust by discovering this metadata at the WIA's iss URL - the RFC 8414
+// document is what lets standards-compliant JWKS discovery chains (e.g.
+// SD-JWT VC §5.3 clients) find the key without any wallet-provider-specific
+// knowledge.
+//
+// No-ops (never registers the routes) when the wallet provider has no
+// signing key configured, so environments without WIA enabled see a plain
+// 404 rather than a route that always errors.
+func RegisterWalletProviderJWKSRoute(router gin.IRoutes, wp *WalletProviderService) {
+	if wp == nil {
+		return
+	}
+	pub := wp.PublicKey()
+	if pub == nil {
+		return
+	}
+	router.GET("/.well-known/jwks.json", func(c *gin.Context) {
+		jwk := jose.JSONWebKey{
+			Key:       pub,
+			KeyID:     "wallet-provider",
+			Algorithm: string(jose.ES256),
+			Use:       "sig",
+		}
+		c.Header("Cache-Control", "public, max-age=300")
+		c.JSON(http.StatusOK, jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
+	})
+
+	issuer := wp.Issuer()
+	if issuer == "" {
+		return
+	}
+	router.GET("/.well-known/oauth-authorization-server", func(c *gin.Context) {
+		c.Header("Cache-Control", "public, max-age=300")
+		c.JSON(http.StatusOK, gin.H{
+			"issuer":   issuer,
+			"jwks_uri": issuer + "/.well-known/jwks.json",
+		})
+	})
+}

--- a/internal/service/wallet_provider_jwks.go
+++ b/internal/service/wallet_provider_jwks.go
@@ -2,22 +2,30 @@ package service
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-jose/go-jose/v4"
+
+	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
 )
 
 // RegisterWalletProviderJWKSRoute registers a bare-root /.well-known/jwks.json
-// endpoint serving the wallet provider's own signing public key, plus RFC
-// 8414 OAuth 2.0 Authorization Server Metadata at
-// /.well-known/oauth-authorization-server pointing to it via jwks_uri.
-// Distinct from the AS module's JWKS (mounted at /auth/.well-known/jwks.json,
-// a different key for a different purpose): relying parties that receive an
-// iss-based WIA (WalletProvider.WIA.Mode == config.WIAModeIETF) resolve
-// trust by discovering this metadata at the WIA's iss URL - the RFC 8414
-// document is what lets standards-compliant JWKS discovery chains (e.g.
-// SD-JWT VC §5.3 clients) find the key without any wallet-provider-specific
-// knowledge.
+// endpoint serving the wallet provider's own signing public key, plus - only
+// in "ietf" mode (see below) - RFC 8414 OAuth 2.0 Authorization Server
+// Metadata at /.well-known/oauth-authorization-server pointing to it via
+// jwks_uri. Distinct from the AS module's JWKS (mounted at
+// /auth/.well-known/jwks.json, a different key for a different purpose):
+// relying parties that receive an iss-based WIA
+// (WalletProvider.WIA.Mode == config.WIAModeIETF) resolve trust by
+// discovering this metadata at the WIA's iss URL - the RFC 8414 document is
+// what lets standards-compliant JWKS discovery chains (e.g. SD-JWT VC §5.3
+// clients) find the key without any wallet-provider-specific knowledge.
+//
+// The bare JWKS itself is served regardless of mode (harmless key
+// publication), but the RFC 8414 metadata is gated on "ietf" mode: in "etsi"
+// mode the WIA has no iss (identity is x5c-only), so advertising a
+// jwks_uri-based discovery path would be actively misleading.
 //
 // No-ops (never registers the routes) when the wallet provider has no
 // signing key configured, so environments without WIA enabled see a plain
@@ -41,15 +49,30 @@ func RegisterWalletProviderJWKSRoute(router gin.IRoutes, wp *WalletProviderServi
 		c.JSON(http.StatusOK, jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
 	})
 
+	// The RFC 8414 metadata specifically advertises JWKS-based trust
+	// discovery via jwks_uri, which is only meaningful in "ietf" mode - in
+	// "etsi" mode the WIA intentionally has no iss (identity is x5c-only per
+	// EC TS03 v1.5.2), so publishing this metadata would advertise a
+	// discovery path relying parties have no reason to use and that doesn't
+	// match how this wallet provider's WIAs actually carry identity.
+	if wp.cfg.WalletProvider.WIA.Mode != config.WIAModeIETF {
+		return
+	}
 	issuer := wp.Issuer()
 	if issuer == "" {
 		return
 	}
 	router.GET("/.well-known/oauth-authorization-server", func(c *gin.Context) {
+		// jwks_uri is built from the issuer with any trailing slash trimmed,
+		// to avoid a double slash before "/.well-known/jwks.json" - the
+		// issuer claim itself stays byte-identical to the configured value,
+		// since relying parties (e.g. vc's JWKSKeyResolver) match it exactly
+		// against the WIA's own iss claim, which also uses the untrimmed
+		// configured value.
 		c.Header("Cache-Control", "public, max-age=300")
 		c.JSON(http.StatusOK, gin.H{
 			"issuer":   issuer,
-			"jwks_uri": issuer + "/.well-known/jwks.json",
+			"jwks_uri": strings.TrimSuffix(issuer, "/") + "/.well-known/jwks.json",
 		})
 	})
 }

--- a/internal/service/wallet_provider_jwks.go
+++ b/internal/service/wallet_provider_jwks.go
@@ -31,7 +31,7 @@ import (
 // signing key configured, so environments without WIA enabled see a plain
 // 404 rather than a route that always errors.
 func RegisterWalletProviderJWKSRoute(router gin.IRoutes, wp *WalletProviderService) {
-	if wp == nil {
+	if wp == nil || wp.cfg == nil {
 		return
 	}
 	pub := wp.PublicKey()

--- a/internal/service/wallet_provider_jwks_test.go
+++ b/internal/service/wallet_provider_jwks_test.go
@@ -1,0 +1,227 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-jose/go-jose/v4"
+
+	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+)
+
+func TestRegisterWalletProviderJWKSRoute_Success(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=300")
+	}
+
+	var jwks jose.JSONWebKeySet
+	if err := json.Unmarshal(w.Body.Bytes(), &jwks); err != nil {
+		t.Fatalf("unmarshal jwks: %v", err)
+	}
+	if len(jwks.Keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(jwks.Keys))
+	}
+	key := jwks.Keys[0]
+	if key.KeyID != "wallet-provider" {
+		t.Errorf("KeyID = %q, want %q", key.KeyID, "wallet-provider")
+	}
+	if key.Algorithm != string(jose.ES256) {
+		t.Errorf("Algorithm = %q, want %q", key.Algorithm, jose.ES256)
+	}
+	if key.Use != "sig" {
+		t.Errorf("Use = %q, want %q", key.Use, "sig")
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+	svc.cfg.WalletProvider.WIA.Mode = config.WIAModeIETF
+	svc.cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example.com"
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=300")
+	}
+
+	var meta struct {
+		Issuer  string `json:"issuer"`
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta.Issuer != "https://wallet-provider.example.com" {
+		t.Errorf("issuer = %q, want %q", meta.Issuer, "https://wallet-provider.example.com")
+	}
+	if want := meta.Issuer + "/.well-known/jwks.json"; meta.JWKSURI != want {
+		t.Errorf("jwks_uri = %q, want %q", meta.JWKSURI, want)
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_TrailingSlashIssuer(t *testing.T) {
+	// Regression test: a configured issuer with a trailing slash must not
+	// produce a double slash in jwks_uri ("https://host//.well-known/..."),
+	// which strict metadata consumers reject. The issuer field itself must
+	// stay byte-identical to the configured value though - relying parties
+	// (e.g. vc's JWKSKeyResolver) match it exactly against the WIA's own iss
+	// claim, which also uses the untrimmed configured value.
+	svc := newTestWalletProviderService(t)
+	svc.cfg.WalletProvider.WIA.Mode = config.WIAModeIETF
+	svc.cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example.com/"
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var meta struct {
+		Issuer  string `json:"issuer"`
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta.Issuer != "https://wallet-provider.example.com/" {
+		t.Errorf("issuer = %q, want byte-identical to configured value %q", meta.Issuer, "https://wallet-provider.example.com/")
+	}
+	if meta.JWKSURI != "https://wallet-provider.example.com/.well-known/jwks.json" {
+		t.Errorf("jwks_uri = %q, want no double slash", meta.JWKSURI)
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_FallsBackToWalletProviderURI(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+	svc.cfg.WalletProvider.WIA.Mode = config.WIAModeIETF
+	svc.cfg.WalletProvider.WIA.WalletProviderURI = "https://fallback.example.com"
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var meta struct {
+		Issuer string `json:"issuer"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta.Issuer != "https://fallback.example.com" {
+		t.Errorf("issuer = %q, want %q", meta.Issuer, "https://fallback.example.com")
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_NoOpWhenNoIssuerConfigured(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+	// Neither WIA.Issuer nor WIA.WalletProviderURI set.
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (route should not be registered)", w.Code, http.StatusNotFound)
+	}
+}
+
+// TestRegisterWalletProviderJWKSRoute_OAuthMetadata_NoOpInETSIMode is a
+// regression test for a review finding: publishing RFC 8414 metadata
+// whenever an issuer happened to be configured, regardless of WIA.Mode,
+// would advertise a jwks_uri-based discovery path even in "etsi" mode, where
+// the WIA has no iss at all (identity is x5c-only). The metadata route must
+// stay unregistered unless Mode is explicitly "ietf".
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_NoOpInETSIMode(t *testing.T) {
+	for _, mode := range []string{"", config.WIAModeETSI} {
+		svc := newTestWalletProviderService(t)
+		svc.cfg.WalletProvider.WIA.Mode = mode
+		svc.cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example.com"
+
+		gin.SetMode(gin.TestMode)
+		r := gin.New()
+		RegisterWalletProviderJWKSRoute(r, svc)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("mode=%q: status = %d, want %d (route must not be registered outside ietf mode)", mode, w.Code, http.StatusNotFound)
+		}
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_NoOpWhenNoSigningKey(t *testing.T) {
+	svc := &WalletProviderService{
+		cfg: &config.Config{},
+		// No signer configured.
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (route should not be registered)", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestRegisterWalletProviderJWKSRoute_NoOpWhenNilService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (route should not be registered)", w.Code, http.StatusNotFound)
+	}
+}

--- a/internal/service/wallet_provider_jwks_test.go
+++ b/internal/service/wallet_provider_jwks_test.go
@@ -122,10 +122,18 @@ func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_TrailingSlashIssuer(t *te
 	}
 }
 
-func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_FallsBackToWalletProviderURI(t *testing.T) {
+// TestRegisterWalletProviderJWKSRoute_OAuthMetadata_NoFallbackToWalletProviderURI
+// is a regression test: WalletProviderURI is a different identifier for a
+// different purpose (the WIA-PoP's expected aud, not this wallet provider's
+// own issuer identity - see docs/wallet-instance-attestation.md), and
+// config.Validate() requires WIA.Issuer to be explicitly set whenever Mode
+// is "ietf". Issuer() must not silently substitute WalletProviderURI when
+// Issuer itself is unset (e.g. because a caller bypassed Validate()).
+func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_NoFallbackToWalletProviderURI(t *testing.T) {
 	svc := newTestWalletProviderService(t)
 	svc.cfg.WalletProvider.WIA.Mode = config.WIAModeIETF
 	svc.cfg.WalletProvider.WIA.WalletProviderURI = "https://fallback.example.com"
+	// WIA.Issuer intentionally left unset.
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -135,18 +143,8 @@ func TestRegisterWalletProviderJWKSRoute_OAuthMetadata_FallsBackToWalletProvider
 	req, _ := http.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
-	}
-
-	var meta struct {
-		Issuer string `json:"issuer"`
-	}
-	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
-		t.Fatalf("unmarshal metadata: %v", err)
-	}
-	if meta.Issuer != "https://fallback.example.com" {
-		t.Errorf("issuer = %q, want %q", meta.Issuer, "https://fallback.example.com")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (route must not be registered without an explicit issuer)", w.Code, http.StatusNotFound)
 	}
 }
 

--- a/internal/service/wallet_provider_jwks_test.go
+++ b/internal/service/wallet_provider_jwks_test.go
@@ -210,6 +210,27 @@ func TestRegisterWalletProviderJWKSRoute_NoOpWhenNoSigningKey(t *testing.T) {
 	}
 }
 
+// TestRegisterWalletProviderJWKSRoute_NoOpWhenNilConfig is a regression test:
+// a WalletProviderService with a real signer but nil cfg (e.g. constructed
+// directly, bypassing NewWalletProviderService) must no-op rather than panic
+// on the WIA.Mode check below.
+func TestRegisterWalletProviderJWKSRoute_NoOpWhenNilConfig(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+	svc.cfg = nil
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterWalletProviderJWKSRoute(r, svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (route should not be registered)", w.Code, http.StatusNotFound)
+	}
+}
+
 func TestRegisterWalletProviderJWKSRoute_NoOpWhenNilService(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/internal/service/wallet_provider_statuslist.go
+++ b/internal/service/wallet_provider_statuslist.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -53,9 +54,13 @@ func RegisterWalletProviderStatusListRoute(router gin.IRoutes, wp *WalletProvide
 		}
 		// iss/sub are set consistently regardless of x5c/kid below, so a
 		// verifier can always identify and locate this wallet provider.
-		if wp.cfg.Server.BaseURL != "" {
-			claims["iss"] = wp.cfg.Server.BaseURL
-			claims["sub"] = wp.cfg.Server.BaseURL + "/wallet-provider/status-list"
+		// Trim BaseURL's trailing slash, if any, so sub doesn't end up with
+		// a double slash before the path (unlike the JWKS route's issuer,
+		// nothing else needs to match this iss byte-for-byte, so trimming
+		// it too keeps both claims consistent with each other).
+		if base := strings.TrimSuffix(wp.cfg.Server.BaseURL, "/"); base != "" {
+			claims["iss"] = base
+			claims["sub"] = base + "/wallet-provider/status-list"
 		}
 
 		token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)

--- a/internal/service/wallet_provider_statuslist.go
+++ b/internal/service/wallet_provider_statuslist.go
@@ -46,7 +46,10 @@ func RegisterWalletProviderStatusListRoute(router gin.IRoutes, wp *WalletProvide
 				"lst":  lst,
 			},
 		}
+		// iss/sub are set consistently regardless of x5c/kid below, so a
+		// verifier can always identify and locate this wallet provider.
 		if wp.cfg.Server.BaseURL != "" {
+			claims["iss"] = wp.cfg.Server.BaseURL
 			claims["sub"] = wp.cfg.Server.BaseURL + "/wallet-provider/status-list"
 		}
 
@@ -54,6 +57,13 @@ func RegisterWalletProviderStatusListRoute(router gin.IRoutes, wp *WalletProvide
 		token.Header["typ"] = "statuslist+jwt"
 		if len(wp.certChain) > 0 {
 			token.Header["x5c"] = wp.certChain
+		} else {
+			// No x5c: without a kid, a verifier fetching
+			// /.well-known/jwks.json (RegisterWalletProviderJWKSRoute, which
+			// publishes this same key under KeyID "wallet-provider") would
+			// have no way to select this key. Matches the WIA's own ietf-mode
+			// kid handling in WIAService.signWIA.
+			token.Header["kid"] = "wallet-provider"
 		}
 
 		tokenString, err := wp.jwtSigner.SignToken(token)

--- a/internal/service/wallet_provider_statuslist.go
+++ b/internal/service/wallet_provider_statuslist.go
@@ -28,7 +28,7 @@ const emptyStatusListSize = 1
 // No-op (never registers the route) when the wallet provider has no signing
 // key configured, mirroring RegisterWalletProviderJWKSRoute.
 func RegisterWalletProviderStatusListRoute(router gin.IRoutes, wp *WalletProviderService) {
-	if wp == nil || wp.jwtSigner == nil {
+	if wp == nil || wp.cfg == nil || wp.jwtSigner == nil {
 		return
 	}
 

--- a/internal/service/wallet_provider_statuslist.go
+++ b/internal/service/wallet_provider_statuslist.go
@@ -31,13 +31,18 @@ func RegisterWalletProviderStatusListRoute(router gin.IRoutes, wp *WalletProvide
 		return
 	}
 
-	router.GET("/wallet-provider/status-list", func(c *gin.Context) {
-		lst, err := statuslist.EmptyCompressedList(emptyStatusListSize)
-		if err != nil {
+	// emptyStatusListSize is fixed, so the compressed list is the same on
+	// every request - compute it once at registration time rather than
+	// redoing the DEFLATE work on every call.
+	lst, err := statuslist.EmptyCompressedList(emptyStatusListSize)
+	if err != nil {
+		router.GET("/wallet-provider/status-list", func(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "STATUS_LIST_GENERATION_FAILED"})
-			return
-		}
+		})
+		return
+	}
 
+	router.GET("/wallet-provider/status-list", func(c *gin.Context) {
 		now := time.Now()
 		claims := jwt.MapClaims{
 			"iat": now.Unix(),

--- a/internal/service/wallet_provider_statuslist.go
+++ b/internal/service/wallet_provider_statuslist.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/sirosfoundation/go-wallet-backend/pkg/statuslist"
+)
+
+// emptyStatusListSize is the number of entries in the always-empty status
+// list this wallet provider publishes. The value is arbitrary — nothing this
+// wallet provider issues ever references a status list index (see
+// AttestationConfig's type-level comment) — so a small fixed size is enough
+// to make the list well-formed.
+const emptyStatusListSize = 1
+
+// RegisterWalletProviderStatusListRoute registers a Token Status List
+// endpoint that always serves a validly-shaped, all-VALID (never revoked)
+// list, for interop completeness only: this wallet provider does not
+// implement WIA/KA revocation-chaining (see AttestationConfig's type-level
+// comment in pkg/config) — no WIA or KA this wallet provider issues ever
+// references this endpoint's URI or an index within it.
+//
+// No-op (never registers the route) when the wallet provider has no signing
+// key configured, mirroring RegisterWalletProviderJWKSRoute.
+func RegisterWalletProviderStatusListRoute(router gin.IRoutes, wp *WalletProviderService) {
+	if wp == nil || wp.jwtSigner == nil {
+		return
+	}
+
+	router.GET("/wallet-provider/status-list", func(c *gin.Context) {
+		lst, err := statuslist.EmptyCompressedList(emptyStatusListSize)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "STATUS_LIST_GENERATION_FAILED"})
+			return
+		}
+
+		now := time.Now()
+		claims := jwt.MapClaims{
+			"iat": now.Unix(),
+			"status_list": map[string]interface{}{
+				"bits": 1,
+				"lst":  lst,
+			},
+		}
+		if wp.cfg.Server.BaseURL != "" {
+			claims["sub"] = wp.cfg.Server.BaseURL + "/wallet-provider/status-list"
+		}
+
+		token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+		token.Header["typ"] = "statuslist+jwt"
+		if len(wp.certChain) > 0 {
+			token.Header["x5c"] = wp.certChain
+		}
+
+		tokenString, err := wp.jwtSigner.SignToken(token)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "STATUS_LIST_SIGNING_FAILED"})
+			return
+		}
+
+		c.Header("Cache-Control", "public, max-age=300")
+		c.Data(http.StatusOK, "application/statuslist+jwt", []byte(tokenString))
+	})
+}

--- a/internal/service/wallet_provider_statuslist_test.go
+++ b/internal/service/wallet_provider_statuslist_test.go
@@ -34,6 +34,27 @@ func TestRegisterWalletProviderStatusListRoute_NoOpWithoutSigner(t *testing.T) {
 	}
 }
 
+// TestRegisterWalletProviderStatusListRoute_NoOpWhenNilConfig is a
+// regression test: a WalletProviderService with a real jwtSigner but nil
+// cfg (e.g. constructed directly, bypassing NewWalletProviderService) must
+// no-op rather than panic on the Server.BaseURL access below.
+func TestRegisterWalletProviderStatusListRoute_NoOpWhenNilConfig(t *testing.T) {
+	svc := newTestWalletProviderService(t)
+	svc.cfg = nil
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	RegisterWalletProviderStatusListRoute(router, svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/wallet-provider/status-list", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (route should not be registered)", rec.Code)
+	}
+}
+
 // TestRegisterWalletProviderStatusListRoute_ServesAllValidList verifies the
 // endpoint serves a well-formed, always-empty (all-VALID) Token Status List
 // JWT — see RegisterWalletProviderStatusListRoute's doc comment: nothing this

--- a/internal/service/wallet_provider_statuslist_test.go
+++ b/internal/service/wallet_provider_statuslist_test.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"bytes"
+	"compress/flate"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
+	"github.com/sirosfoundation/go-wallet-backend/pkg/signing"
+)
+
+func TestRegisterWalletProviderStatusListRoute_NoOpWithoutSigner(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	RegisterWalletProviderStatusListRoute(router, nil)
+	RegisterWalletProviderStatusListRoute(router, &WalletProviderService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/wallet-provider/status-list", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (route should not be registered)", rec.Code)
+	}
+}
+
+// TestRegisterWalletProviderStatusListRoute_ServesAllValidList verifies the
+// endpoint serves a well-formed, always-empty (all-VALID) Token Status List
+// JWT — see RegisterWalletProviderStatusListRoute's doc comment: nothing this
+// wallet provider issues references it, this is interop completeness only.
+func TestRegisterWalletProviderStatusListRoute_ServesAllValidList(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwtSigner, err := signing.NewCryptoSignerES256(privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Server.BaseURL = "https://wp.example.com"
+	wp := &WalletProviderService{cfg: cfg, jwtSigner: jwtSigner}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	RegisterWalletProviderStatusListRoute(router, wp)
+
+	req := httptest.NewRequest(http.MethodGet, "/wallet-provider/status-list", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/statuslist+jwt" {
+		t.Errorf("Content-Type = %q, want application/statuslist+jwt", ct)
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(rec.Body.String(), jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("response is not a parseable JWT: %v", err)
+	}
+	if token.Header["typ"] != "statuslist+jwt" {
+		t.Errorf("typ = %v, want statuslist+jwt", token.Header["typ"])
+	}
+
+	claims := token.Claims.(jwt.MapClaims)
+	sl, ok := claims["status_list"].(map[string]interface{})
+	if !ok {
+		t.Fatal("status_list claim missing")
+	}
+	lstStr, ok := sl["lst"].(string)
+	if !ok {
+		t.Fatal("status_list.lst missing or not a string")
+	}
+
+	compressed, err := base64.RawURLEncoding.DecodeString(lstStr)
+	if err != nil {
+		t.Fatalf("lst is not valid base64url: %v", err)
+	}
+	r := flate.NewReader(bytes.NewReader(compressed))
+	defer r.Close()
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("lst does not decompress: %v", err)
+	}
+	for i, b := range raw {
+		if b != 0 {
+			t.Errorf("byte %d = %#x, want 0 (every status must be VALID)", i, b)
+		}
+	}
+}

--- a/internal/service/wallet_provider_statuslist_test.go
+++ b/internal/service/wallet_provider_statuslist_test.go
@@ -75,8 +75,24 @@ func TestRegisterWalletProviderStatusListRoute_ServesAllValidList(t *testing.T) 
 	if token.Header["typ"] != "statuslist+jwt" {
 		t.Errorf("typ = %v, want statuslist+jwt", token.Header["typ"])
 	}
+	// Regression: no x5c configured means a verifier can only select this
+	// key via /.well-known/jwks.json (RegisterWalletProviderJWKSRoute),
+	// which requires kid to match.
+	if token.Header["kid"] != "wallet-provider" {
+		t.Errorf("kid = %v, want wallet-provider (required to resolve trust via JWKS when no x5c is configured)", token.Header["kid"])
+	}
+	if token.Header["x5c"] != nil {
+		t.Error("x5c should not be present when no certificate chain is configured")
+	}
 
 	claims := token.Claims.(jwt.MapClaims)
+	if claims["iss"] != "https://wp.example.com" {
+		t.Errorf("iss = %v, want https://wp.example.com", claims["iss"])
+	}
+	if claims["sub"] != "https://wp.example.com/wallet-provider/status-list" {
+		t.Errorf("sub = %v, want https://wp.example.com/wallet-provider/status-list", claims["sub"])
+	}
+
 	sl, ok := claims["status_list"].(map[string]interface{})
 	if !ok {
 		t.Fatal("status_list claim missing")
@@ -100,5 +116,47 @@ func TestRegisterWalletProviderStatusListRoute_ServesAllValidList(t *testing.T) 
 		if b != 0 {
 			t.Errorf("byte %d = %#x, want 0 (every status must be VALID)", i, b)
 		}
+	}
+}
+
+// TestRegisterWalletProviderStatusListRoute_WithCertChain verifies the x5c
+// path: when a certificate chain is configured, it's used instead of kid.
+func TestRegisterWalletProviderStatusListRoute_WithCertChain(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwtSigner, err := signing.NewCryptoSignerES256(privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Server.BaseURL = "https://wp.example.com"
+	wp := &WalletProviderService{cfg: cfg, jwtSigner: jwtSigner, certChain: []string{"deadbeef"}}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	RegisterWalletProviderStatusListRoute(router, wp)
+
+	req := httptest.NewRequest(http.MethodGet, "/wallet-provider/status-list", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(rec.Body.String(), jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("response is not a parseable JWT: %v", err)
+	}
+	if token.Header["kid"] != nil {
+		t.Errorf("kid = %v, want absent when x5c is configured", token.Header["kid"])
+	}
+	x5c, ok := token.Header["x5c"].([]interface{})
+	if !ok || len(x5c) != 1 || x5c[0] != "deadbeef" {
+		t.Errorf("x5c = %v, want [deadbeef]", token.Header["x5c"])
 	}
 }

--- a/internal/service/wallet_provider_statuslist_test.go
+++ b/internal/service/wallet_provider_statuslist_test.go
@@ -119,6 +119,50 @@ func TestRegisterWalletProviderStatusListRoute_ServesAllValidList(t *testing.T) 
 	}
 }
 
+// TestRegisterWalletProviderStatusListRoute_TrailingSlashBaseURL is a
+// regression test: a configured BaseURL with a trailing slash must not
+// produce a double slash in sub ("https://host//wallet-provider/..."),
+// which strict verifiers reject.
+func TestRegisterWalletProviderStatusListRoute_TrailingSlashBaseURL(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwtSigner, err := signing.NewCryptoSignerES256(privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Server.BaseURL = "https://wp.example.com/"
+	wp := &WalletProviderService{cfg: cfg, jwtSigner: jwtSigner}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	RegisterWalletProviderStatusListRoute(router, wp)
+
+	req := httptest.NewRequest(http.MethodGet, "/wallet-provider/status-list", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(rec.Body.String(), jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("response is not a parseable JWT: %v", err)
+	}
+	claims := token.Claims.(jwt.MapClaims)
+	if claims["iss"] != "https://wp.example.com" {
+		t.Errorf("iss = %v, want https://wp.example.com (trailing slash trimmed)", claims["iss"])
+	}
+	if claims["sub"] != "https://wp.example.com/wallet-provider/status-list" {
+		t.Errorf("sub = %v, want no double slash", claims["sub"])
+	}
+}
+
 // TestRegisterWalletProviderStatusListRoute_WithCertChain verifies the x5c
 // path: when a certificate chain is configured, it's used instead of kid.
 func TestRegisterWalletProviderStatusListRoute_WithCertChain(t *testing.T) {

--- a/internal/service/wallet_provider_test.go
+++ b/internal/service/wallet_provider_test.go
@@ -42,7 +42,6 @@ func newTestWalletProviderService(t *testing.T) *WalletProviderService {
 	cfg.Server.BaseURL = "https://wp.example.com"
 	cfg.WalletProvider.Attestation = config.AttestationConfig{
 		KAExpirySeconds: 15,
-		StatusListMode:  "never",
 	}
 
 	jwtSigner, err := signing.NewCryptoSignerES256(privKey)
@@ -383,11 +382,11 @@ func TestGenerateKeyAttestation_StandardClaims(t *testing.T) {
 	token, _, _ := parser.ParseUnverified(ka, jwt.MapClaims{})
 	claims := token.Claims.(jwt.MapClaims)
 
-	if claims["iss"] != "https://wp.example.com" {
-		t.Errorf("iss = %v, want https://wp.example.com", claims["iss"])
+	if _, ok := claims["iss"]; ok {
+		t.Errorf("iss should not be present on a KA (EC TS03 v1.5.2 removed it), got %v", claims["iss"])
 	}
-	if claims["nonce"] != "my-nonce" {
-		t.Errorf("nonce = %v, want my-nonce", claims["nonce"])
+	if claims["c_nonce"] != "my-nonce" {
+		t.Errorf("c_nonce = %v, want my-nonce", claims["c_nonce"])
 	}
 
 	if token.Header["typ"] != "keyattestation+jwt" {
@@ -415,48 +414,12 @@ func TestGenerateKeyAttestation_NotSupported(t *testing.T) {
 	}
 }
 
-func TestGenerateKeyAttestation_KeyStorageStatus(t *testing.T) {
+// TestGenerateKeyAttestation_NoRevocationClaims is a regression test for the
+// no-revocation-chaining design (see AttestationConfig's type-level comment):
+// a KA must never carry key_storage_status or iss, regardless of config —
+// there is no config knob left that could re-enable them.
+func TestGenerateKeyAttestation_NoRevocationClaims(t *testing.T) {
 	svc := newTestWalletProviderService(t)
-	svc.cfg.WalletProvider.Attestation.StatusListMode = "always"
-	svc.cfg.WalletProvider.Attestation.StatusListURL = "https://wp.example.com/ka-statuslists/7"
-	svc.cfg.WalletProvider.Attestation.StatusListExpiry = 2678400 // 31 days
-
-	jwks := []map[string]interface{}{
-		{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"},
-	}
-
-	ka, err := svc.GenerateKeyAttestation(context.Background(), jwks, "nonce", nil, "", "")
-	if err != nil {
-		t.Fatalf("GenerateKeyAttestation: %v", err)
-	}
-
-	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	token, _, _ := parser.ParseUnverified(ka, jwt.MapClaims{})
-	claims := token.Claims.(jwt.MapClaims)
-
-	ksStatus, ok := claims["key_storage_status"].(map[string]interface{})
-	if !ok {
-		t.Fatal("key_storage_status claim missing")
-	}
-	statusObj, ok := ksStatus["status"].(map[string]interface{})
-	if !ok {
-		t.Fatal("key_storage_status.status missing")
-	}
-	sl, ok := statusObj["status_list"].(map[string]interface{})
-	if !ok {
-		t.Fatal("key_storage_status.status.status_list missing")
-	}
-	if sl["uri"] != "https://wp.example.com/ka-statuslists/7" {
-		t.Errorf("uri = %v", sl["uri"])
-	}
-	if _, ok := ksStatus["exp"]; !ok {
-		t.Error("key_storage_status.exp missing when StatusListExpiry > 0")
-	}
-}
-
-func TestGenerateKeyAttestation_NoKeyStorageStatusWhenNever(t *testing.T) {
-	svc := newTestWalletProviderService(t)
-	svc.cfg.WalletProvider.Attestation.StatusListMode = "never"
 
 	jwks := []map[string]interface{}{
 		{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"},
@@ -472,7 +435,13 @@ func TestGenerateKeyAttestation_NoKeyStorageStatusWhenNever(t *testing.T) {
 	claims := token.Claims.(jwt.MapClaims)
 
 	if _, ok := claims["key_storage_status"]; ok {
-		t.Error("key_storage_status should not be present when StatusListMode=never")
+		t.Error("key_storage_status should never be present (no revocation-chaining support)")
+	}
+	if _, ok := claims["iss"]; ok {
+		t.Error("iss should never be present on a KA (EC TS03 v1.5.2 removed it; identity is x5c-only)")
+	}
+	if claims["c_nonce"] != "nonce" {
+		t.Errorf("c_nonce = %v, want %q (TS03 §2.3.2 requires c_nonce, not nonce)", claims["c_nonce"], "nonce")
 	}
 }
 
@@ -752,32 +721,5 @@ func TestNewWalletProviderService_NoKeys(t *testing.T) {
 	svc := NewWalletProviderService(cfg, zap.NewNop(), nil)
 	if svc.IsSupported() {
 		t.Error("service should not be supported without keys")
-	}
-}
-
-// TestRandomStatusIndexSeed_NotZeroAndVaries is a regression test: the seed
-// used to initialize statusIndexCounter must be randomized per process, not a
-// constant zero. Without this, every replica in a horizontally-scaled
-// deployment (and every restart of the same replica) would hand out colliding
-// status_list indices once wallet_provider.attestation.status_list_mode is "always".
-func TestRandomStatusIndexSeed_NotZeroAndVaries(t *testing.T) {
-	a := randomStatusIndexSeed()
-	b := randomStatusIndexSeed()
-
-	// Probability of either being exactly 0, or the two colliding, is 2^-64 —
-	// this is a meaningful regression check, not a flaky test.
-	if a == 0 {
-		t.Error("randomStatusIndexSeed returned 0 — counter would start unseeded")
-	}
-	if a == b {
-		t.Error("randomStatusIndexSeed returned the same value twice — not actually randomized")
-	}
-}
-
-// TestStatusIndexCounter_SeededAtInit verifies the package-level counter itself
-// was actually initialized from randomStatusIndexSeed (not left at its zero value).
-func TestStatusIndexCounter_SeededAtInit(t *testing.T) {
-	if statusIndexCounter.Load() == 0 {
-		t.Error("statusIndexCounter was not seeded at init — starts at 0, which will collide across replicas/restarts")
 	}
 }

--- a/internal/service/wia.go
+++ b/internal/service/wia.go
@@ -540,26 +540,19 @@ func (s *WIAService) signWIA(cnfJWK map[string]interface{}, jkt string, tenantID
 	// iss: only set in "ietf" mode, where it's the only way a relying party
 	// locates the JWKS needed to verify the WIA (see the header switch
 	// below). config.Validate() enforces Issuer being set whenever Mode is
-	// "ietf" and signing keys are configured. Falls back to
-	// WalletProviderURI if Issuer not explicitly configured.
-	// (WalletProviderService.Issuer(), used by
-	// RegisterWalletProviderJWKSRoute's RFC 8414 metadata, computes this
-	// same fallback independently - WIAService and WalletProviderService are
-	// separate structs sharing this config shape.)
+	// "ietf" and signing keys are configured, so no WalletProviderURI
+	// fallback here - WalletProviderService.Issuer() (used by
+	// RegisterWalletProviderJWKSRoute's RFC 8414 metadata) computes the
+	// same value the same way, so both stay consistent with what Validate()
+	// actually requires.
 	//
 	// In "etsi" mode, no iss is set at all: EC TS03 v1.5.2 removed `iss`
 	// from the WIA entirely — Wallet Provider identity is inferred solely
 	// from the x5c signing certificate, verified against the Trusted List
 	// for Wallet Providers (ETSI TS 119 472-3 AUTH-REQ-PROC-4.4.3-01 /
 	// TOKEN-REQ-PROC-4.5.2-01).
-	if s.cfg.WalletProvider.WIA.Mode == config.WIAModeIETF {
-		issuer := s.cfg.WalletProvider.WIA.Issuer
-		if issuer == "" {
-			issuer = s.cfg.WalletProvider.WIA.WalletProviderURI
-		}
-		if issuer != "" {
-			claims["iss"] = issuer
-		}
+	if s.cfg.WalletProvider.WIA.Mode == config.WIAModeIETF && s.cfg.WalletProvider.WIA.Issuer != "" {
+		claims["iss"] = s.cfg.WalletProvider.WIA.Issuer
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)

--- a/internal/service/wia.go
+++ b/internal/service/wia.go
@@ -195,9 +195,18 @@ func NewWIAService(cfg *config.Config, logger *zap.Logger, jwtSigner *signing.Cr
 	return svc
 }
 
-// IsSupported returns true if WIA generation is available.
+// IsSupported returns true if WIA generation is available. Unlike
+// WalletProviderService.IsSupported (which gates Key Attestation and always
+// requires a certificate), a certificate is only required here in "etsi"
+// mode — "ietf" mode issues JWKS-trust WIAs from a signing key alone.
 func (s *WIAService) IsSupported() bool {
-	return s.jwtSigner != nil && len(s.certChain) > 0
+	if s.jwtSigner == nil {
+		return false
+	}
+	if s.cfg.WalletProvider.WIA.Mode == config.WIAModeIETF {
+		return true
+	}
+	return len(s.certChain) > 0
 }
 
 // maxChallenges is the maximum number of concurrent pending challenges,
@@ -451,7 +460,11 @@ func (s *WIAService) validatePop(popJWT string, expectedNonce string) (map[strin
 func (s *WIAService) signWIA(cnfJWK map[string]interface{}, jkt string, tenantID domain.TenantID, userID *domain.UserID, attestationSource string, clientID string) (string, error) {
 	now := time.Now()
 
-	// Use global attestation lifetime, capped by WIA max expiry
+	// WIA lifetime, capped by WIA max expiry. Deliberately short (default
+	// 300s / 5 min, see AttestationConfig) — this wallet provider has no
+	// client_status/revocation-chaining mechanism (see below); a short
+	// lifetime is the actual mechanism bounding exposure from a
+	// compromised/revoked wallet instance.
 	lifetime := time.Duration(s.cfg.WalletProvider.Attestation.LifetimeSeconds) * time.Second
 	maxExpiry := time.Duration(s.cfg.WalletProvider.WIA.MaxExpirySeconds) * time.Second
 	if maxExpiry <= 0 {
@@ -484,11 +497,22 @@ func (s *WIAService) signWIA(cnfJWK map[string]interface{}, jkt string, tenantID
 		},
 		"iat": now.Unix(),
 		"exp": now.Add(lifetime).Unix(),
-		// attestation_source: SIROS extension (WP4 CS-05 Annex C).
-		// Indicates the attestation tier:
-		//   "backend_attested"         — Tier 3: server-side attestation only
-		//   "ios_app_attest"           — Tier 4/5: Apple App Attest verified
-		//   "android_play_integrity"   — Tier 4/5: Google Play Integrity verified
+		// attestation_source: a SIROS extension claim — neither EC TS03 nor
+		// ETSI TS 119 472-3 define a WIA claim for this. Its values are
+		// chosen to mirror the S1/S3 "WIA dimension" tiers from WE BUILD
+		// wp4-architecture PR #229 ("cs-04: Add Annex C — Tiered WUA for
+		// cross-platform Wallet Solutions", open as of 2026-08, branch
+		// cs-04/annex-c-tiered-attestation) — NOT "WP4 CS-05" (Business
+		// Wallet, unrelated); Annex C is a proposed addition to CS-04.
+		// Annex C's own note is explicit that TS-03/CS-04 don't define this
+		// claim: any such signal "may [be conveyed] via the certification
+		// information or via an extension claim, but this is outside the
+		// scope of TS-03 and CS-04" — this claim is that extension.
+		//   "backend_attested"         — Annex C tier S3: backend-only attestation
+		//   "ios_app_attest"           — Annex C tier S1: full client attestation (Apple App Attest)
+		//   "android_play_integrity"   — Annex C tier S1: full client attestation (Google Play Integrity)
+		// Annex C's tier S2 (partial client attestation, e.g. a browser
+		// extension/companion) has no corresponding value yet.
 		// Third-party wallet providers may omit this claim; issuers must handle
 		// both present and absent cases (absent = unknown tier).
 		"attestation_source": attestationSource,
@@ -509,44 +533,53 @@ func (s *WIAService) signWIA(cnfJWK map[string]interface{}, jkt string, tenantID
 		claims["wallet_solution_certification_information"] = s.cfg.WalletProvider.WIA.CertificationInfo
 	}
 
-	// Client status (WIA revocation via Token Status List, Annex C §C.3.2)
-	switch s.cfg.WalletProvider.Attestation.StatusListMode {
-	case "always":
-		clientStatus := map[string]interface{}{
-			"status": map[string]interface{}{
-				"status_list": map[string]interface{}{
-					"uri": s.cfg.WalletProvider.Attestation.StatusListURL,
-					"idx": statusIndexCounter.Add(1),
-				},
-			},
-		}
-		if s.cfg.WalletProvider.Attestation.StatusListExpiry > 0 {
-			clientStatus["exp"] = now.Add(time.Duration(s.cfg.WalletProvider.Attestation.StatusListExpiry) * time.Second).Unix()
-		}
-		claims["client_status"] = clientStatus
-	case "never":
-		// Omit status list for short-lived attestations
-	default:
-		// "auto" or unset: omit (same as "never" for now)
-	}
+	// No `client_status`: this wallet provider does not implement WIA
+	// revocation-chaining. See AttestationConfig's type-level comment for
+	// the design rationale (short WIA lifetime instead).
 
-	// iss claim: identifies the wallet provider.
-	// Per TS03 §2.2.1, identity is derived from the x5c chain. However, the IETF
-	// draft-ietf-oauth-attestation-based-client-auth §3.1 specifies iss as the
-	// wallet provider identifier. We include both: x5c for EU/EUDI compliance,
-	// iss for efficient PDP routing and non-EU interop.
-	// Falls back to WalletProviderURI if Issuer not explicitly configured.
-	issuer := s.cfg.WalletProvider.WIA.Issuer
-	if issuer == "" {
-		issuer = s.cfg.WalletProvider.WIA.WalletProviderURI
-	}
-	if issuer != "" {
-		claims["iss"] = issuer
+	// iss: only set in "ietf" mode, where it's the only way a relying party
+	// locates the JWKS needed to verify the WIA (see the header switch
+	// below). config.Validate() enforces Issuer being set whenever Mode is
+	// "ietf" and signing keys are configured. Falls back to
+	// WalletProviderURI if Issuer not explicitly configured.
+	// (WalletProviderService.Issuer(), used by
+	// RegisterWalletProviderJWKSRoute's RFC 8414 metadata, computes this
+	// same fallback independently - WIAService and WalletProviderService are
+	// separate structs sharing this config shape.)
+	//
+	// In "etsi" mode, no iss is set at all: EC TS03 v1.5.2 removed `iss`
+	// from the WIA entirely — Wallet Provider identity is inferred solely
+	// from the x5c signing certificate, verified against the Trusted List
+	// for Wallet Providers (ETSI TS 119 472-3 AUTH-REQ-PROC-4.4.3-01 /
+	// TOKEN-REQ-PROC-4.5.2-01).
+	if s.cfg.WalletProvider.WIA.Mode == config.WIAModeIETF {
+		issuer := s.cfg.WalletProvider.WIA.Issuer
+		if issuer == "" {
+			issuer = s.cfg.WalletProvider.WIA.WalletProviderURI
+		}
+		if issuer != "" {
+			claims["iss"] = issuer
+		}
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
 	token.Header["typ"] = "oauth-client-attestation+jwt"
-	token.Header["x5c"] = s.certChain
+
+	switch s.cfg.WalletProvider.WIA.Mode {
+	case config.WIAModeIETF:
+		// No x5c: relying parties resolve the wallet provider's signing key
+		// from its own JWKS (RegisterWalletProviderJWKSRoute, served at the
+		// WIA's own iss URL). That resolution is kid-keyed (standard
+		// practice for multi-key JWKS, and what existing JWT
+		// trust-verification code elsewhere already expects), so the WIA
+		// itself must carry a kid header matching the JWKS entry's KeyID
+		// ("wallet-provider", hardcoded there since this deployment
+		// publishes exactly one signing key) - without it, a relying party
+		// has no way to know which of the issuer's published keys to use.
+		token.Header["kid"] = "wallet-provider"
+	default: // config.WIAModeETSI
+		token.Header["x5c"] = s.certChain
+	}
 
 	tokenString, err := s.jwtSigner.SignToken(token)
 	if err != nil {

--- a/internal/service/wia_test.go
+++ b/internal/service/wia_test.go
@@ -300,6 +300,48 @@ func TestWIAService_GenerateWIA_IETFMode(t *testing.T) {
 	}
 }
 
+// TestWIAService_GenerateWIA_IETFMode_NoFallbackToWalletProviderURI is a
+// regression test: WalletProviderURI is a different identifier for a
+// different purpose (the WIA-PoP's expected aud, not this wallet provider's
+// own issuer identity - see docs/wallet-instance-attestation.md), and
+// config.Validate() requires WIA.Issuer to be explicitly set whenever Mode
+// is "ietf". signWIA must not silently substitute WalletProviderURI for iss
+// when Issuer itself is unset (e.g. because a caller bypassed Validate()).
+func TestWIAService_GenerateWIA_IETFMode_NoFallbackToWalletProviderURI(t *testing.T) {
+	svc, _ := newTestWIAService(t)
+	svc.cfg.WalletProvider.WIA.Mode = config.WIAModeIETF
+	svc.cfg.WalletProvider.WIA.WalletProviderURI = "https://fallback.example.com"
+	// WIA.Issuer intentionally left unset.
+
+	challenge, _, err := svc.CreateChallenge(context.Background(), domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("CreateChallenge: %v", err)
+	}
+	// WalletProviderURI being set means validatePop now requires a matching
+	// aud claim (see TestValidatePop_AudValidation) - unrelated to what this
+	// test checks, but must still be satisfied.
+	pop := newTestPopBuilder(t, challenge).withAudience("https://fallback.example.com").build()
+
+	wiaJWT, err := svc.GenerateWIA(context.Background(), domain.DefaultTenantID, nil, &WIARequest{
+		Pop:       pop,
+		Challenge: challenge,
+	})
+	if err != nil {
+		t.Fatalf("GenerateWIA: %v", err)
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(wiaJWT, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("Parse WIA: %v", err)
+	}
+
+	claims := token.Claims.(jwt.MapClaims)
+	if _, ok := claims["iss"]; ok {
+		t.Errorf("iss should not be set without an explicit issuer, got %v", claims["iss"])
+	}
+}
+
 // TestWIAService_GenerateWIA_ETSIMode is the mirror of the ietf-mode test
 // above: the default ("etsi") mode must always carry x5c and never iss/kid.
 func TestWIAService_GenerateWIA_ETSIMode(t *testing.T) {

--- a/internal/service/wia_test.go
+++ b/internal/service/wia_test.go
@@ -53,7 +53,6 @@ func newTestWIAService(t *testing.T) (*WIAService, *ecdsa.PrivateKey) {
 	}
 	cfg.WalletProvider.Attestation = config.AttestationConfig{
 		LifetimeSeconds: 3600,
-		StatusListMode:  "never",
 	}
 
 	logger := zap.NewNop()
@@ -93,7 +92,6 @@ func newTestWIAServiceWithInstances(t *testing.T) (*WIAService, storage.WalletIn
 	}
 	cfg.WalletProvider.Attestation = config.AttestationConfig{
 		LifetimeSeconds: 3600,
-		StatusListMode:  "never",
 	}
 
 	logger := zap.NewNop()
@@ -250,6 +248,88 @@ func TestWIAService_GenerateWIA_Success(t *testing.T) {
 	jkt, _ := cnf["jkt"].(string)
 	if claims["sub"] != jkt {
 		t.Errorf("sub = %v, want jkt %v (no client_id supplied)", claims["sub"], jkt)
+	}
+}
+
+// "ietf" mode lets a deployment opt into the IETF-draft iss/JWKS identity
+// format instead of ETSI TS 119 472-3's x5c-derived identity - needed when
+// relying parties can't resolve trust via a self-signed x5c chain but can
+// fetch a JWKS from a real iss URL (see RegisterWalletProviderJWKSRoute).
+func TestWIAService_GenerateWIA_IETFMode(t *testing.T) {
+	svc, _ := newTestWIAService(t)
+	svc.cfg.WalletProvider.WIA.Mode = config.WIAModeIETF
+	svc.cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example"
+
+	challenge, _, err := svc.CreateChallenge(context.Background(), domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("CreateChallenge: %v", err)
+	}
+	pop, _ := createTestPop(t, challenge)
+
+	wiaJWT, err := svc.GenerateWIA(context.Background(), domain.DefaultTenantID, nil, &WIARequest{
+		Pop:       pop,
+		Challenge: challenge,
+	})
+	if err != nil {
+		t.Fatalf("GenerateWIA: %v", err)
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(wiaJWT, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("Parse WIA: %v", err)
+	}
+
+	if token.Header["x5c"] != nil {
+		t.Error("x5c header should be omitted in ietf mode")
+	}
+	if token.Header["kid"] != "wallet-provider" {
+		t.Errorf("kid = %v, want wallet-provider", token.Header["kid"])
+	}
+
+	claims := token.Claims.(jwt.MapClaims)
+	if claims["iss"] != "https://wallet-provider.example" {
+		t.Errorf("iss = %v, want https://wallet-provider.example", claims["iss"])
+	}
+}
+
+// TestWIAService_GenerateWIA_ETSIMode is the mirror of the ietf-mode test
+// above: the default ("etsi") mode must always carry x5c and never iss/kid.
+func TestWIAService_GenerateWIA_ETSIMode(t *testing.T) {
+	svc, _ := newTestWIAService(t)
+	// Mode left at its zero value ("") — signWIA's mode switch treats that
+	// the same as explicit "etsi" (config.Validate() would normalize it,
+	// but these unit tests construct WIAService directly, bypassing Validate).
+
+	challenge, _, err := svc.CreateChallenge(context.Background(), domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("CreateChallenge: %v", err)
+	}
+	pop, _ := createTestPop(t, challenge)
+
+	wiaJWT, err := svc.GenerateWIA(context.Background(), domain.DefaultTenantID, nil, &WIARequest{
+		Pop:       pop,
+		Challenge: challenge,
+	})
+	if err != nil {
+		t.Fatalf("GenerateWIA: %v", err)
+	}
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(wiaJWT, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("Parse WIA: %v", err)
+	}
+
+	if token.Header["x5c"] == nil {
+		t.Error("x5c header should be present in etsi mode")
+	}
+	if token.Header["kid"] != nil {
+		t.Error("kid header should not be present in etsi mode")
+	}
+	claims := token.Claims.(jwt.MapClaims)
+	if _, ok := claims["iss"]; ok {
+		t.Errorf("iss should not be present in etsi mode, got %v", claims["iss"])
 	}
 }
 
@@ -1055,10 +1135,13 @@ func TestSignWIA_CertificationInfoOmittedWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestSignWIA_StatusListAlways(t *testing.T) {
+// TestSignWIA_NoClientStatus is a regression test for the no-revocation-
+// chaining design (see AttestationConfig's type-level comment): a WIA must
+// never carry a client_status claim — there is no config knob left that
+// could re-enable it (StatusListMode/StatusListURL/StatusListExpiry were
+// removed).
+func TestSignWIA_NoClientStatus(t *testing.T) {
 	svc, _ := newTestWIAService(t)
-	svc.cfg.WalletProvider.Attestation.StatusListMode = "always"
-	svc.cfg.WalletProvider.Attestation.StatusListURL = "https://status.example.com/list"
 
 	challenge, _, _ := svc.CreateChallenge(context.Background(), domain.DefaultTenantID)
 	pop, _ := createTestPop(t, challenge)
@@ -1072,47 +1155,8 @@ func TestSignWIA_StatusListAlways(t *testing.T) {
 	token, _, _ := parser.ParseUnverified(wia, jwt.MapClaims{})
 	claims := token.Claims.(jwt.MapClaims)
 
-	clientStatus, ok := claims["client_status"].(map[string]interface{})
-	if !ok {
-		t.Fatal("client_status claim missing when StatusListMode=always")
-	}
-	statusObj, ok := clientStatus["status"].(map[string]interface{})
-	if !ok {
-		t.Fatal("client_status.status missing")
-	}
-	sl, ok := statusObj["status_list"].(map[string]interface{})
-	if !ok {
-		t.Fatal("client_status.status.status_list missing")
-	}
-	if sl["uri"] != "https://status.example.com/list" {
-		t.Errorf("status_list.uri = %v", sl["uri"])
-	}
-}
-
-func TestSignWIA_StatusListAlwaysWithExpiry(t *testing.T) {
-	svc, _ := newTestWIAService(t)
-	svc.cfg.WalletProvider.Attestation.StatusListMode = "always"
-	svc.cfg.WalletProvider.Attestation.StatusListURL = "https://status.example.com/list"
-	svc.cfg.WalletProvider.Attestation.StatusListExpiry = 3600
-
-	challenge, _, _ := svc.CreateChallenge(context.Background(), domain.DefaultTenantID)
-	pop, _ := createTestPop(t, challenge)
-
-	wia, err := svc.GenerateWIA(context.Background(), domain.DefaultTenantID, nil, &WIARequest{Pop: pop, Challenge: challenge})
-	if err != nil {
-		t.Fatalf("GenerateWIA: %v", err)
-	}
-
-	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	token, _, _ := parser.ParseUnverified(wia, jwt.MapClaims{})
-	claims := token.Claims.(jwt.MapClaims)
-
-	clientStatus, ok := claims["client_status"].(map[string]interface{})
-	if !ok {
-		t.Fatal("client_status claim missing")
-	}
-	if _, ok := clientStatus["exp"]; !ok {
-		t.Error("client_status.exp should be present when StatusListExpiry > 0")
+	if _, ok := claims["client_status"]; ok {
+		t.Error("client_status should never be present (no revocation-chaining support)")
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,6 +116,37 @@ func (c *ASConfig) SetDefaults() {
 	}
 }
 
+// EnableForRole turns on the AS (if not already explicitly configured) for
+// deployments that request the "auth" role (including via --mode=all).
+// There is no separate AS-specific key or policy to configure: it reuses the
+// wallet provider's own signing key, since every deployment already
+// configures one for WIA/Key Attestation, and defaults to an "allow all"
+// authorization policy (no RulesDir) rather than requiring one - a role flag
+// alone should be enough to turn AS on, matching how every other role works.
+//
+// A caller-supplied c.AS.Enabled (explicitly set false or true in config)
+// always wins - this only fills in what an unconfigured AS section would
+// otherwise leave empty.
+func (c *Config) EnableForRole() {
+	if c.AS.Enabled {
+		return
+	}
+	c.AS.Enabled = true
+	if c.AS.SigningKeyPath == "" && c.AS.SigningKeyPKCS11 == "" {
+		c.AS.SigningKeyPath = c.WalletProvider.PrivateKeyPath
+	}
+	if c.AS.RulesDir == "" {
+		// Ships in the image alongside the binary (see Dockerfile) - the
+		// baseline policy (read-only always allowed, own-tenant access for
+		// any tac) every deployment gets unless it configures its own.
+		c.AS.RulesDir = "/app/rules"
+	}
+	c.AS.SetDefaults()
+	if c.AS.Issuer == "" {
+		c.AS.Issuer = c.JWT.Issuer
+	}
+}
+
 // GetTokenTTL returns the TTL for a given audience, falling back to the default.
 func (c *ASConfig) GetTokenTTL(audience string) time.Duration {
 	if ttl, ok := c.AudienceTTLs[audience]; ok {
@@ -337,7 +368,7 @@ func (c *CORSConfig) SetDefaults() {
 	}
 	if len(c.AllowedHeaders) == 0 {
 		c.AllowedHeaders = []string{
-			"Authorization", "Content-Type", "X-Tenant-ID",
+			"Authorization", "Content-Type", "X-Tenant-ID", "X-Token-Mode",
 			"If-None-Match", "X-Private-Data-If-Match", "X-Private-Data-If-None-Match",
 			"Upgrade", "Connection", "Sec-WebSocket-Key",
 			"Sec-WebSocket-Version", "Sec-WebSocket-Protocol",
@@ -471,26 +502,27 @@ type PKCS11SigningConfig struct {
 }
 
 // AttestationConfig controls attestation lifecycle behavior.
+//
+// Revocation design: this wallet provider deliberately does NOT put
+// `client_status`/`key_storage_status` claims into WIAs or KAs (see
+// signWIA/GenerateKeyAttestation) — instead of a revocation-chaining
+// mechanism, it relies on WIA.LifetimeSeconds being short enough (default 5
+// minutes) that a compromised or revoked wallet instance's outstanding WIA
+// simply expires before it matters. EmptyStatusList still serves a validly
+// shaped, always-empty (all-valid) IETF Token Status List for interop
+// completeness (see RegisterWalletProviderStatusListRoute), but nothing this
+// wallet provider issues ever references it.
 type AttestationConfig struct {
-	// LifetimeSeconds is the global attestation lifetime (WIA + KA).
-	// CS-04 requires < 24h (86400). Default: 3600 (1 hour).
+	// LifetimeSeconds is the WIA lifetime. TS03 v1.5.2 caps this at < 24h
+	// (86400); this wallet provider defaults far below that (300s / 5 min)
+	// specifically so that WIA lifetime — not revocation-list checking — is
+	// the mechanism that bounds exposure from a compromised/revoked wallet
+	// instance. See the type-level comment above.
 	LifetimeSeconds int `yaml:"lifetime_seconds" envconfig:"LIFETIME_SECONDS"`
 
 	// KAExpirySeconds is the key attestation JWT expiry.
 	// Short-lived by default (15s) for single-use credential issuance.
 	KAExpirySeconds int `yaml:"ka_expiry_seconds" envconfig:"KA_EXPIRY_SECONDS"`
-
-	// StatusListMode controls whether attestations include a status_list entry.
-	// Values: "always" (always include), "never" (omit for short-lived),
-	// "auto" (include only if lifetime > threshold). Default: "never".
-	StatusListMode string `yaml:"status_list_mode" envconfig:"STATUS_LIST_MODE"`
-
-	// StatusListURL is the base URL for the Token Status List endpoint.
-	StatusListURL string `yaml:"status_list_url" envconfig:"STATUS_LIST_URL"`
-
-	// StatusListExpiry is the lifetime (seconds) of a status list entry.
-	// When > 0, the client_status object includes an "exp" field (Annex C §C.3.2).
-	StatusListExpiry int `yaml:"status_list_expiry" envconfig:"STATUS_LIST_EXPIRY"`
 
 	// NativeAttestation controls platform attestation verification.
 	NativeAttestation NativeAttestationConfig `yaml:"native_attestation" envconfig:"NATIVE_ATTESTATION"`
@@ -524,24 +556,69 @@ type NativeAttestationConfig struct {
 	GooglePlayIntegrityVerificationKeyPath string `yaml:"google_play_integrity_verification_key_path" envconfig:"GOOGLE_PLAY_INTEGRITY_VERIFICATION_KEY_PATH"`
 }
 
+// WIA trust-model modes — see WIAConfig.Mode.
+const (
+	WIAModeETSI = "etsi"
+	WIAModeIETF = "ietf"
+)
+
 // WIAConfig contains WIA-specific configuration (CS-04 §7.1.2)
 type WIAConfig struct {
 	// Enabled controls whether WIA endpoints are registered
 	Enabled bool `yaml:"enabled" envconfig:"ENABLED"`
-	// Issuer is the optional `iss` claim in WIA JWTs.
-	// Default is empty (omitted per TS03 §2.2.1, identity derived from x5c chain).
-	// Some national profiles require an explicit iss for interop.
+	// Issuer is the `iss` claim in WIA JWTs. Required when Mode is "ietf"
+	// (it's the only way a relying party can locate the JWKS to verify the
+	// WIA); unused/omitted when Mode is "etsi".
 	Issuer string `yaml:"issuer" envconfig:"ISSUER"`
+
+	// Mode selects which WIA trust model this wallet provider issues:
+	//
+	//   - "etsi" (default): the EUDI ARF v3.0 / EC TS03 v1.5.2 / ETSI TS 119
+	//     472-3 V1.1.1 model. The WIA always carries the signing certificate
+	//     chain in the `x5c` JOSE header; relying parties verify it against
+	//     the Trusted List for Wallet Providers (ETSI TS 119 472-3
+	//     AUTH-REQ-PROC-4.4.3-01 / TOKEN-REQ-PROC-4.5.2-01). No `iss` or
+	//     `kid` is set — TS03 v1.5 explicitly removed `iss` from the WIA;
+	//     Wallet Provider identity is inferred solely from the x5c signing
+	//     certificate. This is the only mode with a defined trust path under
+	//     the current EUDI/ARF/ETSI specs; use it when interoperating with
+	//     ARF-conformant PID/EAA Providers.
+	//
+	//   - "ietf": the generic IETF draft-ietf-oauth-attestation-based-client-auth
+	//     model, with no ARF/ETSI counterpart. The WIA omits `x5c` and
+	//     instead carries a `kid` header plus the `iss` claim (required);
+	//     relying parties resolve trust via JWKS discovery at
+	//     "<issuer>/.well-known/jwks.json" (see
+	//     RegisterWalletProviderJWKSRoute). Only meaningful for non-EUDI,
+	//     generic-OAuth ecosystems — an ARF-conformant PID/EAA Provider has
+	//     no spec-defined way to resolve trust via this path.
+	//
+	// Note SUNET/vc's parseAttestationIdentity treats x5c as authoritative
+	// and `iss` as a secondary consistency check only when both are present,
+	// so "etsi" mode (no iss) and "ietf" mode (no x5c) are both unambiguous
+	// to that consumer.
+	Mode string `yaml:"mode" envconfig:"MODE"`
 	// WalletProviderURI is the expected `aud` in WIA-PoP JWTs (wallet provider identifier)
 	WalletProviderURI string `yaml:"wallet_provider_uri" envconfig:"WALLET_PROVIDER_URI"`
-	// WalletName is the wallet_name claim in WIA JWT
+	// WalletName is the wallet_name claim in WIA JWT. REQUIRED by EC TS03
+	// v1.5.2 §2.3.1 when Mode is "etsi" — Validate() enforces this (defaults
+	// to "SIROS ID" so it's populated out of the box).
 	WalletName string `yaml:"wallet_name" envconfig:"WALLET_NAME"`
-	// WalletVersion is the wallet_version claim
+	// WalletVersion is the wallet_version claim. REQUIRED by EC TS03 v1.5.2
+	// §2.3.1 ("Added `wallet_version` (REQUIRED) to the WIA") when Mode is
+	// "etsi" — Validate() enforces this; there is no sensible built-in
+	// default (it must reflect this deployment's actual released version).
 	WalletVersion string `yaml:"wallet_version" envconfig:"WALLET_VERSION"`
-	// WalletLink is the wallet download/info URI
+	// WalletLink is the wallet download/info URI. SHOULD per TS03 §2.3.1;
+	// not enforced by Validate().
 	WalletLink string `yaml:"wallet_link" envconfig:"WALLET_LINK"`
-	// CertificationInfo is the wallet_solution_certification_information claim.
-	// Free-form map included as-is in the WIA JWT (Annex C §C.3.2).
+	// CertificationInfo is the wallet_solution_certification_information
+	// claim. Free-form map included as-is in the WIA JWT. SHALL-required by
+	// TS03 §2.3.1 when Mode is "etsi", but TS03 itself notes the
+	// certification scheme is not yet finalized ("the exact content of
+	// wallet_solution_certification_information is undefined") — Validate()
+	// only warns (via the WIA service logger at startup) rather than hard
+	// failing, unlike WalletVersion.
 	CertificationInfo map[string]interface{} `yaml:"certification_info,omitempty"`
 	// MaxExpirySeconds is the maximum WIA lifetime in seconds (CS-04 requires < 24h)
 	MaxExpirySeconds int `yaml:"max_expiry_seconds" envconfig:"MAX_EXPIRY_SECONDS"`
@@ -1130,6 +1207,7 @@ func defaultConfig() *Config {
 		WalletProvider: WalletProviderConfig{
 			WIA: WIAConfig{
 				Enabled:             true,
+				Mode:                WIAModeETSI,
 				WalletName:          "SIROS ID",
 				MaxExpirySeconds:    86400,
 				ChallengeTTLSeconds: 300,
@@ -1141,9 +1219,11 @@ func defaultConfig() *Config {
 				},
 			},
 			Attestation: AttestationConfig{
-				LifetimeSeconds: 3600,
+				// 5 minutes: short enough that WIA expiry — not revocation-list
+				// checking — bounds exposure from a compromised/revoked wallet
+				// instance. See AttestationConfig's type-level comment.
+				LifetimeSeconds: 300,
 				KAExpirySeconds: 15,
-				StatusListMode:  "never",
 			},
 		},
 	}
@@ -1225,14 +1305,6 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("jwt secret must be at least 32 bytes for HMAC-SHA256 security")
 	}
 
-	// Validate StatusListMode if set
-	switch c.WalletProvider.Attestation.StatusListMode {
-	case "", "always", "never", "auto":
-		// valid values
-	default:
-		return fmt.Errorf("invalid wallet_provider.attestation.status_list_mode: %q (must be always, never, or auto)", c.WalletProvider.Attestation.StatusListMode)
-	}
-
 	// Validate CORS: AllowCredentials cannot be true with wildcard origins
 	if c.Server.CORS.AllowCredentials {
 		for _, origin := range c.Server.CORS.AllowedOrigins {
@@ -1290,6 +1362,15 @@ func (c *Config) Validate() error {
 
 	// Validate WIA configuration
 	if c.WalletProvider.WIA.Enabled {
+		switch c.WalletProvider.WIA.Mode {
+		case WIAModeETSI, WIAModeIETF:
+		case "":
+			c.WalletProvider.WIA.Mode = WIAModeETSI
+		default:
+			return fmt.Errorf("invalid wallet_provider.wia.mode: %q (must be %q or %q)",
+				c.WalletProvider.WIA.Mode, WIAModeETSI, WIAModeIETF)
+		}
+
 		if c.WalletProvider.WIA.MaxExpirySeconds > 86400 {
 			return fmt.Errorf("wallet_provider.wia.max_expiry_seconds exceeds 24h (86400), CS-04 requires < 24h")
 		}
@@ -1307,10 +1388,42 @@ func (c *Config) Validate() error {
 		// unset. Only require it once WIA is actually operational (signing keys
 		// configured) — not on the zero-config default, where WIA.Enabled is
 		// true but no keys are present and no endpoints get registered.
-		walletProviderKeysConfigured := (c.WalletProvider.PrivateKeyPath != "" && c.WalletProvider.CertificatePath != "") ||
+		// Note: unlike Mode-specific checks below, this doesn't require a
+		// certificate — a signing key alone (file or PKCS#11, with or
+		// without a cert) is enough to make WIA operational in "ietf" mode.
+		walletProviderKeysConfigured := c.WalletProvider.PrivateKeyPath != "" ||
 			(c.WalletProvider.PKCS11 != nil && c.WalletProvider.PKCS11.ModulePath != "")
-		if walletProviderKeysConfigured && c.WalletProvider.WIA.WalletProviderURI == "" {
-			return fmt.Errorf("wallet_provider.wia.wallet_provider_uri is required when WIA is enabled with signing keys configured (used to validate the WIA-PoP aud claim)")
+		if walletProviderKeysConfigured {
+			if c.WalletProvider.WIA.WalletProviderURI == "" {
+				return fmt.Errorf("wallet_provider.wia.wallet_provider_uri is required when WIA is enabled with signing keys configured (used to validate the WIA-PoP aud claim)")
+			}
+
+			switch c.WalletProvider.WIA.Mode {
+			case WIAModeIETF:
+				// x5c is never sent in ietf mode, so `iss` + this wallet
+				// provider's own JWKS (RegisterWalletProviderJWKSRoute) is the
+				// only trust path a relying party has — without Issuer, a
+				// WIA would carry no identity at all. No certificate is
+				// required in this mode (JWKS-only trust).
+				if c.WalletProvider.WIA.Issuer == "" {
+					return fmt.Errorf("wallet_provider.wia.issuer is required when wallet_provider.wia.mode is %q", WIAModeIETF)
+				}
+			case WIAModeETSI:
+				// EC TS03 v1.5.2 §2.3.1: wallet_version is REQUIRED. There's
+				// no sensible default (see WIAConfig.WalletVersion), so this
+				// hard-fails rather than silently emitting a non-conformant WIA.
+				if c.WalletProvider.WIA.WalletVersion == "" {
+					return fmt.Errorf("wallet_provider.wia.wallet_version is required when wallet_provider.wia.mode is %q (EC TS03 v1.5.2 requires it)", WIAModeETSI)
+				}
+				if c.WalletProvider.WIA.WalletName == "" {
+					return fmt.Errorf("wallet_provider.wia.wallet_name is required when wallet_provider.wia.mode is %q (EC TS03 v1.5.2 requires it)", WIAModeETSI)
+				}
+				// x5c is mandatory in etsi mode; without a cert the WIA has
+				// no valid trust path under ETSI TS 119 472-3.
+				if c.WalletProvider.CertificatePath == "" {
+					return fmt.Errorf("wallet_provider.certificate_path is required when wallet_provider.wia.mode is %q (WIA identity is x5c-only under ETSI TS 119 472-3)", WIAModeETSI)
+				}
+			}
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,37 +116,6 @@ func (c *ASConfig) SetDefaults() {
 	}
 }
 
-// EnableForRole turns on the AS (if not already explicitly configured) for
-// deployments that request the "auth" role (including via --mode=all).
-// There is no separate AS-specific key or policy to configure: it reuses the
-// wallet provider's own signing key, since every deployment already
-// configures one for WIA/Key Attestation, and defaults to an "allow all"
-// authorization policy (no RulesDir) rather than requiring one - a role flag
-// alone should be enough to turn AS on, matching how every other role works.
-//
-// A caller-supplied c.AS.Enabled (explicitly set false or true in config)
-// always wins - this only fills in what an unconfigured AS section would
-// otherwise leave empty.
-func (c *Config) EnableForRole() {
-	if c.AS.Enabled {
-		return
-	}
-	c.AS.Enabled = true
-	if c.AS.SigningKeyPath == "" && c.AS.SigningKeyPKCS11 == "" {
-		c.AS.SigningKeyPath = c.WalletProvider.PrivateKeyPath
-	}
-	if c.AS.RulesDir == "" {
-		// Ships in the image alongside the binary (see Dockerfile) - the
-		// baseline policy (read-only always allowed, own-tenant access for
-		// any tac) every deployment gets unless it configures its own.
-		c.AS.RulesDir = "/app/rules"
-	}
-	c.AS.SetDefaults()
-	if c.AS.Issuer == "" {
-		c.AS.Issuer = c.JWT.Issuer
-	}
-}
-
 // GetTokenTTL returns the TTL for a given audience, falling back to the default.
 func (c *ASConfig) GetTokenTTL(audience string) time.Duration {
 	if ttl, ok := c.AudienceTTLs[audience]; ok {
@@ -368,7 +337,7 @@ func (c *CORSConfig) SetDefaults() {
 	}
 	if len(c.AllowedHeaders) == 0 {
 		c.AllowedHeaders = []string{
-			"Authorization", "Content-Type", "X-Tenant-ID", "X-Token-Mode",
+			"Authorization", "Content-Type", "X-Tenant-ID",
 			"If-None-Match", "X-Private-Data-If-Match", "X-Private-Data-If-None-Match",
 			"Upgrade", "Connection", "Sec-WebSocket-Key",
 			"Sec-WebSocket-Version", "Sec-WebSocket-Protocol",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1701,11 +1701,76 @@ func TestConfig_Validate_WIA_PassesWithWalletProviderURI(t *testing.T) {
 	cfg.WalletProvider.WIA.Enabled = true
 	cfg.WalletProvider.WIA.MaxExpirySeconds = 86400
 	cfg.WalletProvider.WIA.WalletProviderURI = "https://wallet.example.com"
+	cfg.WalletProvider.WIA.WalletName = "Test Wallet"
+	cfg.WalletProvider.WIA.WalletVersion = "1.0.0"
 	cfg.WalletProvider.PrivateKeyPath = "/path/to/key.pem"
 	cfg.WalletProvider.CertificatePath = "/path/to/cert.pem"
 
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfig_Validate_WIA_ETSIModeRequiresWalletVersion(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.WalletProvider.WIA.Enabled = true
+	cfg.WalletProvider.WIA.MaxExpirySeconds = 86400
+	cfg.WalletProvider.WIA.WalletProviderURI = "https://wallet.example.com"
+	cfg.WalletProvider.WIA.WalletName = "Test Wallet"
+	// WalletVersion deliberately left empty.
+	cfg.WalletProvider.PrivateKeyPath = "/path/to/key.pem"
+	cfg.WalletProvider.CertificatePath = "/path/to/cert.pem"
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "wallet_version is required") {
+		t.Errorf("expected wallet_version error, got %v", err)
+	}
+}
+
+func TestConfig_Validate_WIA_ETSIModeRequiresCertificate(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.WalletProvider.WIA.Enabled = true
+	cfg.WalletProvider.WIA.MaxExpirySeconds = 86400
+	cfg.WalletProvider.WIA.WalletProviderURI = "https://wallet.example.com"
+	cfg.WalletProvider.WIA.WalletName = "Test Wallet"
+	cfg.WalletProvider.WIA.WalletVersion = "1.0.0"
+	cfg.WalletProvider.PrivateKeyPath = "/path/to/key.pem"
+	// CertificatePath deliberately left empty — etsi mode requires x5c.
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "certificate_path is required") {
+		t.Errorf("expected certificate_path error, got %v", err)
+	}
+}
+
+func TestConfig_Validate_WIA_IETFModeRequiresIssuer(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.WalletProvider.WIA.Enabled = true
+	cfg.WalletProvider.WIA.Mode = WIAModeIETF
+	cfg.WalletProvider.WIA.MaxExpirySeconds = 86400
+	cfg.WalletProvider.WIA.WalletProviderURI = "https://wallet.example.com"
+	cfg.WalletProvider.PrivateKeyPath = "/path/to/key.pem"
+	// No CertificatePath, no Issuer.
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "wia.issuer is required") {
+		t.Errorf("expected issuer error, got %v", err)
+	}
+
+	cfg.WalletProvider.WIA.Issuer = "https://wallet-provider.example.com"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error once issuer is set: %v", err)
+	}
+}
+
+func TestConfig_Validate_WIA_InvalidMode(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.WalletProvider.WIA.Enabled = true
+	cfg.WalletProvider.WIA.Mode = "bogus"
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "invalid wallet_provider.wia.mode") {
+		t.Errorf("expected invalid mode error, got %v", err)
 	}
 }
 

--- a/pkg/signing/key_loader.go
+++ b/pkg/signing/key_loader.go
@@ -41,16 +41,19 @@ func LoadKeyMaterial(cfg *KeyConfig) (*KeyMaterial, error) {
 }
 
 func loadFromPKCS11(cfg *KeyConfig) (*KeyMaterial, error) {
-	if cfg.CertificatePath == "" {
-		return nil, errors.New("certificate_path is required for PKCS#11 mode (x5c chain)")
-	}
-
 	signer, err := NewPKCS11Signer(cfg.PKCS11)
 	if err != nil {
 		return nil, fmt.Errorf("pkcs11 signer: %w", err)
 	}
 
-	// Certificate chain still comes from file
+	// CertificatePath is optional: a signer alone is enough for "ietf"-mode
+	// WIA issuance (JWKS-based trust, no x5c). Callers that need x5c (KA
+	// generation, "etsi"-mode WIA) must configure a certificate and enforce
+	// that themselves — this loader doesn't know which mode a caller wants.
+	if cfg.CertificatePath == "" {
+		return &KeyMaterial{Signer: signer}, nil
+	}
+
 	chain, err := loadCertChain(cfg.CertificatePath, cfg.CACertPath)
 	if err != nil {
 		_ = signer.Close()
@@ -61,8 +64,8 @@ func loadFromPKCS11(cfg *KeyConfig) (*KeyMaterial, error) {
 }
 
 func loadFromFile(cfg *KeyConfig) (*KeyMaterial, error) {
-	if cfg.PrivateKeyPath == "" || cfg.CertificatePath == "" {
-		return nil, errors.New("private_key_path and certificate_path are required")
+	if cfg.PrivateKeyPath == "" {
+		return nil, errors.New("private_key_path is required")
 	}
 
 	keyPEM, err := os.ReadFile(cfg.PrivateKeyPath)
@@ -92,9 +95,13 @@ func loadFromFile(cfg *KeyConfig) (*KeyMaterial, error) {
 		}
 	}
 
-	chain, err := loadCertChain(cfg.CertificatePath, cfg.CACertPath)
-	if err != nil {
-		return nil, err
+	// CertificatePath is optional — see the matching comment in loadFromPKCS11.
+	var chain []string
+	if cfg.CertificatePath != "" {
+		chain, err = loadCertChain(cfg.CertificatePath, cfg.CACertPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &KeyMaterial{Signer: key, CertChain: chain}, nil

--- a/pkg/statuslist/statuslist.go
+++ b/pkg/statuslist/statuslist.go
@@ -1,5 +1,7 @@
-// Package statuslist builds an always-empty (all-VALID) IETF Token Status
-// List JWT.
+// Package statuslist builds the compressed, always-empty (all-VALID) bit
+// string for an IETF Token Status List (the `lst` value inside a
+// status_list JWT's payload) - not the JWT itself, which the service layer
+// (RegisterWalletProviderStatusListRoute) wraps this value in.
 //
 // This wallet provider does not implement WIA/KA revocation-chaining (see
 // AttestationConfig's type-level comment in pkg/config) — nothing it issues

--- a/pkg/statuslist/statuslist.go
+++ b/pkg/statuslist/statuslist.go
@@ -1,0 +1,45 @@
+// Package statuslist builds an always-empty (all-VALID) IETF Token Status
+// List JWT.
+//
+// This wallet provider does not implement WIA/KA revocation-chaining (see
+// AttestationConfig's type-level comment in pkg/config) — nothing it issues
+// ever references a status list index. This package exists purely so the
+// wallet provider can still publish a validly-shaped, always-empty status
+// list for interop completeness (some deployments expect a Wallet Provider
+// to expose one), without any WIA/KA depending on it.
+package statuslist
+
+import (
+	"bytes"
+	"compress/flate"
+	"encoding/base64"
+	"fmt"
+)
+
+// EmptyCompressedList returns the base64url-encoded (no padding), raw
+// DEFLATE-compressed (RFC 1951) byte array for a 1-bit-per-status list of
+// size n, with every status set to 0 (VALID) — the `lst` value of a Token
+// Status List's `status_list` claim.
+func EmptyCompressedList(n int) (string, error) {
+	if n <= 0 {
+		n = 1
+	}
+	// 1 bit per status, packed 8 to a byte; all-zero bytes represent "VALID"
+	// for every entry regardless of packing order, so no bit-level packing
+	// logic is needed beyond sizing the buffer.
+	raw := make([]byte, (n+7)/8)
+
+	var buf bytes.Buffer
+	w, err := flate.NewWriter(&buf, flate.BestCompression)
+	if err != nil {
+		return "", fmt.Errorf("create deflate writer: %w", err)
+	}
+	if _, err := w.Write(raw); err != nil {
+		return "", fmt.Errorf("compress status list: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return "", fmt.Errorf("finalize status list compression: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(buf.Bytes()), nil
+}

--- a/pkg/statuslist/statuslist_test.go
+++ b/pkg/statuslist/statuslist_test.go
@@ -1,0 +1,52 @@
+package statuslist
+
+import (
+	"bytes"
+	"compress/flate"
+	"encoding/base64"
+	"io"
+	"testing"
+)
+
+func TestEmptyCompressedList_DecodesToAllZero(t *testing.T) {
+	for _, n := range []int{1, 8, 100, 10000} {
+		lst, err := EmptyCompressedList(n)
+		if err != nil {
+			t.Fatalf("EmptyCompressedList(%d): %v", n, err)
+		}
+
+		compressed, err := base64.RawURLEncoding.DecodeString(lst)
+		if err != nil {
+			t.Fatalf("lst is not valid base64url: %v", err)
+		}
+
+		r := flate.NewReader(bytes.NewReader(compressed))
+		defer r.Close()
+		raw, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("lst does not decompress as raw DEFLATE: %v", err)
+		}
+
+		wantLen := (n + 7) / 8
+		if len(raw) != wantLen {
+			t.Errorf("n=%d: decompressed length = %d, want %d", n, len(raw), wantLen)
+		}
+		for i, b := range raw {
+			if b != 0 {
+				t.Errorf("n=%d: byte %d = %#x, want 0 (every status must be VALID)", n, i, b)
+			}
+		}
+	}
+}
+
+func TestEmptyCompressedList_NonPositiveSizeDefaultsToOne(t *testing.T) {
+	for _, n := range []int{0, -1, -100} {
+		lst, err := EmptyCompressedList(n)
+		if err != nil {
+			t.Fatalf("EmptyCompressedList(%d): %v", n, err)
+		}
+		if lst == "" {
+			t.Errorf("EmptyCompressedList(%d) returned empty string", n)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces `WIAConfig.OmitX5C` with an explicit `Mode` (`etsi`/`ietf`), matching EC TS03 v1.5.2 / ETSI TS 119 472-3 (etsi: x5c-only, no iss/kid) vs. the plain IETF draft (ietf: kid+iss, no x5c, no ARF/ETSI counterpart).
- Removes `client_status`/`key_storage_status` (no revocation-chaining support); WIA lifetime now defaults to 5 minutes so expiry — not a status list — bounds exposure. An always-empty Token Status List endpoint is still served for interop completeness.
- Fixes the KA's nonce claim (`c_nonce`, per TS03 §2.3.2) and removes the stray `iss` claim from the KA.
- Corrects the `attestation_source` claim's citation (SIROS extension mirroring the open, unmerged Annex C PR to wp4-architecture's CS-04 — not "WP4 CS-05").
- Makes `CertificatePath` optional in both file and PKCS#11 signing paths, so a signing key alone is sufficient for ietf-mode WIA (JWKS-only trust); adds `WalletProviderService.HasSigningKey()` distinct from `IsSupported()` (KA/etsi-mode still require a certificate).
- Regenerates `docs/CONFIGURATION.md`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass, including new `pkg/statuslist` and status-list route tests)
- [x] gofmt clean