### PR TITLE
feat(authz): enforce per-route TAC across all HTTP routes (Part B)

### DIFF
--- a/docs/authorization-requirements.md
+++ b/docs/authorization-requirements.md
@@ -1,0 +1,140 @@
+# Authorization requirements: aud, tac, and acr per call
+
+This is the client-facing reference for what token properties (`aud`, `tac`,
+`acr`) each API call requires. Use it to decide what to request from
+`POST /auth/token` before making a given HTTP or WebSocket call, without
+having to read the enforcement source (`internal/server/providers.go`,
+`internal/engine/session.go`, `pkg/middleware/tokenauth.go`).
+
+For the full token-issuance design and rationale, see `docs/new-as.md`.
+
+## The three properties
+
+| Property | What it is | Who sets it |
+|---|---|---|
+| `aud` | Which audience (purpose) the token is scoped to - e.g. `wallet-backend` (general use) or `wallet-registry` (identity-free trust-evaluation/engine calls). | **You request it** - the `aud` field in the token request body. |
+| `tac` | Token Access Control - a string of permission characters (`r` read, `w` write, `l` list, `i` insert, `d` delete, `k` delegate, `a` admin) capping what the token can be used for. | **You request it** (optional) - the `tac` field in the token request body. Defaults and caps depend on the request shape (see below). |
+| `acr` | Authentication Context Class Reference - proof of *how* the underlying session was authenticated (e.g. passkey). | **Never client-supplied.** Inherited automatically from your session (or, for delegation, from the parent token). Every token the AS mints always has one - there is no way to request a token without an `acr`. |
+
+`tac` is a set, not a single value: a route requiring `w` is satisfied by a
+token with `tac: "rwl"`, not just `tac: "w"` - request the narrowest set
+that covers everything you intend to call with that token.
+
+## Getting a token: `POST /auth/token`
+
+Request body:
+
+```json
+{
+  "aud": "wallet-backend",
+  "tenant_id": "optional, defaults to your session's tenant",
+  "tac": "optional, see defaults below",
+  "anonymous": false
+}
+```
+
+How the request is authenticated determines which of three shapes you get:
+
+| Shape | How to trigger it | `sub` (identity) in the issued token | `tac` if omitted | `tac` cap |
+|---|---|---|---|---|
+| **Session** | Session cookie present, `anonymous` omitted/false | Your user ID | Your session's `MaxTAC` | Must be a subset of your session's `MaxTAC` |
+| **Anonymous** | Session cookie present, `anonymous: true` | *(omitted)* | `r` | Must be a subset of `rl` (read-only), **and** a subset of your session's `MaxTAC` |
+| **Delegation** | `Authorization: Bearer <parent token>` header, no session cookie | Same as the parent token's `sub` | Parent's `tac` minus `k` (delegate) | Must be a subset of the parent token's `tac` (any subset, including `w`/`i`/`d`/re-delegating `k` - not capped to read-only) |
+
+Notes:
+- **Anonymous ≠ unauthenticated.** It still requires a real, valid session
+  with a non-empty `acr` - it only means the issued token omits `sub`, e.g.
+  for a privacy-preserving trust-evaluation call you don't want tied to
+  your identity. A session-less caller never reaches this path.
+  Anonymous requests also can't target a different tenant than your own
+  session's tenant (unless your session is itself cross-tenant, `"*"`).
+- **Delegation** is for minting a downscoped token to hand to another
+  party/service. It requires the parent token to have `k` (delegate) in
+  its `tac`. The delegated token's `tenant_id` must match the parent's
+  (or narrow from `"*"`).
+- `tenant_id`, if you set it explicitly, must equal your session/parent's
+  own tenant, unless that session/parent is cross-tenant (`"*"`).
+
+## HTTP routes
+
+All of these require `aud: "wallet-backend"` unless noted otherwise. All
+require a valid token (session or delegation) via `Authorization: Bearer`
+or session cookie as appropriate for the route group.
+
+| Method | Path | Required `tac` | Notes |
+|---|---|---|---|
+| GET | `/user/session/account-info` | `r` | |
+| POST | `/user/session/settings` | `w` | |
+| GET | `/user/session/private-data` | `r` | |
+| POST | `/user/session/private-data` | `w` | |
+| DELETE | `/user/session` | `d` | |
+| POST | `/user/session/webauthn/register-begin` | `i` | |
+| POST | `/user/session/webauthn/register-finish` | `i` | |
+| POST | `/user/session/webauthn/credential/:id/rename` | `w` | |
+| POST | `/user/session/webauthn/credential/:id/delete` | `d` | |
+| GET | `/issuer/all` | `l` | |
+| GET | `/issuer/:id/metadata` | `r` | |
+| GET | `/verifier/all` | `l` | |
+| POST | `/helper/get-cert` | `r` | |
+| POST | `/proxy` | `r` | Only registered if `features.proxy_enabled` |
+| GET | `/keystore/status` | `r` | |
+| POST | `/wallet-provider/key-attestation/generate` | `w` | |
+| POST | `/wallet-provider/wia/challenge` | `w` | |
+| POST | `/wallet-provider/wia/generate` | `w` | |
+| GET | `/storage/vc` | `l` | |
+| POST | `/storage/vc` | `i` | |
+| POST | `/storage/vc/update` | `w` | |
+| GET | `/storage/vc/:credential_identifier` | `r` | |
+| DELETE | `/storage/vc/:credential_identifier` | `d` | |
+| POST | `/v1/evaluate` | `r` | **`aud`: `"wallet-registry"` or `"wallet-backend"`** - this is the intended anonymous-token call. |
+| POST | `/v1/resolve` | `r` | Same `aud` as `/v1/evaluate`. |
+
+Public, unauthenticated routes (registration, login, tenant config,
+`/helper/auth-check`) aren't listed - they need no token at all. Admin
+routes (`/admin/*`) aren't listed either - they use a separate static-secret
+mechanism on a different port, unrelated to `aud`/`tac`/`acr` entirely.
+
+## Engine transport (flow actions)
+
+The engine (credential issuance/presentation flows) enforces `aud` at
+connection time and `tac` per flow action. This is enforced at the
+transport-independent layer inside go-wallet-backend - `Manager.validateToken`
+(token → identity/tac), `Session.TAC`, and `handleFlowStart`'s
+protocol-keyed check all operate on parsed Go values (a token string in,
+a `*Session`/`*FlowStartMessage` domain struct out), not on any particular
+wire format. Any transport that authenticates a token into a `Session` and
+dispatches a `FlowStartMessage` gets the same enforcement automatically.
+
+**Currently implemented: the legacy WebSocket protocol**
+(`wss://{backend}/api/v2/wallet`, see `docs/websocket-protocol-spec.md` for
+the full message format). Connecting (`{"type": "handshake", "app_token":
+"<token>"}`) requires `aud: "wallet-registry"` or `aud: "wallet-backend"` -
+the same as `/v1/evaluate`/`/v1/resolve`. This is exactly the anonymous-token
+use case: most wallet clients connect with an anonymous, identity-free
+token here.
+
+**Per flow**, once connected, starting a flow additionally requires a
+specific `tac` depending on which protocol you're starting - checked
+against the same token's `tac`, not re-requested:
+
+| Protocol | Action | Required `tac` |
+|---|---|---|
+| `oid4vp` | Presenting an existing credential | `r` |
+| `oid4vci` | Receiving a new credential | `i` |
+
+A token requested with only `tac: "r"` (the anonymous default) can present
+credentials but cannot receive new ones - request `tac: "ri"` (or broader)
+if your client needs to do both over the same connection.
+
+WMP (an alternative wire protocol for the same engine transport) is
+tracked in a separate PR and will document its own connection details
+there when it lands - the `aud`/`tac` requirements in this section apply
+to it unchanged, since they're enforced at the shared layer described
+above, not in any transport-specific message parsing.
+
+## Legacy tokens
+
+Deployments without the AS enabled (`cfg.AS.Enabled: false`, legacy HMAC
+tokens) have no `tac`/`acr`/multi-`aud` concept at all - none of the checks
+above apply there. This reference only describes the new-style AS token
+model.

