### PR TITLE
feat(registry): surface attestation_los in type-metadata responses

### DIFF
--- a/internal/registry/document.go
+++ b/internal/registry/document.go
@@ -10,12 +10,13 @@ import "encoding/json"
 // top-level name/description/organization fields are also checked first for
 // forward compatibility with documents that do set them directly.
 type documentHeader struct {
-	VCT          string         `json:"vct"`
-	DocType      string         `json:"doctype"`
-	Name         string         `json:"name"`
-	Description  string         `json:"description"`
-	Organization string         `json:"organization"`
-	Display      []displayEntry `json:"display"`
+	VCT            string         `json:"vct"`
+	DocType        string         `json:"doctype"`
+	Name           string         `json:"name"`
+	Description    string         `json:"description"`
+	Organization   string         `json:"organization"`
+	Display        []displayEntry `json:"display"`
+	AttestationLoS string         `json:"attestation_los"`
 }
 
 // displayEntry is a single locale's display properties within a "display"

--- a/internal/registry/handler.go
+++ b/internal/registry/handler.go
@@ -268,14 +268,21 @@ func (h *Handler) serveEntry(c *gin.Context, entry *VCTMEntry) {
 }
 
 // mergeAttestationLoS decodes a raw VCTM/MDDL JSON document as an object,
-// injects the attestation_los field, and re-serializes it. The document's
-// other fields and overall shape are preserved as-is.
+// injects the attestation_los field, and re-serializes it. Fields are kept
+// as json.RawMessage (not map[string]interface{}) so every other field's
+// original bytes - number representations, key order within nested
+// objects, everything - round-trip untouched; only the top-level key set
+// changes (one key added).
 func mergeAttestationLoS(data json.RawMessage, attestationLoS string) (json.RawMessage, error) {
-	var doc map[string]interface{}
+	var doc map[string]json.RawMessage
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("failed to decode metadata document: %w", err)
 	}
-	doc["attestation_los"] = attestationLoS
+	losJSON, err := json.Marshal(attestationLoS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode attestation_los: %w", err)
+	}
+	doc["attestation_los"] = losJSON
 	merged, err := json.Marshal(doc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to re-serialize metadata document: %w", err)

--- a/internal/registry/handler.go
+++ b/internal/registry/handler.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -232,17 +234,53 @@ func (h *Handler) serveEntry(c *gin.Context, entry *VCTMEntry) {
 			}
 		}
 
+		// Best-effort: surface the TS11 key-storage assurance tier alongside
+		// the document's own fields, so wallets can pick a WSCD plugin before
+		// generating keys for this credential type. Upstream TS11 population
+		// isn't guaranteed for every entry, so this is skipped when empty.
+		if entry.AttestationLoS != "" {
+			merged, err := mergeAttestationLoS(data, entry.AttestationLoS)
+			if err != nil {
+				h.logger.Warn("failed to merge attestation_los into metadata document",
+					zap.String("vct", entry.VCT),
+					zap.Error(err),
+				)
+			} else {
+				data = merged
+			}
+		}
+
 		c.Data(http.StatusOK, "application/json", data)
 		return
 	}
 
 	// No metadata available, return basic info
-	c.JSON(http.StatusOK, gin.H{
+	response := gin.H{
 		"vct":          entry.VCT,
 		"name":         entry.Name,
 		"description":  entry.Description,
 		"organization": entry.Organization,
-	})
+	}
+	if entry.AttestationLoS != "" {
+		response["attestation_los"] = entry.AttestationLoS
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+// mergeAttestationLoS decodes a raw VCTM/MDDL JSON document as an object,
+// injects the attestation_los field, and re-serializes it. The document's
+// other fields and overall shape are preserved as-is.
+func mergeAttestationLoS(data json.RawMessage, attestationLoS string) (json.RawMessage, error) {
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("failed to decode metadata document: %w", err)
+	}
+	doc["attestation_los"] = attestationLoS
+	merged, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-serialize metadata document: %w", err)
+	}
+	return merged, nil
 }
 
 // ListCredentials handles GET /credentials
