### PR TITLE
Relay OID4VCI refresh_token to the client instead of discarding it

### DIFF
--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -73,6 +73,14 @@ func (h *BaseHandler) Complete(credentials []CredentialResult, redirectURI strin
 	return h.Flow.Session.SendFlowComplete(h.Flow.ID, credentials, redirectURI)
 }
 
+// CompleteWithRefreshToken is Complete plus an OID4VCI refresh_token to relay
+// to the client (see FlowCompleteMessage.RefreshToken) - a separate method
+// rather than a new Complete parameter so OID4VP's existing call sites (which
+// never have a refresh_token) are untouched.
+func (h *BaseHandler) CompleteWithRefreshToken(credentials []CredentialResult, redirectURI string, refreshToken string) error {
+	return h.Flow.Session.SendFlowCompleteWithRefreshToken(h.Flow.ID, credentials, redirectURI, refreshToken)
+}
+
 // RequestSign requests a client-side signature
 func (h *BaseHandler) RequestSign(ctx context.Context, action SignAction, params SignRequestParams) (*SignResponseMessage, error) {
 	return h.Flow.Session.RequestSign(ctx, h.Flow.ID, action, params)

--- a/internal/engine/messages.go
+++ b/internal/engine/messages.go
@@ -242,6 +242,13 @@ type FlowCompleteMessage struct {
 	TypeMetadata                      json.RawMessage    `json:"type_metadata,omitempty"`
 	CredentialIssuer                  string             `json:"credential_issuer,omitempty"`
 	SelectedCredentialConfigurationID string             `json:"selected_credential_configuration_id,omitempty"`
+	// RefreshToken is the OAuth refresh_token the issuer's token endpoint
+	// returned alongside this batch, if any (OID4VCI issuance only - never
+	// set for OID4VP). The backend does not persist this itself (see the
+	// credential re-issuance/renewal plan); the client is expected to store
+	// it durably (e.g. via privatedata) and present it back on a future
+	// renewal request for this credential_configuration_id.
+	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
 // CredentialNotificationMessage carries an OID4VCI §10 credential lifecycle

--- a/internal/engine/oid4vci.go
+++ b/internal/engine/oid4vci.go
@@ -779,13 +779,13 @@ func (h *OID4VCIHandler) Execute(ctx context.Context, msg *FlowStartMessage) err
 		// Complete with the issued credential
 		results := h.buildCredentialResults(ctx, deferredResp, selectedConfig, trust)
 		h.registerNotificationContext(metadata, token, deferredResp)
-		return h.Complete(results, "")
+		return h.CompleteWithRefreshToken(results, "", token.RefreshToken)
 	}
 
 	// Step 9: Complete with issued credential (fetch VCTM for display)
 	results := h.buildCredentialResults(ctx, credential, selectedConfig, trust)
 	h.registerNotificationContext(metadata, token, credential)
-	return h.Complete(results, "")
+	return h.CompleteWithRefreshToken(results, "", token.RefreshToken)
 }
 
 // registerNotificationContext captures the ephemeral state needed to forward an

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -791,6 +791,16 @@ func (s *Session) SendProgress(flowID string, step FlowStep, payload interface{}
 
 // SendFlowComplete sends a flow completion message
 func (s *Session) SendFlowComplete(flowID string, credentials []CredentialResult, redirectURI string) error {
+	return s.sendFlowComplete(flowID, credentials, redirectURI, "")
+}
+
+// SendFlowCompleteWithRefreshToken is SendFlowComplete plus an OID4VCI
+// refresh_token to relay to the client (see FlowCompleteMessage.RefreshToken).
+func (s *Session) SendFlowCompleteWithRefreshToken(flowID string, credentials []CredentialResult, redirectURI string, refreshToken string) error {
+	return s.sendFlowComplete(flowID, credentials, redirectURI, refreshToken)
+}
+
+func (s *Session) sendFlowComplete(flowID string, credentials []CredentialResult, redirectURI string, refreshToken string) error {
 	s.flowsMu.RLock()
 	flow := s.flows[flowID]
 	s.flowsMu.RUnlock()
@@ -801,8 +811,9 @@ func (s *Session) SendFlowComplete(flowID string, credentials []CredentialResult
 			FlowID:    flowID,
 			Timestamp: Now(),
 		},
-		Credentials: credentials,
-		RedirectURI: redirectURI,
+		Credentials:  credentials,
+		RedirectURI:  redirectURI,
+		RefreshToken: refreshToken,
 	}
 	if flow != nil {
 		flow.mu.RLock()

--- a/internal/engine/session_test.go
+++ b/internal/engine/session_test.go
@@ -751,3 +751,46 @@ func TestSendFlowCompleteWithRefreshToken_EmptyOmitsField(t *testing.T) {
 	_, hasRefreshToken := received["refresh_token"]
 	assert.False(t, hasRefreshToken, "refresh_token should be omitted when empty")
 }
+
+// TestBaseHandler_CompleteWithRefreshToken covers the BaseHandler-level
+// delegation to Session.SendFlowCompleteWithRefreshToken (mirroring
+// TestBaseHandler_RequestMatch's pattern in match_test.go) - the actual
+// OID4VCI call sites (internal/engine/oid4vci.go) go through this method,
+// not SendFlowCompleteWithRefreshToken directly.
+func TestBaseHandler_CompleteWithRefreshToken(t *testing.T) {
+	conn, cleanup := wsTestServer(t, func(srvConn *websocket.Conn) {
+		defer srvConn.Close()
+		_, data, err := srvConn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var msg map[string]interface{}
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return
+		}
+		_ = srvConn.WriteJSON(msg)
+	})
+	defer cleanup()
+
+	session := testSession(conn)
+	flow := &Flow{
+		ID:      "flow-handler-refresh-token",
+		Session: session,
+	}
+	handler := &BaseHandler{
+		Flow:   flow,
+		Logger: zap.NewNop(),
+	}
+
+	credentials := []CredentialResult{
+		{Format: "dc+sd-jwt", Credential: "eyJ..."},
+	}
+	err := handler.CompleteWithRefreshToken(credentials, "", "handler-refresh-token-value")
+	require.NoError(t, err)
+
+	var received map[string]interface{}
+	err = conn.ReadJSON(&received)
+	require.NoError(t, err)
+
+	assert.Equal(t, "handler-refresh-token-value", received["refresh_token"])
+}

--- a/internal/engine/session_test.go
+++ b/internal/engine/session_test.go
@@ -667,3 +667,87 @@ func TestSendFlowComplete_EmptyDataMapOmitsIssuerFields(t *testing.T) {
 	assert.False(t, hasIssuer, "credential_issuer should not be present when Data map is empty")
 	assert.False(t, hasConfig, "selected_credential_configuration_id should not be present when Data map is empty")
 }
+
+// TestSendFlowCompleteWithRefreshToken_IncludesRefreshToken covers the
+// credential re-issuance/renewal plan's Phase 1 first step: an OID4VCI
+// refresh_token must actually reach the client instead of being silently
+// discarded (as internal/engine/oid4vci.go's TokenResponse.RefreshToken
+// field previously was - parsed, never read again).
+func TestSendFlowCompleteWithRefreshToken_IncludesRefreshToken(t *testing.T) {
+	conn, cleanup := wsTestServer(t, func(srvConn *websocket.Conn) {
+		defer srvConn.Close()
+		_, data, err := srvConn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var msg map[string]interface{}
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return
+		}
+		_ = srvConn.WriteJSON(msg)
+	})
+	defer cleanup()
+
+	session := testSession(conn)
+	flow := &Flow{
+		ID:      "test-flow-refresh-token",
+		Session: session,
+		Data:    make(map[string]interface{}),
+	}
+	session.flowsMu.Lock()
+	session.flows["test-flow-refresh-token"] = flow
+	session.flowsMu.Unlock()
+
+	credentials := []CredentialResult{
+		{Format: "dc+sd-jwt", Credential: "eyJ..."},
+	}
+
+	err := session.SendFlowCompleteWithRefreshToken("test-flow-refresh-token", credentials, "", "opaque-refresh-token-value")
+	require.NoError(t, err)
+
+	var received map[string]interface{}
+	err = conn.ReadJSON(&received)
+	require.NoError(t, err)
+
+	assert.Equal(t, "opaque-refresh-token-value", received["refresh_token"])
+}
+
+// TestSendFlowCompleteWithRefreshToken_EmptyOmitsField confirms an empty
+// refresh_token (the common case - most issuers don't return one) doesn't
+// add a spurious empty field to the wire message, matching every other
+// omitempty field on FlowCompleteMessage.
+func TestSendFlowCompleteWithRefreshToken_EmptyOmitsField(t *testing.T) {
+	conn, cleanup := wsTestServer(t, func(srvConn *websocket.Conn) {
+		defer srvConn.Close()
+		_, data, err := srvConn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var msg map[string]interface{}
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return
+		}
+		_ = srvConn.WriteJSON(msg)
+	})
+	defer cleanup()
+
+	session := testSession(conn)
+	flow := &Flow{
+		ID:      "test-flow-no-refresh-token",
+		Session: session,
+		Data:    make(map[string]interface{}),
+	}
+	session.flowsMu.Lock()
+	session.flows["test-flow-no-refresh-token"] = flow
+	session.flowsMu.Unlock()
+
+	err := session.SendFlowCompleteWithRefreshToken("test-flow-no-refresh-token", nil, "", "")
+	require.NoError(t, err)
+
+	var received map[string]interface{}
+	err = conn.ReadJSON(&received)
+	require.NoError(t, err)
+
+	_, hasRefreshToken := received["refresh_token"]
+	assert.False(t, hasRefreshToken, "refresh_token should be omitted when empty")
+}


