### PR TITLE
docs(spocp): fix delegation.rules to describe reality, not an unenforced restriction

### DIFF
--- a/internal/as/token_endpoint.go
+++ b/internal/as/token_endpoint.go
@@ -272,6 +272,11 @@ func handleDelegationTokenRequest(
 	}
 
 	// Validate downscoping: delegated TAC must be subset of parent TAC.
+	// This is the complete security boundary for delegation - a delegated
+	// token can never exceed what its own parent already had, regardless
+	// of what SPOCP evaluation below would otherwise allow - see
+	// rules/delegation.rules for why SPOCP itself doesn't independently
+	// restrict this.
 	if !tac.IsSubsetOf(parentClaims.TAC) {
 		c.JSON(http.StatusForbidden, gin.H{
 			"error": "delegated permissions exceed parent token",

--- a/rules/delegation.rules
+++ b/rules/delegation.rules
@@ -1,21 +1,24 @@
-; Delegation SPOCP policy rules.
+; Delegation SPOCP policy — intentionally empty.
 ;
-; Delegation tokens are always downscoped: the delegated token's tac must be
-; a subset of the delegating token's tac, and tenant_id must match (or
-; narrow from "*" to a specific tenant). These constraints are enforced at
-; the code level before SPOCP evaluation. The rules below control which
-; delegation-issued tokens the policy engine will permit.
+; Delegation tokens are downscoped entirely at the code level in
+; handleDelegationTokenRequest (internal/as/token_endpoint.go): the
+; delegated token's tac must be a subset of the delegating token's tac,
+; and tenant_id must match (or narrow from "*" to a specific tenant). That
+; check is a complete security boundary on its own - a delegated token can
+; never exceed what its own parent already had - and it allows any subset
+; of the parent's tac (including re-delegation via 'k'), by design.
 ;
-; See default.rules for why rules are duplicated per query shape (positional
-; matching) - delegation queries carry sub always, and acr only when
-; inherited from a passkey-authenticated parent token.
-
-; --- Shape A: acr present (delegated from a passkey-authenticated parent) ---
-(token (acr (*)) (aud (*)) (sub (*)) (tac r))
-(token (acr (*)) (aud (*)) (sub (*)) (tac l))
-(token (acr (*)) (aud (*)) (sub (*)) (tac rl))
-
-; --- Shape B: no acr ---
-(token (aud (*)) (sub (*)) (tac r))
-(token (aud (*)) (sub (*)) (tac l))
-(token (aud (*)) (sub (*)) (tac rl))
+; This file previously carried a set of r/l/rl-only rules attempting to
+; additionally restrict delegation at the SPOCP layer, but they never had
+; any effect: LoadRulesFromDir loads every .rules file in the configured
+; directory into one SPOCP engine, and a query matches if it satisfies ANY
+; loaded rule. Delegation queries use the exact same shape (and go through
+; the exact same issueToken call) as regular session-token queries, so
+; default.rules' "any tac for an authenticated sub" wildcard (shape A/B)
+; already matched every delegation query too - a delegation request
+; downscoping to `tac w`, for example, was never actually blocked by
+; those rules, only permitted (correctly) by the code-level check above.
+; Kept as an explicit placeholder, in case a deployment ever wants SPOCP
+; to distinguish delegation queries from session queries - which would
+; require adding a claim to the query that BuildTokenQuery/the delegation
+; path doesn't emit today, not just rules in this file.


### PR DESCRIPTION
## Summary

Follow-up to a Copilot finding from #261's review: `default.rules`' shape-A/B "any tac for an authenticated sub" wildcard also matches delegation queries, since delegation and normal session-token requests share the exact same query shape via `issueToken`. That means `delegation.rules`' `r`/`l`/`rl`-only rules never actually restricted anything — `LoadRulesFromDir` loads every `.rules` file into one SPOCP engine, and a query is allowed if it satisfies *any* loaded rule.

I initially assumed the fix was to make delegation genuinely read-only at the code level, mirroring the anonymous-token cap in `handleAnonymousTokenRequest` — but that broke two existing, intentional tests (`TestTokenEndpoint_Delegation_DefaultTACStripsK`, `TestTokenEndpoint_Delegation_ReDelegation`): delegation is designed to support downscoping to *any* subset of the parent's tac, including write/insert/delete and re-delegation via `k`, not just read-only. `delegation.rules`' restrictive rules were themselves the stale artifact — not a missing enforcement gap.

The real security boundary (delegated tac must be a subset of the delegating token's tac) is already complete and correctly enforced in code (`handleDelegationTokenRequest`), independent of SPOCP. This PR just replaces `delegation.rules`' misleading rules with documentation explaining why the file is intentionally empty, so a future reader doesn't conclude delegation is policy-restricted to read/list when it never was and was never meant to be.

No behavior change — `go test ./...` passes unchanged.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean (no behavior change)
- [x] Confirmed `TestSPOCPEngine_LoadsShippedDefaultRules` still passes with a comment-only `delegation.rules`
- [x] `gofmt`/`golangci-lint` via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)