### PR TITLE
fix(oid4vp): recognize haip-vp:// scheme in request-URI parsing

### DIFF
--- a/internal/engine/oid4vp.go
+++ b/internal/engine/oid4vp.go
@@ -208,12 +208,20 @@ func (h *OID4VPHandler) parseRequest(ctx context.Context, msg *FlowStartMessage)
 	var authReq AuthorizationRequest
 
 	if msg.RequestURI != "" {
-		// Parse from openid4vp://, haip://, or a direct https:// URL. HAIP
-		// (OpenID4VC High Assurance Interoperability Profile) uses the same
-		// openid4vp://?client_id=...&request_uri=... wire shape as plain
-		// OID4VP, just under its own scheme - treat both identically.
+		// Parse from openid4vp://, haip://, haip-vp://, or a direct https://
+		// URL. HAIP (OpenID4VC High Assurance Interoperability Profile) uses
+		// the same openid4vp://?client_id=...&request_uri=... wire shape as
+		// plain OID4VP, just under its own scheme(s) - treat all three
+		// identically. "haip://" was HAIP's early-draft (1-3) scheme; HAIP
+		// 1.0 final replaced it with "haip-vp://" (presentation) - real
+		// verifiers (e.g. Multipaz) already emit the new one, and omitting
+		// it here fell through to the raw-https-URL branch below, which
+		// treats the whole thing as either an inline query string or a
+		// fetchable reference URL - neither is right for a haip-vp:// link
+		// carrying its own request_uri query param, so it never dereferenced
+		// that reference and failed with a generic "invalid message format".
 		requestStr := msg.RequestURI
-		if strings.HasPrefix(requestStr, "openid4vp://") || strings.HasPrefix(requestStr, "haip://") {
+		if strings.HasPrefix(requestStr, "openid4vp://") || strings.HasPrefix(requestStr, "haip://") || strings.HasPrefix(requestStr, "haip-vp://") {
 			u, err := url.Parse(requestStr)
 			if err != nil {
 				return nil, fmt.Errorf("invalid request URL: %w", err)
@@ -1302,7 +1310,7 @@ func validateResponseURIOrigin(authReq *AuthorizationRequest, msg *FlowStartMess
 		return nil
 	}
 	requestURL := msg.RequestURI
-	if strings.HasPrefix(requestURL, "openid4vp://") || strings.HasPrefix(requestURL, "haip://") {
+	if strings.HasPrefix(requestURL, "openid4vp://") || strings.HasPrefix(requestURL, "haip://") || strings.HasPrefix(requestURL, "haip-vp://") {
 		if u, err := url.Parse(requestURL); err == nil {
 			requestURL = u.Query().Get("request_uri")
 		}

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -1293,7 +1293,8 @@ func TestValidateResponseURIOrigin_HAIPScheme_Mismatch(t *testing.T) {
 		RequestURI: "haip://?request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
 	}
 	err := validateResponseURIOrigin(authReq, msg)
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match request_uri origin")
 }
 
 func TestValidateResponseURIOrigin_HAIPVPScheme(t *testing.T) {

--- a/internal/engine/oid4vp_test.go
+++ b/internal/engine/oid4vp_test.go
@@ -384,6 +384,30 @@ func TestParseRequest(t *testing.T) {
 		assert.Equal(t, "inline-nonce", authReq.Nonce)
 	})
 
+	// HAIP 1.0 final replaced the early-draft "haip://" scheme with
+	// "haip-vp://" (presentation) - regression test for a bug where real
+	// verifiers (e.g. Multipaz) emitting haip-vp:// links fell through to
+	// the "direct URL" branch (same bug class as haip:// above), which never
+	// dereferenced the request_uri query param and failed with a generic
+	// "invalid message format" instead of unwrapping it.
+	t.Run("haip-vp scheme with request_uri reference", func(t *testing.T) {
+		msg := &FlowStartMessage{
+			RequestURI: "haip-vp://?client_id=did:web:verifier&request_uri=" + url.QueryEscape(srv.URL),
+		}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "fetched-nonce", authReq.Nonce)
+	})
+
+	t.Run("haip-vp scheme with inline params", func(t *testing.T) {
+		msg := &FlowStartMessage{
+			RequestURI: "haip-vp://?response_type=vp_token&client_id=https://verifier.example.com&nonce=inline-nonce",
+		}
+		authReq, err := h.parseRequest(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Equal(t, "inline-nonce", authReq.Nonce)
+	})
+
 	// Regression test for a bug where a bare reference URL with no query
 	// string (e.g. a QR/link that IS itself the request_uri, no
 	// openid4vp://...&request_uri= wrapper at all) was parsed as if the
@@ -1267,6 +1291,30 @@ func TestValidateResponseURIOrigin_HAIPScheme_Mismatch(t *testing.T) {
 	}
 	msg := &FlowStartMessage{
 		RequestURI: "haip://?request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	assert.Error(t, err)
+}
+
+func TestValidateResponseURIOrigin_HAIPVPScheme(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ResponseURI:    "https://verifier.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "haip-vp://?request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
+	}
+	err := validateResponseURIOrigin(authReq, msg)
+	assert.NoError(t, err)
+}
+
+func TestValidateResponseURIOrigin_HAIPVPScheme_Mismatch(t *testing.T) {
+	authReq := &AuthorizationRequest{
+		ResponseURI:    "https://evil.example.com/response",
+		ClientIDScheme: ClientIDSchemeX509SANDNS,
+	}
+	msg := &FlowStartMessage{
+		RequestURI: "haip-vp://?request_uri=https%3A%2F%2Fverifier.example.com%2Frequest",
 	}
 	err := validateResponseURIOrigin(authReq, msg)
 	require.Error(t, err)


### PR DESCRIPTION
## Summary
- HAIP 1.0 final replaced the early-draft `haip://` scheme with separate `haip-vp://` (presentation) / `haip-vci://` (issuance) schemes. Real verifiers (Multipaz) already emit `haip-vp://` links.
- `parseRequest`'s scheme allowlist only recognized `openid4vp://` and `haip://`, so `haip-vp://` fell through to the direct-URL branch, which never dereferenced the request's `request_uri` query param - the flow failed with a generic "invalid message format" instead of resolving the request.
- Same gap fixed in `validateResponseURIOrigin`'s matching scheme check.
- Found via live testing: siros-sdk-kotlin's wallet now supports `haip-vp://` deep links (client-side fix already made), but the backend rejected the parsed request.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/engine/...` (full package, including new `haip-vp` regression tests mirroring the existing `haip://` coverage)
- [ ] Deploy to a test environment and confirm a real `haip-vp://` flow from Multipaz completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)