### PR DESCRIPTION
## Summary
- Phase 1, first slice, of the credential re-issuance/renewal plan.
- `TokenResponse.RefreshToken` (`internal/engine/oid4vci.go`) was parsed off the issuer's token endpoint response but never read again anywhere in the file - confirmed dead. Renewal needs the client to hold onto this token durably (via SDK-side `privatedata`, per the plan's resolved design) so it can present it back later - so the backend needs to stop discarding it.
- Added `CompleteWithRefreshToken`/`SendFlowCompleteWithRefreshToken` as siblings to the existing `Complete`/`SendFlowComplete` (mirroring the existing `Error`/`ErrorWithDetails` pattern in this same package) rather than changing their signatures, so OID4VP's completion call sites (which never have a refresh_token) are untouched.
- `FlowCompleteMessage` gains an optional `refresh_token` field, omitted when empty (most issuers don't return one).
- **Not yet included** (deliberately, tracked as the next slice): the actual renewal-request engine action. Research found `go-wallet-backend`'s existing DPoP key (`h.dpopKey`, generated fresh per flow at `oid4vci.go:677`) is an ephemeral, per-flow OAuth client-binding key - architecturally distinct from the wallet's persistent credential-holder-binding key (signed via the existing `SignActionGenerateProof` round-trip to the SDK). It cannot satisfy the EUDI ARF's ISSU_65 same-key continuity requirement for renewal, so the renewal action needs a new signing round-trip reusing the SDK's persistent key, not an extension of the current ephemeral-DPoP-key code path. Full design at `~/.claude/plans/misty-wandering-lynx.md`.

## Test plan
- [x] New tests: `TestSendFlowCompleteWithRefreshToken_IncludesRefreshToken`, `TestSendFlowCompleteWithRefreshToken_EmptyOmitsField`.
- [x] `go vet ./...` and `go test ./internal/engine/...` pass (existing + new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9zyFYobKY92mLBKMMrYsQ