### PR TITLE
chore(deps): bump go-tokenauth to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/getkin/kin-openapi v0.145.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/sirosfoundation/go-cryptoutil/pkcs11pool v0.1.0
-	github.com/sirosfoundation/go-tokenauth v0.3.0
+	github.com/sirosfoundation/go-tokenauth v0.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/sirosfoundation/go-siros-set v0.1.0 h1:MN9AM3DXD05h+siUeMiV5Gjjte4Rx1
 github.com/sirosfoundation/go-siros-set v0.1.0/go.mod h1:HmgBclV01wp81itz2gYpn91L8lABWwxpbE38rkR1y20=
 github.com/sirosfoundation/go-spocp v0.1.0 h1:fH/jrSHS8vc+KfAzJmq3fE9OH69ShRgL7G1ihb9FCPs=
 github.com/sirosfoundation/go-spocp v0.1.0/go.mod h1:a6WtxG5hnsUzcqUt5iHmSMvyX4PLUPMDFK7FLoDMSMs=
-github.com/sirosfoundation/go-tokenauth v0.3.0 h1:M/4R+qrQ78sHmxGa0kIJh1OPorfGMvXWPOUCXOqDLXU=
-github.com/sirosfoundation/go-tokenauth v0.3.0/go.mod h1:cF1S4ev6ZaRl/Jt7boxO+fduuFtKDF8DEFaExB95kKM=
+github.com/sirosfoundation/go-tokenauth v0.4.0 h1:3V6KgxJUN96MAoXKB43rpL3mgfL51oOw6SQL/h5hRP0=
+github.com/sirosfoundation/go-tokenauth v0.4.0/go.mod h1:GcaY3K5tsqlMt76NoVFO+Eq8j/h6DXLE4SG1fTGhzuI=
 github.com/sirosfoundation/go-trust v0.9.2 h1:NApXxYMkYi+OimLDhOSFfktsFo6wYmSeLkleL7ycuLc=
 github.com/sirosfoundation/go-trust v0.9.2/go.mod h1:9dYlhsPyK8zoBzSFa+gRsTLfgkpVbeBYCGCv8hhf9ig=
 github.com/sirosfoundation/virtualwebauthn v0.0.0-20260701135251-caac157287c5 h1:1UkTjkgj6NSA04SogK6tvfvlMZVT7vkdfWsJurwe69Q=


### PR DESCRIPTION
## Summary
- Bumps `github.com/sirosfoundation/go-tokenauth` v0.3.0 → v0.4.0.
- New release adds `X-Tenant-ID` on outbound issuer/JWKS requests (routing to `backend.id.siros.org`) and `claims.Result.HasAudience`.
- Also picks up fixes for two vulnerabilities reachable through the JWKS fetch path: a crypto/tls ECH privacy leak (GO-2026-5856) and a quic-go HTTP/3 QPACK memory-exhaustion bug (GO-2026-5676).
- Additive/backward-compatible upstream change — no call-site changes needed here.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)