--- a/docs/new-as.md
+++ b/docs/new-as.md
@@ -104,6 +104,12 @@ When a client (wallet or SDK) needs to call an API on behalf of a user, it obtai
 - The session cookie (automatically sent by the browser, or explicitly by native clients)
 - A **token request** JSON body specifying the desired access token properties
 
+> For the concrete, current answer to "what `aud`/`tac` do I need to call
+> route X" (including the identity-free `anonymous` request shape added
+> after this design doc was written), see `docs/authorization-requirements.md`
+> - this section covers the design rationale, not an exhaustive per-route
+> reference.
+
 ### Token request format
 
 ```jsonc

--- a/docs/websocket-protocol-spec.md
+++ b/docs/websocket-protocol-spec.md
@@ -112,6 +112,18 @@ Server → Client (failure):
 }
 ```
 
+`app_token` must be scoped to `aud: "wallet-registry"` or `aud:
+"wallet-backend"` - a token requested for any other audience is rejected at
+handshake. Per-flow, starting a flow (`flow_start`) additionally requires a
+specific `tac` on the same token, checked at that point rather than at
+handshake time: `r` for `oid4vp` (presenting an existing credential), `i`
+for `oid4vci` (receiving a new one) - a rejection there uses `flow_error`
+with code `FORBIDDEN` (a permission/tac rejection - not to be confused with
+`AUTHORIZATION_FAILED`, which is specifically an OAuth authorization *flow*
+failure elsewhere in this protocol), not the handshake-level `AUTH_FAILED`
+above. See `docs/authorization-requirements.md` for the full picture,
+including how to request a token with the `tac` your client needs.
+
 ### Keepalive
 
 Clients SHOULD send ping frames every 30 seconds. Servers MUST respond with pong.
@@ -772,6 +784,7 @@ Server → Client:
 | Code | Description |
 |------|-------------|
 | `AUTH_FAILED` | Invalid or expired authentication token |
+| `FORBIDDEN` | Token's `tac` doesn't permit the requested action (e.g. `flow_start` for a protocol the token's `tac` doesn't cover) |
 | `INVALID_MESSAGE` | Malformed message |
 | `UNKNOWN_FLOW` | `flow_id` not recognized |
 | `FLOW_TIMEOUT` | Flow exceeded maximum duration |