@@ -252,12 +290,16 @@ func (h *Handler) ListCredentials(c *gin.Context) {
 
 	credentials := make([]gin.H, 0, len(entries))
 	for _, entry := range entries {
-		credentials = append(credentials, gin.H{
+		cred := gin.H{
 			"vct":          entry.VCT,
 			"name":         entry.Name,
 			"description":  entry.Description,
 			"organization": entry.Organization,
-		})
+		}
+		if entry.AttestationLoS != "" {
+			cred["attestation_los"] = entry.AttestationLoS
+		}
+		credentials = append(credentials, cred)
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/registry/handler_test.go
+++ b/internal/registry/handler_test.go
@@ -91,6 +91,161 @@ func TestHandler_GetTypeMetadata_NoMetadata(t *testing.T) {
 	assert.Equal(t, "Test Org", result["organization"])
 }
 
+func TestHandler_GetTypeMetadata_AttestationLoS_WithMetadata(t *testing.T) {
+	store := NewStore("")
+	store.Put(&VCTMEntry{
+		VCT:            "https://example.com/credential/v1",
+		Name:           "Test Credential",
+		Description:    "A test credential",
+		Organization:   "Test Org",
+		AttestationLoS: "iso_18045_high",
+		Metadata:       json.RawMessage(`{"vct": "https://example.com/credential/v1", "claims": {"name": {"display": [{"name": "Name"}]}}}`),
+	})
+
+	router := setupTestRouter(store)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/type-metadata?vct=https://example.com/credential/v1", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	// The raw document's own fields must be preserved.
+	assert.Equal(t, "https://example.com/credential/v1", result["vct"])
+	assert.Contains(t, result, "claims")
+	// attestation_los must be merged in alongside them.
+	assert.Equal(t, "iso_18045_high", result["attestation_los"])
+}
+
+func TestHandler_GetTypeMetadata_AttestationLoS_NoMetadata(t *testing.T) {
+	store := NewStore("")
+	store.Put(&VCTMEntry{
+		VCT:            "https://example.com/credential/v1",
+		Name:           "Test Credential",
+		Description:    "A test credential",
+		Organization:   "Test Org",
+		AttestationLoS: "iso_18045_moderate",
+		Metadata:       nil,
+	})
+
+	router := setupTestRouter(store)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/type-metadata?vct=https://example.com/credential/v1", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "Test Credential", result["name"])
+	assert.Equal(t, "iso_18045_moderate", result["attestation_los"])
+}
+
+func TestHandler_GetTypeMetadata_AttestationLoS_MdocDoctype(t *testing.T) {
+	store := NewStore("")
+	// mdoc doctype identifiers (not a "vct" URN) go through the exact same
+	// serveEntry code path as sd-jwt VCTs.
+	store.Put(&VCTMEntry{
+		VCT:            "org.iso.18013.5.1.mDL",
+		Name:           "Mobile Driving Licence",
+		AttestationLoS: "iso_18045_basic",
+		Metadata:       json.RawMessage(`{"doctype": "org.iso.18013.5.1.mDL", "namespaces": {}}`),
+	})
+
+	router := setupTestRouter(store)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/type-metadata?vct=org.iso.18013.5.1.mDL", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "org.iso.18013.5.1.mDL", result["doctype"])
+	assert.Equal(t, "iso_18045_basic", result["attestation_los"])
+}
+
+func TestHandler_GetTypeMetadata_AttestationLoS_Empty(t *testing.T) {
+	store := NewStore("")
+	store.Put(&VCTMEntry{
+		VCT:            "https://example.com/credential/v1",
+		Name:           "Test Credential",
+		AttestationLoS: "", // not populated upstream
+		Metadata:       json.RawMessage(`{"vct": "https://example.com/credential/v1"}`),
+	})
+	store.Put(&VCTMEntry{
+		VCT:            "https://example.com/credential/v2",
+		Name:           "Test Credential 2",
+		AttestationLoS: "",
+		Metadata:       nil,
+	})
+
+	router := setupTestRouter(store)
+
+	for _, vct := range []string{"https://example.com/credential/v1", "https://example.com/credential/v2"} {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/type-metadata?vct="+vct, nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var result map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		require.NoError(t, err)
+		assert.NotContains(t, result, "attestation_los", "attestation_los must be omitted, not emitted empty, for vct=%s", vct)
+	}
+}
+
+func TestHandler_ListCredentials_AttestationLoS(t *testing.T) {
+	store := NewStore("")
+	store.Put(&VCTMEntry{
+		VCT:            "https://example.com/credential1",
+		Name:           "Credential 1",
+		AttestationLoS: "iso_18045_high",
+	})
+	store.Put(&VCTMEntry{
+		VCT:  "https://example.com/credential2",
+		Name: "Credential 2",
+		// AttestationLoS empty - omitted
+	})
+
+	router := setupTestRouter(store)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/credentials", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	credentials := result["credentials"].([]interface{})
+	require.Len(t, credentials, 2)
+
+	var withLoS, withoutLoS map[string]interface{}
+	for _, cred := range credentials {
+		c := cred.(map[string]interface{})
+		if c["vct"] == "https://example.com/credential1" {
+			withLoS = c
+		} else {
+			withoutLoS = c
+		}
+	}
+	require.NotNil(t, withLoS)
+	require.NotNil(t, withoutLoS)
+	assert.Equal(t, "iso_18045_high", withLoS["attestation_los"])
+	assert.NotContains(t, withoutLoS, "attestation_los")
+}
+
 func TestHandler_GetTypeMetadata_NotFound(t *testing.T) {
 	store := NewStore("")
 	router := setupTestRouter(store)

--- a/internal/registry/handler_test.go
+++ b/internal/registry/handler_test.go
@@ -203,6 +203,54 @@ func TestHandler_GetTypeMetadata_AttestationLoS_Empty(t *testing.T) {
 	}
 }
 
+func TestHandler_GetTypeMetadata_AttestationLoS_MergeError(t *testing.T) {
+	store := NewStore("")
+	store.Put(&VCTMEntry{
+		VCT:            "https://example.com/credential/v1",
+		Name:           "Test Credential",
+		AttestationLoS: "iso_18045_high",
+		// Malformed upstream metadata: mergeAttestationLoS will fail to
+		// decode it, so serveEntry must log a warning and fall back to
+		// returning the original (unmodified) bytes rather than erroring
+		// out the whole request.
+		Metadata: json.RawMessage(`not-valid-json`),
+	})
+
+	router := setupTestRouter(store)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/type-metadata?vct=https://example.com/credential/v1", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "not-valid-json", w.Body.String(), "on merge failure the original raw bytes must pass through unchanged")
+}
+
+func TestMergeAttestationLoS(t *testing.T) {
+	t.Run("preserves nested fields and types exactly", func(t *testing.T) {
+		// A JSON number that would change representation if round-tripped
+		// through map[string]interface{} (float64) is the regression case:
+		// it must come back byte-for-byte identical.
+		input := json.RawMessage(`{"vct":"urn:example","claims":{"age":{"min":18}},"weight":1.50}`)
+
+		merged, err := mergeAttestationLoS(input, "iso_18045_high")
+		require.NoError(t, err)
+
+		var result map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(merged, &result))
+		assert.JSONEq(t, `"urn:example"`, string(result["vct"]))
+		assert.JSONEq(t, `{"age":{"min":18}}`, string(result["claims"]))
+		// Preserved exactly as the original bytes, not renormalized to "1.5".
+		assert.Equal(t, "1.50", string(result["weight"]))
+		assert.JSONEq(t, `"iso_18045_high"`, string(result["attestation_los"]))
+	})
+
+	t.Run("returns error on malformed input", func(t *testing.T) {
+		_, err := mergeAttestationLoS(json.RawMessage(`not-valid-json`), "iso_18045_high")
+		require.Error(t, err)
+	})
+}
+
 func TestHandler_ListCredentials_AttestationLoS(t *testing.T) {
 	store := NewStore("")
 	store.Put(&VCTMEntry{
@@ -228,12 +276,16 @@ func TestHandler_ListCredentials_AttestationLoS(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &result)
 	require.NoError(t, err)
 
-	credentials := result["credentials"].([]interface{})
+	credentialsAny, ok := result["credentials"]
+	require.True(t, ok, "response must contain a credentials field")
+	credentials, ok := credentialsAny.([]interface{})
+	require.True(t, ok, "credentials field must be a JSON array")
 	require.Len(t, credentials, 2)
 
 	var withLoS, withoutLoS map[string]interface{}
 	for _, cred := range credentials {
-		c := cred.(map[string]interface{})
+		c, ok := cred.(map[string]interface{})
+		require.True(t, ok, "each credential entry must be a JSON object")
 		if c["vct"] == "https://example.com/credential1" {
 			withLoS = c
 		} else {

--- a/internal/registry/local.go
+++ b/internal/registry/local.go
@@ -85,13 +85,14 @@ func loadFile(store *Store, path string, logger *zap.Logger) error {
 	}
 
 	entry := &VCTMEntry{
-		VCT:          id,
-		Name:         header.displayName(),
-		Description:  header.displayDescription(),
-		Organization: header.Organization,
-		Metadata:     json.RawMessage(data),
-		FetchedAt:    time.Now(),
-		IsLocal:      true,
+		VCT:            id,
+		Name:           header.displayName(),
+		Description:    header.displayDescription(),
+		Organization:   header.Organization,
+		Metadata:       json.RawMessage(data),
+		FetchedAt:      time.Now(),
+		IsLocal:        true,
+		AttestationLoS: header.AttestationLoS,
 	}
 
 	store.Put(entry)

--- a/internal/registry/local_test.go
+++ b/internal/registry/local_test.go
@@ -275,3 +275,51 @@ func TestLoadLocalOverrides_ExtractsOrganization(t *testing.T) {
 		t.Errorf("Organization = %q, want %q", entry.Organization, "ACME Corp")
 	}
 }
+
+func TestLoadLocalOverrides_ExtractsAttestationLoS(t *testing.T) {
+	dir := t.TempDir()
+
+	data := []byte(`{"vct": "urn:test:los", "name": "LoS Test", "description": "desc", "attestation_los": "iso_18045_high"}`)
+	fp := filepath.Join(dir, "los.json")
+	if err := os.WriteFile(fp, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	if err := LoadLocalOverrides(store, []string{fp}, logger); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, ok := store.Get("urn:test:los")
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.AttestationLoS != "iso_18045_high" {
+		t.Errorf("AttestationLoS = %q, want %q", entry.AttestationLoS, "iso_18045_high")
+	}
+}
+
+func TestLoadLocalOverrides_NoAttestationLoS(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "nolos.json")
+	if err := os.WriteFile(fp, testVCTMJSON("urn:test:nolos", "No LoS"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(filepath.Join(dir, "cache.json"))
+	logger := zap.NewNop()
+
+	if err := LoadLocalOverrides(store, []string{fp}, logger); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, ok := store.Get("urn:test:nolos")
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.AttestationLoS != "" {
+		t.Errorf("AttestationLoS = %q, want empty", entry.AttestationLoS)
+	}
+}


### PR DESCRIPTION
## Summary

- Issuers can already express a required key-storage assurance tier (`iso_18045_basic`/`iso_18045_moderate`/`iso_18045_high`) per credential type via the existing TS11 registry ingestion path — `VCTMEntry.AttestationLoS` in `internal/registry/store.go` is already populated from `internal/registry/fetcher.go`'s TS11 fetch logic. But the value never made it into the HTTP response: `GET /type-metadata?vct=<id>` and `GET /credentials` both stopped surfacing it at the store layer.
- This is the backend half of enabling native wallets to pick the correct local WSCD (key-storage) plugin *before* generating credential keys for a given credential type. The wallet-side plugin-selection logic is separate, parallel work happening in the SDK repos (siros-sdk-kotlin / siros-sdk-swift) — this PR only makes the signal available over the wire.
- Fixed both response paths in `serveEntry` (`internal/registry/handler.go`):
  - When `entry.Metadata` (raw upstream JSON) is present, decode it as a map, inject `attestation_los`, and re-serialize — preserving the rest of the document's shape as-is. Applies uniformly to both SD-JWT VCT and ISO 18013-5 mdoc doctype entries, since `fetchSchemaDocument` in `fetcher.go` produces both kinds of entries through the same code path.
  - When `Metadata` is nil (bare `gin.H` fallback), add `attestation_los` alongside the existing `vct`/`name`/`description`/`organization` keys.
  - Also added it to `ListCredentials`' per-entry `gin.H` construction.
- Omitted entirely (not emitted as `""`) when `entry.AttestationLoS` is empty, since upstream TS11 population isn't guaranteed for every entry.
- No changes to `TS11SchemaMeta` or the TS11 fetch logic — that ingestion path already populated `AttestationLoS`.
- One ingestion-path change: locally-loaded VCTM/MDDL override documents (`internal/registry/local.go`'s `loadFile`) never picked up `attestation_los` from their own JSON, so a local override always dropped the field even when the upstream TS11 entry it replaced had one set. Added `AttestationLoS` to `documentHeader` (`internal/registry/document.go`) and wired it through `loadFile` so local overrides carry the field the same as TS11-fetched entries.

## Test plan

- [x] Added `internal/registry/handler_test.go` coverage:
  - Raw-Metadata-present path with `AttestationLoS` set → `attestation_los` appears in the response body alongside the document's own fields.
  - `Metadata` nil (gin.H fallback) path with `AttestationLoS` set → appears there too.
  - mdoc-doctype entry (not a `vct` URN) with `AttestationLoS` set → same code path, same result.
  - Entries with `AttestationLoS` empty → field omitted, not emitted empty (both metadata-present and metadata-nil cases).
  - `ListCredentials` with mixed entries → present when set, omitted when empty.
- [x] Added `internal/registry/local_test.go` coverage: local override with `attestation_los` set populates `entry.AttestationLoS`; local override without it leaves the field empty.
- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go vet ./...` — clean
- [x] `GOWORK=off go test ./...` — all packages pass
- [x] `GOWORK=off golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Rg5eP3qKpkh7vcFLFDsGx