### PR TITLE
fix(wia): send both c_nonce and nonce claims on Key Attestation

### DIFF
--- a/internal/service/wallet_provider.go
+++ b/internal/service/wallet_provider.go
@@ -297,12 +297,20 @@ func (s *WalletProviderService) GenerateKeyAttestation(ctx context.Context, jwks
 		// x5c signing certificate below.
 		"jti":           uuid.New().String(),
 		"attested_keys": attested,
-		// c_nonce (not `nonce`): TS03 §2.3.2 requires a KA sent via the
-		// `attestation` proof type to carry `c_nonce`. When a KA is instead
-		// wrapped in the `jwt` proof type, the nonce belongs in the outer
-		// proof JWT's body (built client-side), not here — this claim is
-		// then unused by conformant verifiers but harmless to include.
+		// c_nonce (TS03 §2.3.2 requires a KA sent via the `attestation`
+		// proof type to carry `c_nonce`) *and* nonce (the plain OpenID4VCI
+		// `attestation` proof type claim name some issuers - confirmed
+		// against a live geneva2026.mdoc.online conformance run - only
+		// recognize under this name, rejecting c_nonce-only KAs with
+		// invalid_nonce/"The nonce is not known"): send both rather than
+		// picking a side in what value TS03 vs. base OpenID4VCI expect
+		// here. An unrecognized extra claim is harmless to a conformant
+		// verifier (same reasoning that already applies when a KA is
+		// wrapped in the `jwt` proof type instead, where neither claim is
+		// consulted at all) - this keeps TS03/ARF compliance for verifiers
+		// that expect c_nonce while restoring interop with ones that don't.
 		"c_nonce": nonce,
+		"nonce":   nonce,
 		"iat":     now.Unix(),
 		"exp":     now.Add(kaExpiry).Unix(),
 	}

--- a/internal/service/wallet_provider_test.go
+++ b/internal/service/wallet_provider_test.go
@@ -388,6 +388,9 @@ func TestGenerateKeyAttestation_StandardClaims(t *testing.T) {
 	if claims["c_nonce"] != "my-nonce" {
 		t.Errorf("c_nonce = %v, want my-nonce", claims["c_nonce"])
 	}
+	if claims["nonce"] != "my-nonce" {
+		t.Errorf("nonce = %v, want my-nonce (sent alongside c_nonce for interop)", claims["nonce"])
+	}
 
 	if token.Header["typ"] != "keyattestation+jwt" {
 		t.Errorf("typ = %v, want keyattestation+jwt", token.Header["typ"])
@@ -442,6 +445,9 @@ func TestGenerateKeyAttestation_NoRevocationClaims(t *testing.T) {
 	}
 	if claims["c_nonce"] != "nonce" {
 		t.Errorf("c_nonce = %v, want %q (TS03 §2.3.2 requires c_nonce, not nonce)", claims["c_nonce"], "nonce")
+	}
+	if claims["nonce"] != "nonce" {
+		t.Errorf("nonce = %v, want %q (sent alongside c_nonce for interop with issuers expecting the base OpenID4VCI claim name)", claims["nonce"], "nonce")
 	}
 }
 


### PR DESCRIPTION
## Summary
- The KA (`attestation` proof type) currently sends only `c_nonce` per TS03 §2.3.2 (#261). geneva2026.mdoc.online's credential endpoint doesn't recognize `c_nonce` there and rejects issuance with `invalid_nonce`/"The nonce is not known" — confirmed via a live conformance run where the rejected value exactly matched what the nonce endpoint had just issued.
- Send both `c_nonce` and `nonce` claims rather than picking a side in what TS03 vs. base OpenID4VCI expect. An unrecognized extra claim is harmless to a conformant verifier — the same reasoning already documented in this code for the `jwt`-proof-type case, where neither claim is consulted at all.

## Test plan
- [x] `internal/service` unit tests updated + passing (asserts both `c_nonce` and `nonce` present)
- [ ] Redeploy sirosid-dev's test environment with this fix and confirm Geneva issuance succeeds end-to-end

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>