--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -80,7 +80,12 @@ const (
 type ErrorCode string
 
 const (
-	ErrCodeAuthFailed        ErrorCode = "AUTH_FAILED"
+	ErrCodeAuthFailed ErrorCode = "AUTH_FAILED"
+	// ErrCodeForbidden is a permission (tac) rejection, distinct from
+	// ErrCodeAuthorizationFail below despite the similar name - that one is
+	// specifically an OAuth authorization *flow* failure (bad redirect_uri,
+	// state mismatch, etc.), not a token-permission check.
+	ErrCodeForbidden         ErrorCode = "FORBIDDEN"
 	ErrCodeInvalidMessage    ErrorCode = "INVALID_MESSAGE"
 	ErrCodeUnknownFlow       ErrorCode = "UNKNOWN_FLOW"
 	ErrCodeFlowTimeout       ErrorCode = "FLOW_TIMEOUT"
@@ -107,6 +112,8 @@ func (c ErrorCode) UserFacingMessage() string {
 	switch c {
 	case ErrCodeAuthFailed:
 		return "Authentication failed"
+	case ErrCodeForbidden:
+		return "Insufficient permissions"
 	case ErrCodeInvalidMessage:
 		return "Invalid message format"
 	case ErrCodeUnknownFlow:

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
 
+	"github.com/sirosfoundation/go-tokenauth/claims"
 	tokenvalidator "github.com/sirosfoundation/go-tokenauth/validator"
 
 	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
@@ -53,11 +54,17 @@ type Session struct {
 	ID       string
 	UserID   string
 	TenantID string
-	conn     *websocket.Conn
-	sendMu   sync.Mutex
-	flows    map[string]*Flow
-	flowsMu  sync.RWMutex
-	logger   *zap.Logger
+	// TAC is only ever populated on the go-tokenauth path - see
+	// Manager.validateToken. An empty TAC means "not applicable" (legacy
+	// auth, no TAC concept at all), not "no permissions" - handleFlowStart's
+	// per-protocol check must treat it as a no-op, exactly like
+	// requireTACIfEnforced does for HTTP routes.
+	TAC     claims.TAC
+	conn    *websocket.Conn
+	sendMu  sync.Mutex
+	flows   map[string]*Flow
+	flowsMu sync.RWMutex
+	logger  *zap.Logger
 
 	// Channels for flow coordination
 	actionCh chan *FlowActionMessage
@@ -241,7 +248,7 @@ func (m *Manager) handleNewConnection(conn *websocket.Conn) {
 	}
 
 	// Validate token and extract claims
-	userID, tenantID, err := m.validateToken(handshake.AppToken)
+	userID, tenantID, tac, err := m.validateToken(handshake.AppToken)
 	if err != nil {
 		m.logger.Warn("Authentication failed",
 			zap.Error(err),
@@ -271,6 +278,7 @@ func (m *Manager) handleNewConnection(conn *websocket.Conn) {
 		ID:            sessionID,
 		UserID:        userID,
 		TenantID:      tenantID,
+		TAC:           tac,
 		conn:          conn,
 		flows:         make(map[string]*Flow),
 		logger:        m.logger.With(zap.String("session", logLabel)),
@@ -447,6 +455,15 @@ func (m *Manager) handleSession(session *Session) {
 	}
 }
 
+// requiredTACForProtocol maps each flow protocol to the TAC permission its
+// action semantically requires: OID4VP shares an existing credential (read),
+// OID4VCI receives a new one (insert). Only enforced when the session
+// actually has a TAC to check - see handleFlowStart.
+var requiredTACForProtocol = map[Protocol]string{
+	ProtocolOID4VP:  "r",
+	ProtocolOID4VCI: "i",
+}
+
 func (m *Manager) handleFlowStart(session *Session, msg *FlowStartMessage) {
 	flowID := msg.FlowID
 	if flowID == "" {
@@ -471,6 +488,22 @@ func (m *Manager) handleFlowStart(session *Session, msg *FlowStartMessage) {
 	if !ok {
 		_ = session.SendFlowError(flowID, "", ErrCodeInvalidMessage, "Unknown protocol: "+string(msg.Protocol))
 		return
+	}
+
+	// TAC check: only enforced when the session actually has a TAC to check
+	// (empty means legacy auth, which has no TAC concept - see
+	// Manager.validateToken - not "no permissions"), mirroring
+	// requireTACIfEnforced's identical conditional enforcement for HTTP
+	// routes (internal/server/providers.go).
+	if session.TAC != "" {
+		if required, ok := requiredTACForProtocol[msg.Protocol]; ok && !session.TAC.HasAll(required) {
+			_ = session.SendFlowError(flowID, "", ErrCodeAuthorizationFail, "insufficient permissions for protocol: "+string(msg.Protocol))
+			logger.Warn("Rejected flow start - insufficient TAC",
+				zap.String("tac", string(session.TAC)),
+				zap.String("required", required),
+			)
+			return
+		}
 	}
 
 	// Check concurrent flow limit and register atomically to prevent race condition.
@@ -588,20 +621,25 @@ func (m *Manager) unregisterSession(session *Session) {
 	session.logger.Info("Session closed")
 }
 
-func (m *Manager) validateToken(tokenString string) (userID, tenantID string, err error) {
+// validateToken authenticates tokenString and returns its identity.
+// tac is only ever populated on the go-tokenauth path - the legacy HMAC
+// path (below) has no TAC concept at all, so callers must treat an empty
+// tac as "not applicable here", not "no permissions", exactly like
+// requireTACIfEnforced does for HTTP routes (see internal/server/providers.go).
+func (m *Manager) validateToken(tokenString string) (userID, tenantID string, tac claims.TAC, err error) {
 	// Use go-tokenauth validator when available (supports both new-style and legacy tokens)
 	if m.tokenValidator != nil {
 		result, err := m.tokenValidator.Validate(context.Background(), tokenString)
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 		// The engine transport, like the AuthZEN proxy, only needs a
 		// wallet-registry or wallet-backend audience - never a broader one.
 		if !result.HasAudience("wallet-registry", "wallet-backend") {
-			return "", "", errors.New("token audience not permitted for engine transport")
+			return "", "", "", errors.New("token audience not permitted for engine transport")
 		}
 		// UserID may be empty for anonymous tokens — that is acceptable.
-		return result.UserID, result.TenantID, nil
+		return result.UserID, result.TenantID, result.TAC, nil
 	}
 
 	// Legacy path: direct HMAC validation
@@ -613,23 +651,23 @@ func (m *Manager) validateToken(tokenString string) (userID, tenantID string, er
 	}, jwt.WithLeeway(config.JWTLeeway))
 
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
-	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+	if mapClaims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
 		// Support both "user_id" (go-wallet-backend native) and "uuid" (wallet-backend-server compat)
-		userID, _ = claims["user_id"].(string)
+		userID, _ = mapClaims["user_id"].(string)
 		if userID == "" {
-			userID, _ = claims["uuid"].(string)
+			userID, _ = mapClaims["uuid"].(string)
 		}
-		tenantID, _ = claims["tenant_id"].(string)
+		tenantID, _ = mapClaims["tenant_id"].(string)
 		if userID == "" {
-			return "", "", errors.New("invalid token claims: missing user_id or uuid")
+			return "", "", "", errors.New("invalid token claims: missing user_id or uuid")
 		}
-		return userID, tenantID, nil
+		return userID, tenantID, "", nil
 	}
 
-	return "", "", errors.New("invalid token")
+	return "", "", "", errors.New("invalid token")
 }
 
 func (m *Manager) getCapabilities() []string {

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -497,7 +497,7 @@ func (m *Manager) handleFlowStart(session *Session, msg *FlowStartMessage) {
 	// routes (internal/server/providers.go).
 	if session.TAC != "" {
 		if required, ok := requiredTACForProtocol[msg.Protocol]; ok && !session.TAC.HasAll(required) {
-			_ = session.SendFlowError(flowID, "", ErrCodeAuthorizationFail, "insufficient permissions for protocol: "+string(msg.Protocol))
+			_ = session.SendFlowError(flowID, "", ErrCodeForbidden, "insufficient permissions for protocol: "+string(msg.Protocol))
 			logger.Warn("Rejected flow start - insufficient TAC",
 				zap.String("tac", string(session.TAC)),
 				zap.String("required", required),

--- a/internal/engine/session_test.go
+++ b/internal/engine/session_test.go
@@ -518,7 +518,7 @@ func TestManager_handleFlowStart_RejectsInsufficientTAC(t *testing.T) {
 	if msg == nil {
 		t.Fatal("expected a flow_error, got none")
 	}
-	assert.Equal(t, ErrCodeAuthorizationFail, msg.Error.Code)
+	assert.Equal(t, ErrCodeForbidden, msg.Error.Code)
 }
 
 func TestManager_handleFlowStart_AllowsSufficientTAC(t *testing.T) {

--- a/internal/engine/session_test.go
+++ b/internal/engine/session_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirosfoundation/go-tokenauth/claims"
 	tokenvalidator "github.com/sirosfoundation/go-tokenauth/validator"
 
+	"github.com/sirosfoundation/go-wallet-backend/internal/storage"
 	"github.com/sirosfoundation/go-wallet-backend/pkg/config"
 )
 
@@ -217,10 +218,14 @@ func TestManager_validateToken_UserID(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("test-secret"))
 	require.NoError(t, err)
 
-	userID, tenantID, err := m.validateToken(tokenString)
+	userID, tenantID, tac, err := m.validateToken(tokenString)
 	require.NoError(t, err)
 	assert.Equal(t, "test-user-123", userID)
 	assert.Equal(t, "test-tenant", tenantID)
+	// Regression: the legacy HMAC path has no TAC concept at all - callers
+	// (handleFlowStart) must treat this as "not applicable", not "no
+	// permissions". See requiredTACForProtocol's doc comment.
+	assert.Equal(t, claims.TAC(""), tac)
 }
 
 func TestManager_validateToken_UUID(t *testing.T) {
@@ -241,7 +246,7 @@ func TestManager_validateToken_UUID(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("test-secret"))
 	require.NoError(t, err)
 
-	userID, tenantID, err := m.validateToken(tokenString)
+	userID, tenantID, _, err := m.validateToken(tokenString)
 	require.NoError(t, err)
 	assert.Equal(t, "uuid-user-456", userID)
 	assert.Empty(t, tenantID) // wallet-backend-server tokens don't have tenant_id
@@ -265,7 +270,7 @@ func TestManager_validateToken_UserIDTakesPrecedence(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("test-secret"))
 	require.NoError(t, err)
 
-	userID, _, err := m.validateToken(tokenString)
+	userID, _, _, err := m.validateToken(tokenString)
 	require.NoError(t, err)
 	assert.Equal(t, "native-user", userID)
 }
@@ -287,7 +292,7 @@ func TestManager_validateToken_MissingBothUserIDAndUUID(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("test-secret"))
 	require.NoError(t, err)
 
-	_, _, err = m.validateToken(tokenString)
+	_, _, _, err = m.validateToken(tokenString)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing user_id or uuid")
 }
@@ -308,7 +313,7 @@ func TestManager_validateToken_InvalidSigningMethod(t *testing.T) {
 	})
 	tokenString, _ := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
 
-	_, _, err := m.validateToken(tokenString)
+	_, _, _, err := m.validateToken(tokenString)
 	assert.Error(t, err)
 }
 
@@ -329,7 +334,7 @@ func TestManager_validateToken_ExpiredToken(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("test-secret"))
 	require.NoError(t, err)
 
-	_, _, err = m.validateToken(tokenString)
+	_, _, _, err = m.validateToken(tokenString)
 	assert.Error(t, err)
 }
 
@@ -349,7 +354,7 @@ func TestManager_validateToken_WrongSecret(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("wrong-secret"))
 	require.NoError(t, err)
 
-	_, _, err = m.validateToken(tokenString)
+	_, _, _, err = m.validateToken(tokenString)
 	assert.Error(t, err)
 }
 
@@ -371,7 +376,7 @@ func TestManager_validateToken_NbfSlightlyInFuture(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("test-secret"))
 	require.NoError(t, err)
 
-	userID, _, err := m.validateToken(tokenString)
+	userID, _, _, err := m.validateToken(tokenString)
 	require.NoError(t, err)
 	assert.Equal(t, "test-user", userID)
 }
@@ -394,7 +399,7 @@ func TestManager_validateToken_NbfBeyondLeeway(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("test-secret"))
 	require.NoError(t, err)
 
-	_, _, err = m.validateToken(tokenString)
+	_, _, _, err = m.validateToken(tokenString)
 	assert.Error(t, err)
 }
 
@@ -415,9 +420,10 @@ func TestManager_validateToken_GoTokenauth_AllowsRegistryAudience(t *testing.T) 
 		ACR:      "urn:siros:acr:passkey",
 	})
 
-	_, tenantID, err := m.validateToken(token)
+	_, tenantID, tac, err := m.validateToken(token)
 	require.NoError(t, err)
 	assert.Equal(t, "test-tenant", tenantID)
+	assert.Equal(t, claims.TAC("r"), tac)
 }
 
 // TestManager_validateToken_GoTokenauth_RejectsOtherAudience confirms a
@@ -436,8 +442,107 @@ func TestManager_validateToken_GoTokenauth_RejectsOtherAudience(t *testing.T) {
 		ACR:      "urn:siros:acr:passkey",
 	})
 
-	_, _, err := m.validateToken(token)
+	_, _, _, err := m.validateToken(token)
 	assert.Error(t, err)
+}
+
+// ===== handleFlowStart TAC enforcement tests =====
+
+// stubFlowHandler is a minimal FlowHandler that succeeds immediately,
+// for tests that only care whether handleFlowStart's TAC gate let the
+// flow reach a handler at all, not what the handler itself does.
+type stubFlowHandler struct{}
+
+func (stubFlowHandler) Execute(ctx context.Context, msg *FlowStartMessage) error { return nil }
+func (stubFlowHandler) Cancel()                                                  {}
+
+func newManagerWithStubOID4VCIHandler(t *testing.T) *Manager {
+	t.Helper()
+	cfg := &config.Config{JWT: config.JWTConfig{Secret: "test-secret"}}
+	m := NewManager(cfg, zap.NewNop())
+	m.RegisterFlowHandler(ProtocolOID4VCI, func(flow *Flow, cfg *config.Config, logger *zap.Logger, trustSvc *TrustService, registry *RegistryClient, verifiers storage.VerifierStore, trustCache *TrustCache) (FlowHandler, error) {
+		return stubFlowHandler{}, nil
+	})
+	return m
+}
+
+// runHandleFlowStart wires a Manager+Session whose conn is the client side
+// of wsTestServer, calls handleFlowStart, and returns whatever the session
+// sent (as observed server-side via srvConn), or nil if nothing arrived
+// within a short window. session.conn.WriteJSON sends the message from the
+// test's "session" (client dialer conn) to the server-side handler
+// (srvConn) - matching the existing TestSendFlowComplete_* convention,
+// where the assertion always happens in the server-side callback, not by
+// reading back from the dialer conn.
+func runHandleFlowStart(t *testing.T, m *Manager, tac claims.TAC, protocol Protocol) *FlowErrorMessage {
+	t.Helper()
+
+	result := make(chan *FlowErrorMessage, 1)
+	conn, cleanup := wsTestServer(t, func(srvConn *websocket.Conn) {
+		// Deliberately shorter than the outer select's timeout below, so a
+		// successful (no-message) flow start reliably delivers nil to
+		// result well before the outer timeout could ever race it.
+		_ = srvConn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+		_, data, err := srvConn.ReadMessage()
+		if err != nil {
+			result <- nil
+			return
+		}
+		var msg FlowErrorMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			result <- nil
+			return
+		}
+		result <- &msg
+	})
+	defer cleanup()
+
+	session := testSession(conn)
+	session.TAC = tac
+
+	m.handleFlowStart(session, &FlowStartMessage{Protocol: protocol})
+
+	select {
+	case msg := <-result:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server-side callback")
+		return nil
+	}
+}
+
+func TestManager_handleFlowStart_RejectsInsufficientTAC(t *testing.T) {
+	m := newManagerWithStubOID4VCIHandler(t)
+
+	msg := runHandleFlowStart(t, m, "r", ProtocolOID4VCI) // OID4VCI (issuance) requires 'i'
+	if msg == nil {
+		t.Fatal("expected a flow_error, got none")
+	}
+	assert.Equal(t, ErrCodeAuthorizationFail, msg.Error.Code)
+}
+
+func TestManager_handleFlowStart_AllowsSufficientTAC(t *testing.T) {
+	m := newManagerWithStubOID4VCIHandler(t)
+
+	// Should reach stubFlowHandler.Execute (which succeeds immediately and
+	// sends nothing) rather than being rejected by the TAC gate.
+	msg := runHandleFlowStart(t, m, "i", ProtocolOID4VCI)
+	if msg != nil {
+		t.Fatalf("expected no flow_error, got code %q", msg.Error.Code)
+	}
+}
+
+// TestManager_handleFlowStart_NoOpWhenTACEmpty is a regression test: an
+// empty session.TAC means "not applicable" (legacy auth, no TAC concept at
+// all - see Manager.validateToken), not "no permissions". A legacy-
+// authenticated session must not be blocked from starting any flow.
+func TestManager_handleFlowStart_NoOpWhenTACEmpty(t *testing.T) {
+	m := newManagerWithStubOID4VCIHandler(t)
+
+	msg := runHandleFlowStart(t, m, "", ProtocolOID4VCI)
+	if msg != nil {
+		t.Fatalf("expected no flow_error, got code %q", msg.Error.Code)
+	}
 }
 
 // ===== SendFlowComplete tests =====

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -138,55 +138,55 @@ func (p *AuthProvider) RegisterRoutes(router *gin.Engine) {
 		// User session routes (authenticated)
 		session := protected.Group("/user/session")
 		{
-			session.GET("/account-info", p.handlers.GetAccountInfo)
-			session.POST("/settings", p.handlers.UpdateSettings)
-			session.GET("/private-data", p.handlers.GetPrivateData)
-			session.POST("/private-data", p.handlers.UpdatePrivateData)
-			session.DELETE("/", p.handlers.DeleteUser)
+			session.GET("/account-info", requireTACIfEnforced(p.tokenValidator, "r"), p.handlers.GetAccountInfo)
+			session.POST("/settings", requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.UpdateSettings)
+			session.GET("/private-data", requireTACIfEnforced(p.tokenValidator, "r"), p.handlers.GetPrivateData)
+			session.POST("/private-data", requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.UpdatePrivateData)
+			session.DELETE("/", requireTACIfEnforced(p.tokenValidator, "d"), p.handlers.DeleteUser)
 
 			// WebAuthn credential management
-			session.POST("/webauthn/register-begin", p.handlers.StartAddWebAuthnCredential)
-			session.POST("/webauthn/register-finish", p.handlers.FinishAddWebAuthnCredential)
-			session.POST("/webauthn/credential/:id/rename", p.handlers.RenameWebAuthnCredential)
-			session.POST("/webauthn/credential/:id/delete", p.handlers.DeleteWebAuthnCredential)
+			session.POST("/webauthn/register-begin", requireTACIfEnforced(p.tokenValidator, "i"), p.handlers.StartAddWebAuthnCredential)
+			session.POST("/webauthn/register-finish", requireTACIfEnforced(p.tokenValidator, "i"), p.handlers.FinishAddWebAuthnCredential)
+			session.POST("/webauthn/credential/:id/rename", requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.RenameWebAuthnCredential)
+			session.POST("/webauthn/credential/:id/delete", requireTACIfEnforced(p.tokenValidator, "d"), p.handlers.DeleteWebAuthnCredential)
 		}
-		protected.DELETE("/user/session", p.handlers.DeleteUser)
+		protected.DELETE("/user/session", requireTACIfEnforced(p.tokenValidator, "d"), p.handlers.DeleteUser)
 
 		// Issuer routes
 		issuerGroup := protected.Group("/issuer")
 		{
-			issuerGroup.GET("/all", p.handlers.GetAllIssuers)
-			issuerGroup.GET("/:id/metadata", p.handlers.GetIssuerMetadata)
+			issuerGroup.GET("/all", requireTACIfEnforced(p.tokenValidator, "l"), p.handlers.GetAllIssuers)
+			issuerGroup.GET("/:id/metadata", requireTACIfEnforced(p.tokenValidator, "r"), p.handlers.GetIssuerMetadata)
 		}
 
 		// Verifier routes
 		verifierGroup := protected.Group("/verifier")
 		{
-			verifierGroup.GET("/all", p.handlers.GetAllVerifiers)
+			verifierGroup.GET("/all", requireTACIfEnforced(p.tokenValidator, "l"), p.handlers.GetAllVerifiers)
 		}
 
 		// Helper routes
-		protected.POST("/helper/get-cert", p.handlers.GetCertificate)
+		protected.POST("/helper/get-cert", requireTACIfEnforced(p.tokenValidator, "r"), p.handlers.GetCertificate)
 
 		// Proxy routes (can be disabled via features.proxy_enabled)
 		if p.cfg.Features.ProxyEnabled {
-			protected.POST("/proxy", p.handlers.ProxyRequest)
+			protected.POST("/proxy", requireTACIfEnforced(p.tokenValidator, "r"), p.handlers.ProxyRequest)
 		}
 
 		// Keystore routes
 		keystoreGroup := protected.Group("/keystore")
 		{
-			keystoreGroup.GET("/status", p.handlers.KeystoreStatus)
+			keystoreGroup.GET("/status", requireTACIfEnforced(p.tokenValidator, "r"), p.handlers.KeystoreStatus)
 		}
 
 		// Wallet provider routes
 		walletProvider := protected.Group("/wallet-provider")
 		{
-			walletProvider.POST("/key-attestation/generate", p.handlers.GenerateKeyAttestation)
+			walletProvider.POST("/key-attestation/generate", requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.GenerateKeyAttestation)
 			if p.cfg.WalletProvider.WIA.Enabled && p.services.WIA != nil {
 				wiaLimit := middleware.AuthRateLimitMiddlewareWithIdentifier(p.wiaRateLimiter, wiaCallerIdentifier)
-				walletProvider.POST("/wia/challenge", wiaLimit, p.handlers.WIAChallenge)
-				walletProvider.POST("/wia/generate", wiaLimit, p.handlers.WIAGenerate)
+				walletProvider.POST("/wia/challenge", wiaLimit, requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.WIAChallenge)
+				walletProvider.POST("/wia/generate", wiaLimit, requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.WIAGenerate)
 			}
 		}
 	}
@@ -213,6 +213,21 @@ func (p *AuthProvider) authMiddleware() gin.HandlerFunc {
 		return middleware.TokenAuthMiddleware(p.tokenValidator, p.store.Tenants(), p.logger)
 	}
 	return middleware.AuthMiddleware(p.cfg, p.store, p.logger)
+}
+
+// requireTACIfEnforced returns MustHaveTAC(required) when tv is non-nil (the
+// go-tokenauth path is active, so tokenauth_result - and therefore a TAC to
+// check - is actually populated). When tv is nil, the legacy HMAC
+// AuthMiddleware path is in effect instead, which has no TAC concept at all
+// (see AuthMiddleware) - MustHaveTAC would 401 every request there since it
+// never finds tokenauth_result, so this no-ops instead of enforcing.
+// Mirrors RequireAudience's own identical conditional application, for the
+// same reason.
+func requireTACIfEnforced(tv *tokenvalidator.Validator, required string) gin.HandlerFunc {
+	if tv == nil {
+		return func(c *gin.Context) { c.Next() }
+	}
+	return middleware.MustHaveTAC(required)
 }
 
 // =============================================================================
@@ -259,11 +274,11 @@ func (p *StorageProvider) RegisterRoutes(router *gin.Engine) {
 	{
 		// Credential storage (gated)
 		if p.cfg.Features.CredentialStorageEnabled {
-			protected.GET("/vc", p.handlers.GetAllCredentials)
-			protected.POST("/vc", p.handlers.StoreCredential)
-			protected.POST("/vc/update", p.handlers.UpdateCredential)
-			protected.GET("/vc/:credential_identifier", p.handlers.GetCredentialByIdentifier)
-			protected.DELETE("/vc/:credential_identifier", p.handlers.DeleteCredential)
+			protected.GET("/vc", requireTACIfEnforced(p.tokenValidator, "l"), p.handlers.GetAllCredentials)
+			protected.POST("/vc", requireTACIfEnforced(p.tokenValidator, "i"), p.handlers.StoreCredential)
+			protected.POST("/vc/update", requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.UpdateCredential)
+			protected.GET("/vc/:credential_identifier", requireTACIfEnforced(p.tokenValidator, "r"), p.handlers.GetCredentialByIdentifier)
+			protected.DELETE("/vc/:credential_identifier", requireTACIfEnforced(p.tokenValidator, "d"), p.handlers.DeleteCredential)
 		}
 	}
 }
@@ -558,8 +573,8 @@ func (p *BackendProvider) RegisterRoutes(router *gin.Engine) {
 		}
 		v1 := protected.Group("/v1")
 		{
-			v1.POST("/evaluate", p.authzenHandler.Evaluate)
-			v1.POST("/resolve", p.authzenHandler.Resolve)
+			v1.POST("/evaluate", requireTACIfEnforced(p.tokenValidator, "r"), p.authzenHandler.Evaluate)
+			v1.POST("/resolve", requireTACIfEnforced(p.tokenValidator, "r"), p.authzenHandler.Resolve)
 		}
 	}
 }
@@ -928,11 +943,11 @@ func (p *WalletProviderProvider) RegisterRoutes(router *gin.Engine) {
 		wp.Use(middleware.RequireAudience("wallet-backend"))
 	}
 	{
-		wp.POST("/key-attestation/generate", p.handlers.GenerateKeyAttestation)
+		wp.POST("/key-attestation/generate", requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.GenerateKeyAttestation)
 		if p.cfg.WalletProvider.WIA.Enabled && p.services.WIA != nil {
 			wiaLimit := middleware.AuthRateLimitMiddlewareWithIdentifier(p.wiaRateLimiter, wiaCallerIdentifier)
-			wp.POST("/wia/challenge", wiaLimit, p.handlers.WIAChallenge)
-			wp.POST("/wia/generate", wiaLimit, p.handlers.WIAGenerate)
+			wp.POST("/wia/challenge", wiaLimit, requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.WIAChallenge)
+			wp.POST("/wia/generate", wiaLimit, requireTACIfEnforced(p.tokenValidator, "w"), p.handlers.WIAGenerate)
 		}
 	}
 

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -708,6 +709,114 @@ func TestAuthProvider_RequireAudience_AllowsWalletBackendToken(t *testing.T) {
 	}
 	if w.Code == http.StatusNotFound {
 		t.Fatalf("route not registered - test would false-pass on a routing regression")
+	}
+}
+
+// =============================================================================
+// requireTACIfEnforced / route-level TAC enforcement tests
+// =============================================================================
+
+func TestRequireTACIfEnforced_NoOpWhenValidatorNil(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	// No tokenauth_result set at all - if this enforced anything, it would
+	// 401, matching the legacy AuthMiddleware path having no TAC concept.
+	r.Use(requireTACIfEnforced(nil, "w"))
+	r.GET("/test", func(c *gin.Context) { c.Status(200) })
+
+	c.Request = httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, c.Request)
+
+	if w.Code != 200 {
+		t.Fatalf("expected no-op (200) when tokenValidator is nil, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireTACIfEnforced_EnforcesWhenValidatorSet(t *testing.T) {
+	v, _, _ := setupServerTokenValidatorTest(t)
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	r.Use(func(c *gin.Context) {
+		c.Set("tokenauth_result", &claims.Result{TAC: "rl"})
+		c.Next()
+	})
+	r.Use(requireTACIfEnforced(v, "w"))
+	r.GET("/test", func(c *gin.Context) { c.Status(200) })
+
+	c.Request = httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, c.Request)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 (tac 'rl' lacks 'w') when tokenValidator is set, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestStorageProvider_RequireTAC_RejectsInsufficientPermission is an
+// end-to-end proof that requireTACIfEnforced is actually wired into a real
+// route, not just correct in isolation: a token with tac "rl" (read/list,
+// no delete) must be rejected on DELETE /storage/vc/:id.
+func TestStorageProvider_RequireTAC_RejectsInsufficientPermission(t *testing.T) {
+	v, key, issuer := setupServerTokenValidatorTest(t)
+	provider := newTestBackendProviderWithValidator(t, v)
+	provider.cfg.Features.CredentialStorageEnabled = true
+
+	token := signServerToken(t, key, issuer, claims.AccessTokenClaims{
+		Claims:   jwt.Claims{Subject: "user-123", Audience: jwt.Audience{"wallet-backend"}},
+		TenantID: string(domain.DefaultTenantID),
+		TAC:      "rl",
+		ACR:      "urn:siros:acr:passkey",
+	})
+
+	router := gin.New()
+	provider.RegisterRoutes(router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/storage/vc/some-id", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for a tac=rl token on a delete route, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestStorageProvider_RequireTAC_AllowsSufficientPermission is the
+// counterpart: a token with 'd' must reach the handler (not be blocked by
+// requireTACIfEnforced). It still 404s here - DeleteCredential's own
+// business logic correctly reports "no such credential" for an id that was
+// never stored in this bare test fixture - so this asserts the response
+// body is that handler-level not-found, not gin's router-level "no route
+// matches" (which reuses the same status code but a different body).
+func TestStorageProvider_RequireTAC_AllowsSufficientPermission(t *testing.T) {
+	v, key, issuer := setupServerTokenValidatorTest(t)
+	provider := newTestBackendProviderWithValidator(t, v)
+	provider.cfg.Features.CredentialStorageEnabled = true
+
+	token := signServerToken(t, key, issuer, claims.AccessTokenClaims{
+		Claims:   jwt.Claims{Subject: "user-123", Audience: jwt.Audience{"wallet-backend"}},
+		TenantID: string(domain.DefaultTenantID),
+		TAC:      "rwld",
+		ACR:      "urn:siros:acr:passkey",
+	})
+
+	router := gin.New()
+	provider.RegisterRoutes(router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/storage/vc/some-id", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	if w.Code == http.StatusForbidden {
+		t.Fatalf("expected a tac=rwld token to pass the TAC gate on a delete route, got 403: %s", w.Body.String())
+	}
+	if w.Code != http.StatusNotFound || !strings.Contains(w.Body.String(), "Credential not found") {
+		t.Fatalf("expected DeleteCredential's own not-found response for a nonexistent id, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Part B of the audience/TAC enforcement work (Part A was #262). `MustHaveTAC` existed but was **never actually called from any production route** — every protected route checked authentication only, so any authenticated token, regardless of its `tac`, could call every route (including deletes and writes) as long as it passed the tenant/audience checks already in place. Admin routes are unaffected — they use a separate, unrelated static-secret auth mechanism on a different port, not the go-tokenauth/TAC system at all.

### HTTP routes

Adds `requireTACIfEnforced(tv, required)`, which applies `MustHaveTAC(required)` under go-tokenauth (`tv != nil`, so `tokenauth_result` — and a TAC to check — actually exists), or no-ops under the legacy HMAC `AuthMiddleware` path (`tv == nil`), which has no TAC concept at all and would otherwise 401 every request. Mirrors `RequireAudience`'s existing identical conditional application, for the same reason.

Wired into every protected route across `AuthProvider`, `StorageProvider`, `BackendProvider`'s AuthZEN proxy, and the standalone `WalletProviderProvider`, mapped by what each route actually does:

| tac | meaning | routes |
|---|---|---|
| `r` | read a single resource | account-info, private-data, issuer/verifier metadata, get-cert, proxy, keystore status, AuthZEN evaluate/resolve |
| `w` | mutate an existing resource, or issue an attestation tied to the caller's own identity | settings, private-data update, rename credential, update stored VC, key attestation, WIA challenge/generate |
| `l` | list/enumerate a collection | issuer/verifier "all", storage vc list |
| `i` | create a new entry | add WebAuthn credential, store a new VC |
| `d` | delete | delete account, delete WebAuthn credential, delete VC |

WIA/key-attestation routes are mapped to `w` for now — they aren't CRUD on a stored collection, so r/w/l/i/d doesn't map perfectly, but `w` is the closest fit.

### WebSocket engine transport

The engine's WS transport was the other gap: `Session` had no TAC concept at all, and credential storage triggered by a flow (e.g. an OID4VCI issuance writing a newly-received credential) goes through the engine's direct service calls, not back through the gin routes above — so it was entirely unguarded by TAC regardless of the HTTP-layer work.

- `Manager.validateToken` now also returns the token's TAC (only populated on the go-tokenauth path; legacy HMAC has none, same "not applicable" case as HTTP).
- `Session` carries that TAC from handshake time.
- `handleFlowStart` — the natural per-action enforcement point, since the engine multiplexes two semantically different protocols over one connection — now requires `r` for OID4VP (presenting an existing credential) and `i` for OID4VCI (receiving a new one), rejecting with the existing `ErrCodeAuthorizationFail`. No-ops when `session.TAC` is empty (legacy auth), mirroring `requireTACIfEnforced`'s identical conditional enforcement.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean — the existing test suite is entirely unaffected (all existing test tokens already carry sufficient TAC, or run the legacy path where this no-ops)
- [x] New tests: `requireTACIfEnforced`'s two branches in isolation, an end-to-end proof (`TestStorageProvider_RequireTAC_{Rejects,Allows}...`) that a real signed token's TAC is enforced on a real HTTP route, and `TestManager_handleFlowStart_*` covering the WS per-protocol enforcement (rejects insufficient, allows sufficient, no-ops on empty/legacy TAC)
- [x] `gofmt`/`golangci-lint` via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)